### PR TITLE
Use different libwbxml methods in C python module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ from setuptools import setup, Extension
 with open('README.rst', 'r') as file:
     long_description = file.read()
 
+import glob
 wbxml = Extension('wbxml',
-                  libraries=['wbxml2'],
-                  sources=['src/wbxml.c'])
+                  libraries=['expat'],
+                  sources=glob.glob('src/libwbxml/*.c') + ['src/wbxml.c'])
 
 setup(name='wbxml',
       version='0.1.1',

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ wbxml = Extension('wbxml',
                   sources=glob.glob('src/libwbxml/*.c') + ['src/wbxml.c'])
 
 setup(name='wbxml',
-      version='0.1.1',
-      author='Jezeniel Zapanta',
-      author_email='jezeniel@infoshiftinc.com',
+      version='0.1.2',
+      author='Mathieu Rodic',
+      author_email='mathieu@iko-system.com',
       description='Python wrapper for libwbxml',
       long_description=long_description,
       license='MIT',
-      keywords=['wbxml', 'xml', 'mobile'],
+      keywords=['wbxml', 'xml', 'mobile', 'exchange', 'EAS'],
       url='https://github.com/infoshift/python-wbxml',
       classifiers=[
           'Intended Audience :: Developers',

--- a/src/libwbxml/wbxml.h
+++ b/src/libwbxml/wbxml.h
@@ -1,0 +1,46 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml.h
+ * @ingroup wbxml
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/11/11
+ *
+ * @brief WBXML Library Main Header
+ */
+
+#ifndef WBXML_H
+#define WBXML_H
+
+#include "wbxml_config.h"
+#include "wbxml_defines.h"
+#include "wbxml_errors.h"
+#include "wbxml_conv.h"
+
+/** @} */
+
+#endif /* WBXML_H */

--- a/src/libwbxml/wbxml_base64.c
+++ b/src/libwbxml/wbxml_base64.c
@@ -1,0 +1,166 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_base64.c
+ * @ingroup wbxml_base64
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 01/11/03
+ *
+ * @brief Base64 encoding/decoding functions
+ *
+ * @note Code adapted from APR library (http://apr.apache.org/) 
+ */
+
+#include "wbxml_base64.h"
+#include "wbxml_mem.h"
+
+
+/* aaaack but it's fast and const should make it shared text page. */
+static const unsigned char pr2six[256] =
+{
+    /* ASCII table */
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+    64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
+};
+
+/** Base64 table */
+static const char basis_64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+
+/**********************************
+ *    Public functions
+ */
+
+/* Function adapted from APR library (http://apr.apache.org/) */
+WBXML_DECLARE(WB_UTINY *) wbxml_base64_encode(const WB_UTINY *buffer, WB_LONG len)
+{
+    WB_LONG i = 0;
+    WB_UTINY *p = NULL, *result = NULL;
+
+    if ((buffer == NULL) || (len <= 0))
+        return NULL;
+
+    /* Malloc result buffer */
+    if ((result = wbxml_malloc(((len + 2) / 3 * 4) + 1 + 1)) == NULL)
+        return NULL;
+
+    p = result;
+    for (i = 0; i < len - 2; i += 3) {
+        *p++ = basis_64[(buffer[i] >> 2) & 0x3F];
+        *p++ = basis_64[((buffer[i] & 0x3) << 4) |
+                        ((int) (buffer[i + 1] & 0xF0) >> 4)];
+        *p++ = basis_64[((buffer[i + 1] & 0xF) << 2) |
+                        ((int) (buffer[i + 2] & 0xC0) >> 6)];
+        *p++ = basis_64[buffer[i + 2] & 0x3F];
+    }
+    if (i < len) {
+        *p++ = basis_64[(buffer[i] >> 2) & 0x3F];
+        if (i == (len - 1)) {
+            *p++ = basis_64[((buffer[i] & 0x3) << 4)];
+            *p++ = '=';
+        }
+        else {
+            *p++ = basis_64[((buffer[i] & 0x3) << 4) |
+                            ((int) (buffer[i + 1] & 0xF0) >> 4)];
+            *p++ = basis_64[((buffer[i + 1] & 0xF) << 2)];
+        }
+        *p++ = '=';
+    }
+
+    *p++ = '\0';
+
+    return result;
+}
+
+
+/* Function adapted from APR library (http://apr.apache.org/) */
+WBXML_DECLARE(WB_LONG) wbxml_base64_decode(const WB_UTINY *buffer, WB_LONG len, WB_UTINY **result)
+{
+    WB_LONG nbytesdecoded = 0, nprbytes = 0;
+    const WB_UTINY *bufin = NULL;
+	const WB_UTINY *end = (len >= 0) ? (buffer + len) : NULL;
+    WB_UTINY *bufout = NULL;
+
+    if ((buffer == NULL) || (result == NULL))
+        return 0;
+
+    /* Initialize output buffer */
+    *result = NULL;
+
+    bufin = buffer;   
+    while (bufin != end && pr2six[*bufin] <= 63)
+		bufin++;
+    
+	nprbytes = bufin - buffer;
+
+    nbytesdecoded = ((nprbytes + 3) / 4) * 3;
+    
+    /* Malloc result buffer */
+    if ((*result = wbxml_malloc(nbytesdecoded + 1)) == NULL)
+        return 0;
+
+    bufout = *result;
+    bufin = buffer;
+
+    while (nprbytes > 4) 
+    {
+        *(bufout++) = (WB_UTINY) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+        *(bufout++) = (WB_UTINY) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+        *(bufout++) = (WB_UTINY) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+        bufin += 4;
+        nprbytes -= 4;
+    }
+
+    /* Note: (nprbytes == 1) would be an error, so just ingore that case */
+    if (nprbytes > 1) {
+        *(bufout++) = (WB_UTINY) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+    }
+    if (nprbytes > 2) {
+        *(bufout++) = (WB_UTINY) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+    }
+    if (nprbytes > 3) {
+        *(bufout++) = (WB_UTINY) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+    }
+
+    nbytesdecoded -= (4 - nprbytes) & 3;
+    
+    return nbytesdecoded;
+}

--- a/src/libwbxml/wbxml_base64.h
+++ b/src/libwbxml/wbxml_base64.h
@@ -1,0 +1,77 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_base64.h 
+ * @ingroup wbxml_base64
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 01/11/03
+ *
+ * @brief Base64 encoding/decoding functions
+ *
+ * @note Code adapted from APR library (http://apr.apache.org/) 
+ */
+
+#ifndef WBXML_BASE64_H
+#define WBXML_BASE64_H
+
+#include "wbxml.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_base64 
+ *  @{ 
+ */
+
+/**
+ * @brief Encode a buffer to Base64
+ * @param buffer The buffer to encode
+ * @param len    Buffer length
+ * @return The new base64 encoded Buffer (must be freed by caller), or NULL if not enough memory
+ */
+WBXML_DECLARE(WB_UTINY *) wbxml_base64_encode(const WB_UTINY *buffer, WB_LONG len);
+
+/**
+ * @brief Decode a Base64 encoded buffer
+ * @param buffer The buffer to decode
+ * @param len    Buffer length. If len is negative, assume buffer is terminated
+ *               by a non-Base64 character (such as NUL).
+ * @param result Resulting decoded buffer
+ * @return Length of resulting decoded buffer ('0' if no decoded)
+ * @note Be aware that if return value is '0', then 'result' param will be NULL, else 'result' param
+ *       has to be freed by caller.
+ */
+WBXML_DECLARE(WB_LONG) wbxml_base64_decode(const WB_UTINY *buffer, WB_LONG len, WB_UTINY **result);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_BASE64_H */

--- a/src/libwbxml/wbxml_buffers.c
+++ b/src/libwbxml/wbxml_buffers.c
@@ -1,0 +1,842 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_buffers.c
+ * @ingroup wbxml_buffers
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/03/12
+ *
+ * @brief Generic Buffers Functions
+ *
+ * @note Original idea: Kannel Project (http://www.kannel.org/)
+ */
+
+#include <limits.h>
+#include <ctype.h>
+
+#include "wbxml_buffers.h"
+#include "wbxml_base64.h"
+
+
+/* Memory management define */
+#define WBXML_BUFFER_SPLIT_BLOCK 20
+
+/**
+ * The Generic Buffer type
+ */
+struct WBXMLBuffer_s
+{
+    WB_UTINY *data;             /**< The data */
+    WB_ULONG  len;              /**< Length of data in buffer */
+    WB_ULONG  malloced;         /**< Length of buffer */
+    WB_BOOL   is_static;        /**< Is it a static buffer ?  */
+};
+
+
+static WB_BOOL grow_buff(WBXMLBuffer *buffer, WB_ULONG size);
+static WB_BOOL insert_data(WBXMLBuffer *buffer, WB_ULONG pos, const WB_UTINY *data, WB_ULONG len);
+
+
+
+/**********************************
+ *    Public functions
+ */
+
+
+WBXML_DECLARE(WBXMLBuffer *) wbxml_buffer_create_real(const WB_UTINY *data, WB_ULONG len, WB_ULONG malloc_block)
+{
+    WBXMLBuffer *buffer = NULL;
+
+    buffer = wbxml_malloc(sizeof(WBXMLBuffer));
+    if (buffer == NULL)
+        return NULL;
+        
+    buffer->is_static    = FALSE;
+
+    if ((len <= 0) || (data == NULL)) {        
+        buffer->malloced = 0;
+        buffer->len = 0;
+        buffer->data = NULL;
+    } 
+    else {               
+        if (len + 1 > malloc_block + 1)
+            buffer->malloced = len + 1 + malloc_block;
+        else
+            buffer->malloced = malloc_block + 1;
+        
+        buffer->data = wbxml_malloc(buffer->malloced * sizeof(WB_UTINY));
+        if (buffer->data == NULL) {
+            wbxml_free(buffer);
+            return NULL;
+        }
+
+        buffer->len = len;
+        memcpy(buffer->data, data, len);
+        buffer->data[len] = '\0';
+    }
+
+    return buffer;
+}
+
+
+WBXML_DECLARE(WBXMLBuffer *) wbxml_buffer_sta_create_real(const WB_UTINY *data, WB_ULONG len)
+{
+    WBXMLBuffer *buffer = NULL;
+  
+    buffer = wbxml_malloc(sizeof(WBXMLBuffer));
+    if (buffer == NULL) {
+        return NULL;
+    }
+
+    buffer->is_static    = TRUE;
+    buffer->data         = (WB_UTINY *) data;
+    buffer->len          = len;
+
+    return buffer;
+}
+
+
+WBXML_DECLARE(void) wbxml_buffer_destroy(WBXMLBuffer *buffer)
+{
+    if (buffer != NULL) {
+        if (!buffer->is_static) {
+            /* Free dynamic data */
+            wbxml_free(buffer->data);
+        }
+
+        /* Free structure */
+        wbxml_free(buffer);
+    }
+}
+
+
+WBXML_DECLARE_NONSTD(void) wbxml_buffer_destroy_item(void *buff)
+{
+    wbxml_buffer_destroy((WBXMLBuffer *) buff);
+}
+
+
+WBXML_DECLARE(WBXMLBuffer *) wbxml_buffer_duplicate(WBXMLBuffer *buff)
+{
+    WBXMLBuffer *result = NULL;
+
+    if (buff == NULL)
+        return NULL;
+
+    result = wbxml_buffer_create_real(wbxml_buffer_get_cstr(buff),
+                                      wbxml_buffer_len(buff),  
+                                      wbxml_buffer_len(buff));
+
+    return result;
+}
+
+
+WBXML_DECLARE(WB_ULONG) wbxml_buffer_len(WBXMLBuffer *buffer)
+{
+    if (buffer == NULL)
+        return 0;
+        
+    return buffer->len;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_get_char(WBXMLBuffer *buffer, WB_ULONG pos, WB_UTINY *result)
+{
+    if ((buffer == NULL) || (pos >= buffer->len) || (result == NULL))
+        return FALSE;
+        
+    *result = buffer->data[pos];
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_set_char(WBXMLBuffer *buffer, WB_ULONG pos, WB_UTINY ch)
+{
+    if ((buffer == NULL) || (buffer->is_static) || (pos >= buffer->len))
+        return FALSE;
+
+    buffer->data[pos] = ch;
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_UTINY *) wbxml_buffer_get_cstr(WBXMLBuffer *buffer)
+{
+    if ((buffer == NULL) || (buffer->len == 0))
+        return WBXML_UTINY_NULL_STRING;
+        
+    return buffer->data;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_insert(WBXMLBuffer *to, WBXMLBuffer *buffer, WB_ULONG pos)
+{
+    if ((to != NULL) && (buffer != NULL) && !to->is_static)
+        return insert_data(to, pos, buffer->data, buffer->len);
+
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_insert_cstr(WBXMLBuffer *to, const WB_UTINY *str, WB_ULONG pos)
+{
+    if ((to != NULL) && (str != NULL) && !to->is_static)
+        return insert_data(to, pos, str, WBXML_STRLEN(str));
+
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append(WBXMLBuffer *dest, WBXMLBuffer *buff)
+{
+    if ((dest == NULL) || dest->is_static)
+        return FALSE;
+
+    if (buff == NULL)
+        return TRUE;
+
+    return wbxml_buffer_append_data(dest, wbxml_buffer_get_cstr(buff), wbxml_buffer_len(buff));
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_data_real(WBXMLBuffer *buffer, const WB_UTINY *data, WB_ULONG len)
+{
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+
+    if ((data == NULL) || (len == 0))
+        return TRUE;
+
+    return insert_data(buffer, buffer->len, data, len);
+}
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_cstr_real(WBXMLBuffer *buffer, const WB_UTINY *data)
+{
+    if ((buffer == NULL) || buffer->is_static) {
+        return FALSE;
+    }
+
+    if (data == NULL)
+        return TRUE;
+
+    return wbxml_buffer_append_data(buffer, data, WBXML_STRLEN(data));
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_char(WBXMLBuffer *buffer, WB_UTINY ch)
+{
+    WB_UTINY c = ch;
+
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+
+    return insert_data(buffer, buffer->len, &c, 1);
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_mb_uint_32(WBXMLBuffer *buffer, WB_ULONG value)
+{
+    /**
+     * A uintvar is defined to be up to 32 bits large
+     * so it will fit in 5 octets (to handle continuation bits) 
+     */
+    WB_UTINY octets[5];
+    WB_LONG i = 0, start = 0;
+
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+
+    /**
+     * Handle last byte separately; it has no continuation bit,
+     * and must be encoded even if value is 0. 
+     */
+    octets[4] = (WB_UTINY) (value & 0x7f);
+    value >>= 7;
+
+    for (i = 3; value > 0 && i >= 0; i--) {
+        octets[i] = (WB_UTINY) (0x80 | (value & 0x7f));
+        value >>= 7;
+    }
+    start = i + 1;
+
+    return wbxml_buffer_append_data(buffer, octets + start, 5 - start);
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_delete(WBXMLBuffer *buffer, WB_ULONG pos, WB_ULONG len)
+{
+    if ((buffer == NULL) || (buffer->is_static))
+        return FALSE;
+
+    if ((pos >= buffer->len) || (len <= 0))
+        return FALSE;
+
+    memmove(buffer->data + pos, buffer->data + pos + len,
+            buffer->len - pos - len);
+                
+    buffer->len -= len;
+    buffer->data[buffer->len] = '\0';
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_shrink_blanks(WBXMLBuffer *buffer)
+{
+    WB_ULONG i = 0, j = 0, end = 0;
+    WB_UTINY ch = 0;
+    
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+        
+    end = wbxml_buffer_len(buffer);
+
+    for (i = 0; i < end; i++) 
+    {
+        if (wbxml_buffer_get_char(buffer, i, &ch) && isspace(ch)) 
+        {
+            /* Replace space by a whitespace */
+            if (ch != ' ')
+                wbxml_buffer_set_char(buffer, i, ' ');           
+
+            /* Remove all following spaces */
+            j = i = i + 1;
+            while (wbxml_buffer_get_char(buffer, j, &ch) && isspace(ch))
+                j++;
+
+            if (j - i > 1)
+                wbxml_buffer_delete(buffer, i, j - i);
+        }
+    }
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_strip_blanks(WBXMLBuffer *buffer)
+{
+    WB_ULONG start = 0, end = 0, len = 0;
+    WB_UTINY ch = 0;
+
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+
+    /* Remove whitespaces at beginning of buffer... */
+    while (wbxml_buffer_get_char(buffer, start, &ch) && 
+           isspace(ch) && 
+           start <= wbxml_buffer_len(buffer))
+    {
+        start ++;
+    }
+
+    if (start > 0)
+        wbxml_buffer_delete(buffer, 0, start);
+
+    /* ... and at the end */
+    if ((len = wbxml_buffer_len(buffer)) > 0) {
+        end = len = len - 1;
+        while (wbxml_buffer_get_char(buffer, end, &ch) &&
+            isspace(ch)) 
+        {
+            end--;
+        }
+        wbxml_buffer_delete(buffer, end + 1, len - end);
+    }
+
+    return TRUE;
+}
+
+WBXML_DECLARE(void) wbxml_buffer_no_spaces(WBXMLBuffer *buffer)
+{
+    WB_ULONG i = 0, j = 0, end = 0;
+    WB_UTINY ch = 0;
+    
+    if ((buffer == NULL) || buffer->is_static)
+        return;
+        
+    while (i < wbxml_buffer_len(buffer))
+    {
+        if (wbxml_buffer_get_char(buffer, i, &ch) && isspace(ch)) 
+        {
+             wbxml_buffer_delete(buffer, i, 1);
+        } else {
+             i++;
+        }
+    }
+}
+
+WBXML_DECLARE(WB_LONG) wbxml_buffer_compare(WBXMLBuffer *buff1, WBXMLBuffer *buff2)
+{
+    WB_LONG ret = 0, len = 0;
+
+    if ((buff1 == NULL) || (buff2 == NULL)) {
+        if ((buff1 == NULL) && (buff2 == NULL))
+            return 0;
+
+        if (buff1 == NULL)
+            return -1;
+        else
+            return 1;
+    }
+
+    if (buff1->len < buff2->len)
+        len = buff1->len;
+    else
+        len = buff2->len;
+
+    if (len == 0) 
+    {
+        if (buff1->len == 0 && buff2->len > 0)
+            return -1;
+        if (buff1->len > 0 && buff2->len == 0)
+            return 1;
+        return 0;
+    }
+
+    if ((ret = memcmp(buff1->data, buff2->data, len)) == 0) 
+    {
+        if (buff1->len < buff2->len)
+            ret = -1;
+        else {
+            if (buff1->len > buff2->len)
+                ret = 1;
+        }
+    }
+
+    return ret;
+}
+
+
+WBXML_DECLARE(WB_LONG) wbxml_buffer_compare_cstr(WBXMLBuffer *buff, const WB_TINY *str)
+{
+    WB_LONG ret = 0, len = 0;
+
+    if ((buff == NULL) || (str == NULL)) {
+        if ((buff == NULL) && (str == NULL))
+            return 0;
+
+        if (buff == NULL)
+            return -1;
+        else
+            return 1;
+    }
+
+    if (buff->len < WBXML_STRLEN(str))
+        len = buff->len;
+    else
+        len = WBXML_STRLEN(str);
+
+    if (len == 0) 
+    {
+        if (buff->len == 0 && WBXML_STRLEN(str) > 0)
+            return -1;
+        if (buff->len > 0 && WBXML_STRLEN(str) == 0)
+            return 1;
+        return 0;
+    }
+
+    if ((ret = memcmp(buff->data, str, len)) == 0) 
+    {
+        if (buff->len < WBXML_STRLEN(str))
+            ret = -1;
+        else {
+            if (buff->len > WBXML_STRLEN(str))
+                ret = 1;
+        }
+    }
+
+    return ret;
+}
+
+
+WBXML_DECLARE(WBXMLList *) wbxml_buffer_split_words_real(WBXMLBuffer *buff)
+{
+    WB_UTINY *p = NULL;
+    WBXMLList *list = NULL;
+    WBXMLBuffer *word = NULL;
+    WB_ULONG i = 0, start = 0, end = 0;
+
+    if (buff == NULL)
+        return NULL;
+
+    if ((list = wbxml_list_create()) == NULL)
+        return NULL;
+
+    p = buff->data;
+    i = 0;
+    while (TRUE)
+    {
+        while (i < buff->len && isspace(*p)) {
+            ++p;
+            ++i;
+        }
+        start = i;
+
+        while (i < buff->len && !isspace(*p)) {
+            ++p;
+            ++i;
+        }
+        end = i;
+
+        if (start == end)
+            break;
+
+        if((word = wbxml_buffer_create(buff->data + start, end - start, WBXML_BUFFER_SPLIT_BLOCK)) == NULL) {
+            wbxml_list_destroy(list, wbxml_buffer_destroy_item);
+            return NULL;
+        }
+
+        wbxml_list_append(list, word);
+    }
+
+    return list;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_char(WBXMLBuffer *to, const WB_UTINY ch, WB_ULONG pos, WB_ULONG *result)
+{
+    WB_UTINY *p = NULL;
+
+    if (to == NULL)
+        return FALSE;
+
+    if (pos >= to->len)
+        return FALSE;
+
+    if ((p = (WB_UTINY *) memchr(to->data + pos, ch, to->len - pos)) == NULL)
+        return FALSE;
+
+    if (result != NULL)
+        *result = p - to->data;
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search(WBXMLBuffer *to, WBXMLBuffer *search, WB_ULONG pos, WB_ULONG *result)
+{
+    WB_UTINY first = 0;
+
+    if ((to == NULL) || (search == NULL))
+        return FALSE;
+
+    if (result != NULL)
+        *result = 0;
+
+    /* Always "find" an empty string */
+    if (search->len == 0)
+        return TRUE;
+
+    /* Check if 'search' is greater than 'to' */
+    if (search->len > to->len)
+        return FALSE;
+
+    /* We are searching for one char */
+    if (search->len == 1)
+        return wbxml_buffer_search_char(to, search->data[0], pos, result);
+
+    /* For each occurrence of search's first character in to, then check if the rest of needle follows.
+     * Stop if there are no more occurrences, or if the rest of 'search' can't possibly fit in 'to'. */
+    first = search->data[0];
+    while ((wbxml_buffer_search_char(to, first, pos, &pos)) && 
+           (to->len - pos >= search->len)) 
+    {
+        if (memcmp(to->data + pos, search->data, search->len) == 0) {
+            if (result != NULL)
+                *result = pos;
+            return TRUE;
+        }
+        pos++;
+    }
+
+    return FALSE;    
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_cstr(WBXMLBuffer *to, const WB_UTINY *search, WB_ULONG pos, WB_ULONG *result)
+{
+    WB_UTINY first = 0;
+
+    if ((to == NULL) || (search == NULL))
+        return FALSE;
+
+    if (result != NULL)
+        *result = 0;
+
+    /* Always "find" an empty string */
+    if (WBXML_STRLEN(search) == 0)
+        return TRUE;
+
+    /* Check if 'search' is greater than 'to' */
+    if (WBXML_STRLEN(search) > to->len)
+        return FALSE;
+
+    /* We are searching for one char */
+    if (WBXML_STRLEN(search) == 1)
+        return wbxml_buffer_search_char(to, search[0], pos, result);
+
+    /* For each occurrence of search's first character in to, then check if the rest of needle follows.
+     * Stop if there are no more occurrences, or if the rest of 'search' can't possibly fit in 'to'. */
+    first = search[0];
+    while ((wbxml_buffer_search_char(to, first, pos, &pos)) && 
+           (to->len - pos >= WBXML_STRLEN(search))) 
+    {
+        if (memcmp(to->data + pos, search, WBXML_STRLEN(search)) == 0) {
+            if (result != NULL)
+                *result = pos;
+            return TRUE;
+        }
+        pos++;
+    }
+
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_contains_only_whitespaces(WBXMLBuffer *buffer)
+{
+    WB_ULONG i = 0;
+
+    if (buffer == NULL)
+        return FALSE;
+
+    for (i=0; i<buffer->len; i++) {
+        if (!isspace(*(buffer->data + i)))
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_hex_to_binary(WBXMLBuffer *buffer)
+{
+    WB_UTINY *p = NULL;
+    WB_ULONG i = 0, len = 0;
+
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+
+    p = buffer->data;
+    len = wbxml_buffer_len(buffer);
+
+    /* Convert ascii data to binary values */
+    for (i = 0; i < len; i++, p++) {
+        if (*p >= '0' && *p <= '9')
+            *p -= '0';
+        else if (*p >= 'a' && *p <= 'f')
+            *p = (WB_UTINY) (*p - 'a' + 10);
+        else if (*p >= 'A' && *p <= 'F')
+            *p = (WB_UTINY) (*p - 'A' + 10);
+        else {
+            /* Bad Bad ! There should be only digits in the buffer ! */
+            *p = 0;
+        }
+    }
+
+    /* De-hexing will compress data by factor of 2 */
+    len = buffer->len / 2;
+
+    for (i = 0; i < len; i++)
+        buffer->data[i] = (WB_UTINY) (buffer->data[i * 2] * 16 | buffer->data[i * 2 + 1]);
+
+    buffer->len = len;
+    buffer->data[len] = '\0';
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_binary_to_hex(WBXMLBuffer *buffer, WB_BOOL uppercase)
+{
+    WB_UTINY *hexits = NULL;
+    WB_LONG i = 0;
+
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+
+    if (wbxml_buffer_len(buffer) == 0)
+        return TRUE;
+
+    hexits = (WB_UTINY *)(uppercase ? "0123456789ABCDEF" : "0123456789abcdef");
+
+    /* Grows the Buffer size by 2 */
+    grow_buff(buffer, buffer->len * 2);
+
+    /* In-place modification must be done back-to-front to avoid
+     * overwriting the data while we read it.  Even the order of
+     * the two assignments is important, to get i == 0 right. 
+     */
+    for (i = buffer->len - 1; i >= 0; i--) {
+        buffer->data[i * 2 + 1] = hexits[buffer->data[i] % 16];
+        buffer->data[i * 2] = hexits[(buffer->data[i] / 16) & 0xf];
+    }
+
+    buffer->len = buffer->len * 2;
+    buffer->data[buffer->len] = '\0';
+
+    return TRUE;
+}
+
+WBXML_DECLARE(WBXMLError) wbxml_buffer_decode_base64(WBXMLBuffer *buffer)
+{
+    WB_UTINY   *result = NULL;
+    WB_LONG     len    = 0;
+    WBXMLError  ret    = WBXML_OK;
+    
+    if ( (buffer == NULL) || (buffer->is_static) ) {
+        return WBXML_ERROR_INTERNAL;
+    }
+
+    wbxml_buffer_no_spaces(buffer);
+    
+    if ((len = wbxml_base64_decode((const WB_UTINY *) wbxml_buffer_get_cstr(buffer),
+                                   wbxml_buffer_len(buffer), &result)) <= 0)
+    {
+        return WBXML_ERROR_B64_DEC;
+    }
+    
+    /* Reset buffer */
+    wbxml_buffer_delete(buffer, 0, wbxml_buffer_len(buffer));
+    
+    /* Set binary data */
+    if (!wbxml_buffer_append_data(buffer, result, len)) {
+        ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+    
+    wbxml_free(result);
+    
+    return ret;
+}
+
+WBXML_DECLARE(WBXMLError) wbxml_buffer_encode_base64(WBXMLBuffer *buffer)
+{
+    WB_UTINY   *result = NULL;
+    WBXMLError  ret    = WBXML_OK;
+    
+    if ( (buffer == NULL) || (buffer->is_static) ) {
+        return WBXML_ERROR_INTERNAL;
+    }
+    
+    if ((result = wbxml_base64_encode((const WB_UTINY *) wbxml_buffer_get_cstr(buffer),
+                                      wbxml_buffer_len(buffer))) == NULL)
+    {
+        return WBXML_ERROR_B64_ENC;
+    }
+    
+    /* Reset buffer */
+    wbxml_buffer_delete(buffer, 0, wbxml_buffer_len(buffer));
+    
+    /* Set data */
+    if (!wbxml_buffer_append_cstr(buffer, result)) {
+        ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+    
+    wbxml_free(result);
+    
+    return ret;
+}
+
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_remove_trailing_zeros(WBXMLBuffer *buffer)
+{
+    WB_UTINY ch = 0;
+
+    if ((buffer == NULL) || (buffer->is_static))
+        return FALSE;
+
+    while (buffer->len > 0) {
+        if (wbxml_buffer_get_char(buffer, wbxml_buffer_len(buffer) - 1, &ch) && (ch == '\0'))
+            wbxml_buffer_delete(buffer, wbxml_buffer_len(buffer) - 1, 1);
+        else
+            return TRUE;
+    }
+
+    return TRUE;
+}
+
+
+/**********************************
+ *    Private functions
+ */
+
+/**
+ * @brief Add space for at least 'size' octets
+ * @param buffer The buffer
+ * @param size The size to add
+ * @return TRUE is space successfully reserved, FALSE is size was negative, buffer was NULL or if not enough memory
+ */
+static WB_BOOL grow_buff(WBXMLBuffer *buffer, WB_ULONG size)
+{
+    if ((buffer == NULL) || buffer->is_static)
+        return FALSE;
+        
+    /* Make room for the invisible terminating NUL */
+    size++; 
+
+    if ((buffer->len + size) > buffer->malloced) {
+        if ((buffer->malloced * 2) < (buffer->len + size))
+            buffer->malloced = buffer->len + size;
+        else
+            buffer->malloced *= 2;
+            
+        buffer->data = wbxml_realloc(buffer->data, buffer->malloced);
+        if (buffer->data == NULL)
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+/**
+ * @brief Insert data into a Generic Buffer
+ * @param buffer The Generic Buffer
+ * @param pos Position in Generic Buffer where to insert data
+ * @param data Data to insert
+ * @param len Data length
+ * @return TRUE is data inserted, FALSE if not
+ */
+static WB_BOOL insert_data(WBXMLBuffer *buffer, WB_ULONG pos, const WB_UTINY *data, WB_ULONG len)
+{
+    if ((buffer == NULL) || buffer->is_static || (len == 0) || (pos > buffer->len))
+        return FALSE;
+
+    if (!grow_buff(buffer, len))
+        return FALSE;
+
+    if (buffer->len > pos) {    
+        /* Only if neccessary */
+        memmove(buffer->data + pos + len, buffer->data + pos, buffer->len - pos);
+    }
+
+    memcpy(buffer->data + pos, data, len);
+    buffer->len += len;
+    buffer->data[buffer->len] = '\0';
+
+    return TRUE;
+}

--- a/src/libwbxml/wbxml_buffers.h
+++ b/src/libwbxml/wbxml_buffers.h
@@ -1,0 +1,341 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_buffers.h 
+ * @ingroup wbxml_buffers
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/03/12
+ *
+ * @brief Generic Buffers Functions
+ *
+ * @note Original idea: Kannel Project (http://kannel.3glab.org/)
+ */
+
+#ifndef WBXML_BUFFERS_H
+#define WBXML_BUFFERS_H
+
+#include <stdio.h>
+
+#include "wbxml.h"
+#include "wbxml_lists.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief WBXML Generic Buffer
+ */
+typedef struct WBXMLBuffer_s WBXMLBuffer;
+
+
+/** @addtogroup wbxml_buffers  
+ *  @{ 
+ */
+
+/**
+ * @brief Create a Buffer
+ * @param data The initial data for buffer
+ * @param len Size of data
+ * @param malloc_block Size of the initial malloc block (tune this parameter to avoid too many reallocations)
+ * @return The newly created Buffer, or NULL if not enought memory
+ * @warning Do NOT use this function directly, use wbxml_buffer_create() macro instead
+ */
+WBXML_DECLARE(WBXMLBuffer *) wbxml_buffer_create_real(const WB_UTINY *data, WB_ULONG len, WB_ULONG malloc_block);
+
+/** Wrapper around wbxml_buffer_create_real() to track Memory */
+#define wbxml_buffer_create(a,b,c) \
+  wbxml_mem_cleam(wbxml_buffer_create_real((const WB_UTINY *)a,b,c))
+
+/** Wrapper around wbxml_buffer_create() when creating buffer with a C String (NULL Terminated) */
+#define wbxml_buffer_create_from_cstr(a) \
+  wbxml_buffer_create((const WB_UTINY *)a,WBXML_STRLEN(a),WBXML_STRLEN(a))
+
+/**
+ * @brief Create a static Buffer
+ * @param data Buffer data
+ * @param len  Data lenght
+ * @return The newly created Buffer, or NULL if not enough memory
+ * @note A static buffer can't be modified, so do not use functions dedeicated to dynamic buffers
+ *       as wbxml_buffer_insert() or wbxml_buffer_append()
+ * @warning Do NOT use this function directly, use wbxml_buffer_sta_create() macro instead
+ */
+WBXML_DECLARE(WBXMLBuffer *) wbxml_buffer_sta_create_real(const WB_UTINY *data, WB_ULONG len);
+
+/** Wrapper around wbxml_buffer_sta_create_real() to track Memory */
+#define wbxml_buffer_sta_create(a,b) \
+  wbxml_mem_cleam(wbxml_buffer_sta_create_real((const WB_UTINY *)a,b))
+
+/** Wrapper around wbxml_buffer_sta_create() when creating static buffer with a C String (NULL Terminated) */
+#define wbxml_buffer_sta_create_from_cstr(a) \
+  wbxml_buffer_sta_create((const WB_UTINY *)a,WBXML_STRLEN(a))
+
+/**
+ * @brief Destroy a Buffer
+ * @param buff The Buffer to destroy
+ */
+WBXML_DECLARE(void) wbxml_buffer_destroy(WBXMLBuffer *buff);
+
+/**
+ * @brief Destroy a Buffer (used for wbxml_list_destroy())
+ * @param buff The Buffer to destroy
+ */
+WBXML_DECLARE_NONSTD(void) wbxml_buffer_destroy_item(void *buff);
+
+/**
+ * Duplicate a Buffer
+ *
+ * Even if a static buffer is provided, the duplicated buffer is
+ * a dynamic buffer.
+ *
+ * @param buff The Buffer to duplicate
+ * @return The duplicated buffer, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLBuffer *) wbxml_buffer_duplicate(WBXMLBuffer *buff);
+
+/**
+ * @brief Get data length of a buffer
+ * @param buff The Buffer
+ * @return The Buffer data length
+ */
+WBXML_DECLARE(WB_ULONG) wbxml_buffer_len(WBXMLBuffer *buff);
+
+/**
+ * @brief Get a byte from a Buffer
+ * @param buff The Buffer
+ * @param pos Byte position in buffer
+ * @param result The resulting char
+ * @return TRUE if OK, or FALSE if error
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_get_char(WBXMLBuffer *buff, WB_ULONG pos, WB_UTINY *result);
+
+/**
+ * @brief Set a byte in a dynamic Buffer
+ * @param buff The Buffer
+ * @param pos Byte position in buffer
+ * @param ch The character to set
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_set_char(WBXMLBuffer *buff, WB_ULONG pos, WB_UTINY ch);
+
+/**
+ * @brief Get pointer to internal buffer data
+ * @param buff The Buffer
+ * @return Pointer to buffer data, or "" if buffer is NULL or empty
+ */
+WBXML_DECLARE(WB_UTINY *) wbxml_buffer_get_cstr(WBXMLBuffer *buff);
+
+/**
+ * @brief Insert a Buffer into a dynamic Buffer
+ * @param to The Buffer to modify
+ * @param buff The Buffer to insert
+ * @param pos The position of insertion in 'to'
+ * @return TRUE if data inserted, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_insert(WBXMLBuffer *to, WBXMLBuffer *buff, WB_ULONG pos);
+
+/**
+ * @brief Insert a C String into a dynamic Buffer
+ * @param to The Buffer to modify
+ * @param str The BC String to insert
+ * @param pos The position of insertion in 'to'
+ * @return TRUE if data inserted, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_insert_cstr(WBXMLBuffer *to, const WB_UTINY *str, WB_ULONG pos);
+
+/**
+ * @brief Append a Buffer to a dynamic Buffer
+ * @param dest The destination Buffer
+ * @param buff The Buffer to append
+ * @return TRUE if buffer appended, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append(WBXMLBuffer *dest, WBXMLBuffer *buff);
+
+
+/**
+ * @brief Append data to a dynamic Buffer
+ * @param buff The Buffer
+ * @param data Data to append
+ * @param len Data length
+ * @return TRUE if data appended, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_data_real(WBXMLBuffer *buff, const WB_UTINY *data, WB_ULONG len);
+
+/** Wrapper around wbxml_buffer_append_data_real() to avoid Casts in code */
+#define wbxml_buffer_append_data(a,b,c) wbxml_buffer_append_data_real(a,(const WB_UTINY *)b,c)
+
+/**
+ * @brief Append a C String (NULL terminated) to a dynamic Buffer
+ * @param buff The Buffer
+ * @param data String to append
+ * @return TRUE if data appended, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_cstr_real(WBXMLBuffer *buff, const WB_UTINY *data);
+
+/** Wrapper around wbxml_buffer_append_cstr_real() to avoid Casts in code */
+#define wbxml_buffer_append_cstr(a,b) wbxml_buffer_append_cstr_real(a,(const WB_UTINY *)b)
+
+
+/**
+ * @brief Append a byte to a dynamic Buffer
+ * @param buff The Buffer
+ * @param ch Byte to append
+ * @return TRUE if byte appended, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_char(WBXMLBuffer *buff, WB_UTINY ch);
+
+/**
+ * @brief Append a Multibyte Integer to a dynamic Buffer
+ * @param buff The Buffer
+ * @param value The value to append
+ * @return TRUE if value appended, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_append_mb_uint_32(WBXMLBuffer *buff, WB_ULONG value);
+
+/**
+ * @brief Delete a range of Bytes in a  dynamicBuffer
+ * @param buff The Buffer
+ * @param pos Position where to start deletion
+ * @param len Number of bytes to delete
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_delete(WBXMLBuffer *buff, WB_ULONG pos, WB_ULONG len);
+
+/**
+ * @brief Shrink all spaces in a  dynamicBuffer
+ * @param buff The Buffer to shrink
+ * @note Replace every consecutive sequence of spaces into one unique whitespace
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_shrink_blanks(WBXMLBuffer *buff);
+
+/**
+ * @brief Remove whitespaces at beginning and end of a dynamic Buffer
+ * @param buff The Buffer to strip
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_strip_blanks(WBXMLBuffer *buff);
+
+/**
+ * @brief Compare two Buffers
+ * @param buff1
+ * @param buff2
+ * @return 0 if they are equal, negative if `buff1' is less than `buff2' and positive if greater
+ */
+WBXML_DECLARE(WB_LONG) wbxml_buffer_compare(WBXMLBuffer *buff1, WBXMLBuffer *buff2);
+
+/**
+ * @brief Compare a WBXML Buffer with a C String
+ * @param buff The WBXML Buffer
+ * @param str  The C String
+ * @return 0 if they are equal, negative if `buff' is less than `str' and positive if greater
+ */
+WBXML_DECLARE(WB_LONG) wbxml_buffer_compare_cstr(WBXMLBuffer *buff, const WB_TINY *str);
+
+/**
+ * @brief Split a Buffer into words at whitespace
+ * @param buff The buffer to split
+ * @return The List of splitted Words, or NULL if not enough memory
+ * @warning Do NOT use this function directly, use wbxml_buffer_split_words() macro instead
+ */
+WBXML_DECLARE(WBXMLList *) wbxml_buffer_split_words_real(WBXMLBuffer *buff);
+#define wbxml_buffer_split_words(a) wbxml_mem_cleam(wbxml_buffer_split_words_real(a))
+
+/**
+ * @brief Search a char in Buffer
+ * @param to The buffer to search into
+ * @param ch The char to search
+ * @param pos Position to start searching in 'to' buffer
+ * @param result The start position of char in 'to' buffer
+ * @return TRUE if char successfully found in 'to' buffer, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_char(WBXMLBuffer *to, const WB_UTINY ch, WB_ULONG pos, WB_ULONG *result);
+
+/**
+ * @brief Search a Buffer in another Buffer
+ * @param to The buffer to search into
+ * @param search The buffer to search
+ * @param pos Position to start searching in 'to' buffer
+ * @param result The start position of 'search' buffer in 'to' buffer
+ * @return TRUE if successfully found 'search' in 'to' buffer, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search(WBXMLBuffer *to, WBXMLBuffer *search, WB_ULONG pos, WB_ULONG *result);
+
+/**
+ * @brief Search a C String in a WBXMLBuffer Buffer
+ * @param to The buffer to search into
+ * @param search The C String to search
+ * @param pos Position to start searching in 'to' buffer
+ * @param result The start position of 'search' buffer in 'to' buffer
+ * @return TRUE if successfully found 'search' in 'to' buffer, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_search_cstr(WBXMLBuffer *to, const WB_UTINY *search, WB_ULONG pos, WB_ULONG *result);
+
+/**
+ * @brief Check if a buffer contains only Whitespaces
+ * @param buffer The buffer to check
+ * @return TRUE if it contains only whitespaces, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_contains_only_whitespaces(WBXMLBuffer *buffer);
+
+/**
+ * @brief Convert an Hexa dynamic buffer to Binary
+ * @param buffer The buffer to convert
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_hex_to_binary(WBXMLBuffer *buffer);
+
+/**
+ * @brief Convert an Binary dynamic buffer to Hexa
+ * @param buffer The buffer to convert
+ * @param uppercase Do we convert to Uppercase Hexa ?
+ * @return TRUE if converted, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_binary_to_hex(WBXMLBuffer *buffer, WB_BOOL uppercase);
+
+/**
+ * @brief Convert base64 encoded data to binary data
+ * @param buffer The buffer to convert
+ * @return TRUE if converted, FALSE otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_buffer_decode_base64(WBXMLBuffer *buffer);
+
+/**
+ * @brief Convert binary data to base64 encoded data
+ * @param buffer The buffer to convert
+ * @return TRUE if converted, FALSE otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_buffer_encode_base64(WBXMLBuffer *buffer);
+
+/**
+ * @brief Remove trailing Zeros from a dynamic Buffer
+ * @param buffer The buffer
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_buffer_remove_trailing_zeros(WBXMLBuffer *buffer);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_BUFFERS_H */

--- a/src/libwbxml/wbxml_charset.c
+++ b/src/libwbxml/wbxml_charset.c
@@ -1,0 +1,346 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_charset.c
+ * @ingroup wbxml_charset
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 04/03/24
+ *
+ * @brief Charset Functions
+ */
+
+#include "wbxml_charset.h"
+#include "wbxml_internals.h"
+
+/* Structures */
+
+/** WBXML Charset */
+typedef struct WBXMLCharsetEntry_s {
+    const WB_TINY       *name;     /**< Charset Name */
+    WBXMLCharsetMIBEnum  mib_enum; /**< Charset MIBEnum Value */
+} WBXMLCharsetEntry;
+
+
+/* Globals */
+
+/**
+ * @brief Charset table
+ * @note  From http://www.iana.org/assignments/character-sets
+ */
+static const WBXMLCharsetEntry wbxml_charset_entries[] =
+{
+    { "US-ASCII",        WBXML_CHARSET_US_ASCII        },
+    { "ISO-8859-1",      WBXML_CHARSET_ISO_8859_1      },
+    { "ISO-8859-2",      WBXML_CHARSET_ISO_8859_2      },
+    { "ISO-8859-3",      WBXML_CHARSET_ISO_8859_3      },
+    { "ISO-8859-4",      WBXML_CHARSET_ISO_8859_4      },
+    { "ISO-8859-5",      WBXML_CHARSET_ISO_8859_5      },
+    { "ISO-8859-6",      WBXML_CHARSET_ISO_8859_6      },
+    { "ISO-8859-7",      WBXML_CHARSET_ISO_8859_7      },
+    { "ISO-8859-8",      WBXML_CHARSET_ISO_8859_8      },
+    { "ISO-8859-9",      WBXML_CHARSET_ISO_8859_9      },
+    { "Shift_JIS",       WBXML_CHARSET_SHIFT_JIS       },
+    { "UTF-8",           WBXML_CHARSET_UTF_8           },
+    { "ISO-10646-UCS-2", WBXML_CHARSET_ISO_10646_UCS_2 },
+    { "UTF-16",          WBXML_CHARSET_UTF_16          },
+    { "Big5",            WBXML_CHARSET_BIG5            }
+};
+
+
+/* Private Functions Prototypes */
+static WB_BOOL search_null_block(const WB_TINY *in_buf,
+                                 WB_ULONG       in_buf_len,
+                                 WB_ULONG       block_len,
+                                 WB_ULONG      *out_pos);
+
+
+/***************************************************
+ *    Public Functions
+ */
+
+WBXML_DECLARE(WB_BOOL) wbxml_charset_get_mib(const WB_TINY       *name,
+                                             WBXMLCharsetMIBEnum *mib_enum)
+{
+    WB_ULONG i = 0;
+  
+    for (i = 0; i < WBXML_TABLE_SIZE(wbxml_charset_entries); i++) {
+        if (WBXML_STRCASECMP(name, wbxml_charset_entries[i].name) == 0) {
+            if (mib_enum != NULL) {
+                *mib_enum = wbxml_charset_entries[i].mib_enum;
+            }
+
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_charset_get_name(WBXMLCharsetMIBEnum   mib_enum,
+                                              const WB_TINY       **name)
+{
+    WB_ULONG i = 0;
+  
+    for (i = 0; i < WBXML_TABLE_SIZE(wbxml_charset_entries); i++) {
+        if (mib_enum == wbxml_charset_entries[i].mib_enum) {
+            if (name != NULL) {
+                *name = wbxml_charset_entries[i].name;
+            }
+      
+            return TRUE;
+        }
+    }
+  
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_charset_conv(const WB_TINY        *in_buf,
+                                             WB_ULONG             *io_bytes,
+                                             WBXMLCharsetMIBEnum   in_charset,
+                                             WBXMLBuffer         **out_buf,
+                                             WBXMLCharsetMIBEnum   out_charset)
+{
+    /**************************************************
+     * First, check for simple US-ASCII / UTF-8 cases
+     */
+
+    /* Are we dealing with US-ASCII or UTF-8 ? */
+    if (((in_charset  == WBXML_CHARSET_US_ASCII) || (in_charset  == WBXML_CHARSET_UTF_8)) &&
+        ((out_charset == WBXML_CHARSET_US_ASCII) || (out_charset == WBXML_CHARSET_UTF_8)))
+    {
+        /* Create a static buffer */
+        if ((*out_buf = wbxml_buffer_sta_create_from_cstr(in_buf)) == NULL) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        /* US-ASCII and UTF-8 are NULL terminated */
+        *io_bytes -= WBXML_STRLEN(in_buf) + 1;
+    
+        return WBXML_OK;
+    }
+  
+    /**************************************
+     * Ok guys, we really have to convert
+     */
+  
+#if defined( HAVE_ICONV )
+  
+    {
+        /**********************
+         * The iconv way
+         */
+    
+        const WB_TINY * inbuf_pos    = NULL;
+        WB_TINY      **__restrict__ inbuf_ref = NULL;
+        const WB_TINY * charset_to   = NULL;
+        const WB_TINY * charset_from = NULL;
+        WB_TINY       * tmp_buf      = NULL;
+        WB_TINY       * tmp_ptr      = NULL;
+        WB_ULONG        tmp_buf_len  = 0;
+        WB_ULONG        tmp_len_left = 0;
+        WBXMLError      ret          = WBXML_OK;
+        iconv_t         cd           = 0;
+        WB_UTINY        last_char    = 0;
+    
+        /* Get Charsets names */
+        if (!wbxml_charset_get_name(in_charset, &charset_from)) {
+            return WBXML_ERROR_CHARSET_UNKNOWN;
+        }
+  
+        if (!wbxml_charset_get_name(out_charset, &charset_to)) {
+            return WBXML_ERROR_CHARSET_UNKNOWN;
+        }
+    
+        /* Init iconv */
+        if ((cd = iconv_open(charset_to, charset_from)) == (iconv_t)(-1))
+        {
+            /* Init failed */
+            return WBXML_ERROR_CHARSET_CONV_INIT;
+        }
+    
+        /* Allocate maximum result buffer (4 bytes unicode) */
+        tmp_len_left = tmp_buf_len = 4 * (sizeof(WB_TINY) * (*io_bytes));
+    
+        if ((tmp_buf = wbxml_malloc(tmp_buf_len)) == NULL) {
+            iconv_close(cd);
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        tmp_ptr = tmp_buf;
+
+        /* The input buffer is const but not the pointer itself.
+           The original const *inbuf should not be modified for a potential later usage.
+         */
+        inbuf_pos = in_buf;
+        inbuf_ref = (WB_TINY **__restrict__) &inbuf_pos;
+    
+        /* Convert ! */
+        (void) iconv(cd,
+                     inbuf_ref,
+                     (size_t*)io_bytes,
+                     &tmp_buf,
+                     (size_t*)&tmp_len_left);
+
+        /** @todo Check errno (but it doesn't seems to work on windows) */
+
+        if (tmp_buf_len > tmp_len_left) {
+            /* Create result buffer */
+            if ((*out_buf = wbxml_buffer_create(tmp_ptr,
+                                                tmp_buf_len - tmp_len_left,
+                                                tmp_buf_len - tmp_len_left)) == NULL)
+            {
+                /* Not enough memory */
+                ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+
+            /* Remove trailing NULL char */
+            wbxml_buffer_remove_trailing_zeros(*out_buf);
+        }
+        else
+        {
+            /* Not converted */
+            ret = WBXML_ERROR_CHARSET_CONV;
+        }
+    
+        /* Shutdown iconv */
+        iconv_close(cd);
+    
+        /* Clean-up */
+        wbxml_free(tmp_ptr);
+
+        return ret;
+    }
+  
+#else
+  
+    {
+        /***************************************************
+         * Add your own charset conversion function here !
+         */
+    
+        return WBXML_ERROR_NO_CHARSET_CONV;
+    }
+  
+#endif /* HAVE_ICONV */
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_charset_conv_term(const WB_TINY        *in_buf,
+                                                  WB_ULONG             *io_bytes,
+                                                  WBXMLCharsetMIBEnum   in_charset,
+                                                  WBXMLBuffer         **out_buf,
+                                                  WBXMLCharsetMIBEnum   out_charset)
+{
+    WB_ULONG   buf_len  = 0;
+    WB_ULONG   new_len  = 0;
+    WB_ULONG   term_len = 0;
+    WBXMLError ret      = WBXML_OK;
+  
+    /* Find length of input buffer */
+    switch (in_charset)
+    {
+    case WBXML_CHARSET_ISO_10646_UCS_2 :
+    case WBXML_CHARSET_UTF_16 :
+        /* Terminated by two NULL char ("\0\0") */
+        term_len = 2;
+
+        if (!search_null_block(in_buf, *io_bytes, 2, &buf_len)) {
+            return WBXML_ERROR_CHARSET_STR_LEN;
+        }
+
+        /* Add termination bytes length */
+        buf_len += term_len;
+        break;
+    
+    default :
+        /* Terminated by a simple NULL char ('\0') */
+        term_len = 1;
+
+        buf_len = WBXML_STRLEN(in_buf) + term_len;
+        break;
+    }
+
+    /* Check length found */
+    if (buf_len > *io_bytes) {
+        return WBXML_ERROR_CHARSET_STR_LEN;
+    }
+
+    /* Use a temporary length var (because it is decreased) */
+    new_len = buf_len;
+  
+    /* Convert ! */
+    ret = wbxml_charset_conv(in_buf, 
+                             &new_len,
+                             in_charset,
+                             out_buf,
+                             out_charset);
+  
+    /* Set input buffer length */           
+    *io_bytes = buf_len;
+  
+    return ret;
+}
+
+
+/***************************************************
+ *    Private Functions
+ */
+
+/**
+ * Binary search of a sequence of NULL bytes in a buffer
+ *
+ * @param in_buf     Buffer to search in
+ * @param in_buf_len Length of input buffer
+ * @param block_len  Length of the NULL sequence
+ * @param out_pos    Index of Sequence into Buffer
+ * @return TRUE if found, FALSE otherwise
+ */
+static WB_BOOL search_null_block(const WB_TINY *in_buf,
+                                 WB_ULONG       in_buf_len,
+                                 WB_ULONG       block_len,
+                                 WB_ULONG      *out_pos)
+{
+    WB_ULONG pos = 0;
+    WB_ULONG i = 0;
+
+    for (pos = 0; pos + block_len <= in_buf_len; pos += block_len) {
+        for (i = 0; i < block_len; i++) {
+            if (memcmp(in_buf + pos + i, "\0", 1)) {
+                i = block_len;
+            } else {
+                if (i == block_len -1) {
+                    *out_pos = pos;
+                    return TRUE;
+                }
+            }
+        }
+    }
+
+    return FALSE;
+}

--- a/src/libwbxml/wbxml_charset.c
+++ b/src/libwbxml/wbxml_charset.c
@@ -2,27 +2,27 @@
  * libwbxml, the WBXML Library.
  * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
  * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- * 
+ *
  * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
- * 
+ *
  * Contact: aymerick@jehanne.org
  * Home: http://libwbxml.aymerick.com
  */
- 
+
 /**
  * @file wbxml_charset.c
  * @ingroup wbxml_charset
@@ -49,25 +49,264 @@ typedef struct WBXMLCharsetEntry_s {
 
 /**
  * @brief Charset table
- * @note  From http://www.iana.org/assignments/character-sets
+ * @note  From https://www.iana.org/assignments/character-sets/character-sets.txt
  */
 static const WBXMLCharsetEntry wbxml_charset_entries[] =
 {
-    { "US-ASCII",        WBXML_CHARSET_US_ASCII        },
-    { "ISO-8859-1",      WBXML_CHARSET_ISO_8859_1      },
-    { "ISO-8859-2",      WBXML_CHARSET_ISO_8859_2      },
-    { "ISO-8859-3",      WBXML_CHARSET_ISO_8859_3      },
-    { "ISO-8859-4",      WBXML_CHARSET_ISO_8859_4      },
-    { "ISO-8859-5",      WBXML_CHARSET_ISO_8859_5      },
-    { "ISO-8859-6",      WBXML_CHARSET_ISO_8859_6      },
-    { "ISO-8859-7",      WBXML_CHARSET_ISO_8859_7      },
-    { "ISO-8859-8",      WBXML_CHARSET_ISO_8859_8      },
-    { "ISO-8859-9",      WBXML_CHARSET_ISO_8859_9      },
-    { "Shift_JIS",       WBXML_CHARSET_SHIFT_JIS       },
-    { "UTF-8",           WBXML_CHARSET_UTF_8           },
-    { "ISO-10646-UCS-2", WBXML_CHARSET_ISO_10646_UCS_2 },
-    { "UTF-16",          WBXML_CHARSET_UTF_16          },
-    { "Big5",            WBXML_CHARSET_BIG5            }
+    { "US-ASCII",                                      WBXML_CHARSET_US_ASCII },
+    { "ISO-8859-1",                                    WBXML_CHARSET_ISO_8859_1 },
+    { "ISO-8859-2",                                    WBXML_CHARSET_ISO_8859_2 },
+    { "ISO-8859-3",                                    WBXML_CHARSET_ISO_8859_3 },
+    { "ISO-8859-4",                                    WBXML_CHARSET_ISO_8859_4 },
+    { "ISO-8859-5",                                    WBXML_CHARSET_ISO_8859_5 },
+    { "ISO-8859-6",                                    WBXML_CHARSET_ISO_8859_6 },
+    { "ISO-8859-7",                                    WBXML_CHARSET_ISO_8859_7 },
+    { "ISO-8859-8",                                    WBXML_CHARSET_ISO_8859_8 },
+    { "ISO-8859-9",                                    WBXML_CHARSET_ISO_8859_9 },
+    { "ISO-8859-10",                                   WBXML_CHARSET_ISO_8859_10 },
+    { "Shift_JIS",                                     WBXML_CHARSET_SHIFT_JIS },
+    { "Extended_UNIX_Code_Packed_Format_for_Japanese", WBXML_CHARSET_EXTENDED_UNIX_CODE_PACKED_FORMAT_FOR_JAPANESE },
+    { "Extended_UNIX_Code_Fixed_Width_for_Japanese",   WBXML_CHARSET_EXTENDED_UNIX_CODE_FIXED_WIDTH_FOR_JAPANESE },
+    { "BS_4730",                                       WBXML_CHARSET_BS_4730 },
+    { "SEN_850200_C",                                  WBXML_CHARSET_SEN_850200_C },
+    { "IT",                                            WBXML_CHARSET_IT },
+    { "ES",                                            WBXML_CHARSET_ES },
+    { "DIN_66003",                                     WBXML_CHARSET_DIN_66003 },
+    { "NS_4551-1",                                     WBXML_CHARSET_NS_4551_1 },
+    { "NF_Z_62-010",                                   WBXML_CHARSET_NF_Z_62_010 },
+    { "ISO-10646-UTF-1",                               WBXML_CHARSET_ISO_10646_UTF_1 },
+    { "ISO-646.basic",                                 WBXML_CHARSET_ISO_646_BASIC },
+    { "INVARIANT",                                     WBXML_CHARSET_INVARIANT },
+    { "ISO-646.irv",                                   WBXML_CHARSET_ISO_646_IRV },
+    { "NATS-SEFI",                                     WBXML_CHARSET_NATS_SEFI },
+    { "NATS-SEFI-ADD",                                 WBXML_CHARSET_NATS_SEFI_ADD },
+    { "NATS-DANO",                                     WBXML_CHARSET_NATS_DANO },
+    { "NATS-DANO-ADD",                                 WBXML_CHARSET_NATS_DANO_ADD },
+    { "SEN_850200_B",                                  WBXML_CHARSET_SEN_850200_B },
+    { "KS_C_5601-1987",                                WBXML_CHARSET_KS_C_5601_1987 },
+    { "ISO-2022-KR",                                   WBXML_CHARSET_ISO_2022_KR },
+    { "EUC-KR",                                        WBXML_CHARSET_EUC_KR },
+    { "ISO-2022-JP",                                   WBXML_CHARSET_ISO_2022_JP },
+    { "ISO-2022-JP-2",                                 WBXML_CHARSET_ISO_2022_JP_2 },
+    { "JIS_C6220-1969-jp",                             WBXML_CHARSET_JIS_C6220_1969_JP },
+    { "JIS_C6220-1969-ro",                             WBXML_CHARSET_JIS_C6220_1969_RO },
+    { "PT",                                            WBXML_CHARSET_PT },
+    { "greek7-old",                                    WBXML_CHARSET_GREEK7_OLD },
+    { "latin-greek",                                   WBXML_CHARSET_LATIN_GREEK },
+    { "NF_Z_62-010_(1973)",                            WBXML_CHARSET_NF_Z_62_010_1973 },
+    { "Latin-greek-1",                                 WBXML_CHARSET_LATIN_GREEK_1 },
+    { "ISO-5427",                                      WBXML_CHARSET_ISO_5427 },
+    { "JIS_C6226-1978",                                WBXML_CHARSET_JIS_C6226_1978 },
+    { "BS_viewdata",                                   WBXML_CHARSET_BS_VIEWDATA },
+    { "INIS",                                          WBXML_CHARSET_INIS },
+    { "INIS-8",                                        WBXML_CHARSET_INIS_8 },
+    { "INIS-cyrillic",                                 WBXML_CHARSET_INIS_CYRILLIC },
+    { "ISO-5427",                                      WBXML_CHARSET_ISO_5427_1981 },
+    { "ISO-5428",                                      WBXML_CHARSET_ISO_5428 },
+    { "GB_1988-80",                                    WBXML_CHARSET_GB_1988_80 },
+    { "GB_2312-80",                                    WBXML_CHARSET_GB_2312_80 },
+    { "NS_4551-2",                                     WBXML_CHARSET_NS_4551_2 },
+    { "videotex-suppl",                                WBXML_CHARSET_VIDEOTEX_SUPPL },
+    { "PT2",                                           WBXML_CHARSET_PT2 },
+    { "ES2",                                           WBXML_CHARSET_ES2 },
+    { "MSZ_7795.3",                                    WBXML_CHARSET_MSZ_7795_3 },
+    { "JIS_C6226-1983",                                WBXML_CHARSET_JIS_C6226_1983 },
+    { "greek7",                                        WBXML_CHARSET_GREEK7 },
+    { "ASMO_449",                                      WBXML_CHARSET_ASMO_449 },
+    { "iso-ir-90",                                     WBXML_CHARSET_ISO_IR_90 },
+    { "JIS_C6229-1984-a",                              WBXML_CHARSET_JIS_C6229_1984_A },
+    { "JIS_C6229-1984-b",                              WBXML_CHARSET_JIS_C6229_1984_B },
+    { "JIS_C6229-1984-b-add",                          WBXML_CHARSET_JIS_C6229_1984_B_ADD },
+    { "JIS_C6229-1984-hand",                           WBXML_CHARSET_JIS_C6229_1984_HAND },
+    { "JIS_C6229-1984-hand-add",                       WBXML_CHARSET_JIS_C6229_1984_HAND_ADD },
+    { "JIS_C6229-1984-kana",                           WBXML_CHARSET_JIS_C6229_1984_KANA },
+    { "ISO-2033-1983",                                 WBXML_CHARSET_ISO_2033_1983 },
+    { "ANSI_X3.110-1983",                              WBXML_CHARSET_ANSI_X3_110_1983 },
+    { "T.61-7bit",                                     WBXML_CHARSET_T_61_7BIT },
+    { "T.61-8bit",                                     WBXML_CHARSET_T_61_8BIT },
+    { "ECMA-cyrillic",                                 WBXML_CHARSET_ECMA_CYRILLIC },
+    { "CSA_Z243.4-1985-1",                             WBXML_CHARSET_CSA_Z243_4_1985_1 },
+    { "CSA_Z243.4-1985-2",                             WBXML_CHARSET_CSA_Z243_4_1985_2 },
+    { "CSA_Z243.4-1985-gr",                            WBXML_CHARSET_CSA_Z243_4_1985_GR },
+    { "ISO-8859-6-E",                                  WBXML_CHARSET_ISO_8859_6_E },
+    { "ISO-8859-6-I",                                  WBXML_CHARSET_ISO_8859_6_I },
+    { "T.101-G2",                                      WBXML_CHARSET_T_101_G2 },
+    { "ISO-8859-8-E",                                  WBXML_CHARSET_ISO_8859_8_E },
+    { "ISO-8859-8-I",                                  WBXML_CHARSET_ISO_8859_8_I },
+    { "CSN_369103",                                    WBXML_CHARSET_CSN_369103 },
+    { "JUS_I.B1.002",                                  WBXML_CHARSET_JUS_I_B1_002 },
+    { "IEC_P27-1",                                     WBXML_CHARSET_IEC_P27_1 },
+    { "JUS_I.B1.003-serb",                             WBXML_CHARSET_JUS_I_B1_003_SERB },
+    { "JUS_I.B1.003-mac",                              WBXML_CHARSET_JUS_I_B1_003_MAC },
+    { "greek-ccitt",                                   WBXML_CHARSET_GREEK_CCITT },
+    { "NC_NC00-10:81",                                 WBXML_CHARSET_NC_NC00_10 },
+    { "ISO-6937-2-25",                                 WBXML_CHARSET_ISO_6937_2_25 },
+    { "GOST_19768-74",                                 WBXML_CHARSET_GOST_19768_74 },
+    { "ISO-8859-supp",                                 WBXML_CHARSET_ISO_8859_SUPP },
+    { "ISO-10367-box",                                 WBXML_CHARSET_ISO_10367_BOX },
+    { "latin-lap",                                     WBXML_CHARSET_LATIN_LAP },
+    { "JIS_X0212-1990",                                WBXML_CHARSET_JIS_X0212_1990 },
+    { "DS_2089",                                       WBXML_CHARSET_DS_2089 },
+    { "us-dk",                                         WBXML_CHARSET_US_DK },
+    { "dk-us",                                         WBXML_CHARSET_DK_US },
+    { "KSC5636",                                       WBXML_CHARSET_KSC5636 },
+    { "UNICODE-1-1-UTF-7",                             WBXML_CHARSET_UNICODE_1_1_UTF_7 },
+    { "ISO-2022-CN",                                   WBXML_CHARSET_ISO_2022_CN },
+    { "ISO-2022-CN-EXT",                               WBXML_CHARSET_ISO_2022_CN_EXT },
+    { "UTF-8",                                         WBXML_CHARSET_UTF_8 },
+    { "ISO-8859-13",                                   WBXML_CHARSET_ISO_8859_13 },
+    { "ISO-8859-14",                                   WBXML_CHARSET_ISO_8859_14 },
+    { "ISO-8859-15",                                   WBXML_CHARSET_ISO_8859_15 },
+    { "ISO-8859-16",                                   WBXML_CHARSET_ISO_8859_16 },
+    { "GBK",                                           WBXML_CHARSET_GBK },
+    { "GB18030",                                       WBXML_CHARSET_GB18030 },
+    { "OSD_EBCDIC_DF04_15",                            WBXML_CHARSET_OSD_EBCDIC_DF04_15 },
+    { "OSD_EBCDIC_DF03_IRV",                           WBXML_CHARSET_OSD_EBCDIC_DF03_IRV },
+    { "OSD_EBCDIC_DF04_1",                             WBXML_CHARSET_OSD_EBCDIC_DF04_1 },
+    { "ISO-11548-1",                                   WBXML_CHARSET_ISO_11548_1 },
+    { "KZ-1048",                                       WBXML_CHARSET_KZ_1048 },
+    { "ISO-10646-UCS-2",                               WBXML_CHARSET_ISO_10646_UCS_2 },
+    { "ISO-10646-UCS-4",                               WBXML_CHARSET_ISO_10646_UCS_4 },
+    { "ISO-10646-UCS-Basic",                           WBXML_CHARSET_ISO_10646_UCS_BASIC },
+    { "ISO-10646-Unicode-Latin1",                      WBXML_CHARSET_ISO_10646_UNICODE_LATIN1 },
+    { "ISO-10646-J-1",                                 WBXML_CHARSET_ISO_10646_J_1 },
+    { "ISO-Unicode-IBM-1261",                          WBXML_CHARSET_ISO_UNICODE_IBM_1261 },
+    { "ISO-Unicode-IBM-1268",                          WBXML_CHARSET_ISO_UNICODE_IBM_1268 },
+    { "ISO-Unicode-IBM-1276",                          WBXML_CHARSET_ISO_UNICODE_IBM_1276 },
+    { "ISO-Unicode-IBM-1264",                          WBXML_CHARSET_ISO_UNICODE_IBM_1264 },
+    { "ISO-Unicode-IBM-1265",                          WBXML_CHARSET_ISO_UNICODE_IBM_1265 },
+    { "UNICODE-1-1",                                   WBXML_CHARSET_UNICODE_1_1 },
+    { "SCSU",                                          WBXML_CHARSET_SCSU },
+    { "UTF-7",                                         WBXML_CHARSET_UTF_7 },
+    { "UTF-16BE",                                      WBXML_CHARSET_UTF_16BE },
+    { "UTF-16LE",                                      WBXML_CHARSET_UTF_16LE },
+    { "UTF-16",                                        WBXML_CHARSET_UTF_16 },
+    { "CESU-8",                                        WBXML_CHARSET_CESU_8 },
+    { "UTF-32",                                        WBXML_CHARSET_UTF_32 },
+    { "UTF-32BE",                                      WBXML_CHARSET_UTF_32BE },
+    { "UTF-32LE",                                      WBXML_CHARSET_UTF_32LE },
+    { "BOCU-1",                                        WBXML_CHARSET_BOCU_1 },
+    { "ISO-8859-1-Windows-3.0-Latin-1",                WBXML_CHARSET_ISO_8859_1_WINDOWS_3_0_LATIN_1 },
+    { "ISO-8859-1-Windows-3.1-Latin-1",                WBXML_CHARSET_ISO_8859_1_WINDOWS_3_1_LATIN_1 },
+    { "ISO-8859-2-Windows-Latin-2",                    WBXML_CHARSET_ISO_8859_2_WINDOWS_LATIN_2 },
+    { "ISO-8859-9-Windows-Latin-5",                    WBXML_CHARSET_ISO_8859_9_WINDOWS_LATIN_5 },
+    { "hp-roman8",                                     WBXML_CHARSET_HP_ROMAN8 },
+    { "Adobe-Standard-Encoding",                       WBXML_CHARSET_ADOBE_STANDARD_ENCODING },
+    { "Ventura-US",                                    WBXML_CHARSET_VENTURA_US },
+    { "Ventura-International",                         WBXML_CHARSET_VENTURA_INTERNATIONAL },
+    { "DEC-MCS",                                       WBXML_CHARSET_DEC_MCS },
+    { "IBM850",                                        WBXML_CHARSET_IBM850 },
+    { "PC8-Danish-Norwegian",                          WBXML_CHARSET_PC8_DANISH_NORWEGIAN },
+    { "IBM862",                                        WBXML_CHARSET_IBM862 },
+    { "PC8-Turkish",                                   WBXML_CHARSET_PC8_TURKISH },
+    { "IBM-Symbols",                                   WBXML_CHARSET_IBM_SYMBOLS },
+    { "IBM-Thai",                                      WBXML_CHARSET_IBM_THAI },
+    { "HP-Legal",                                      WBXML_CHARSET_HP_LEGAL },
+    { "HP-Pi-font",                                    WBXML_CHARSET_HP_PI_FONT },
+    { "HP-Math8",                                      WBXML_CHARSET_HP_MATH8 },
+    { "Adobe-Symbol-Encoding",                         WBXML_CHARSET_ADOBE_SYMBOL_ENCODING },
+    { "HP-DeskTop",                                    WBXML_CHARSET_HP_DESKTOP },
+    { "Ventura-Math",                                  WBXML_CHARSET_VENTURA_MATH },
+    { "Microsoft-Publishing",                          WBXML_CHARSET_MICROSOFT_PUBLISHING },
+    { "Windows-31J",                                   WBXML_CHARSET_WINDOWS_31J },
+    { "GB2312",                                        WBXML_CHARSET_GB2312 },
+    { "Big5",                                          WBXML_CHARSET_BIG5 },
+    { "macintosh",                                     WBXML_CHARSET_MACINTOSH },
+    { "IBM037",                                        WBXML_CHARSET_IBM037 },
+    { "IBM038",                                        WBXML_CHARSET_IBM038 },
+    { "IBM273",                                        WBXML_CHARSET_IBM273 },
+    { "IBM274",                                        WBXML_CHARSET_IBM274 },
+    { "IBM275",                                        WBXML_CHARSET_IBM275 },
+    { "IBM277",                                        WBXML_CHARSET_IBM277 },
+    { "IBM278",                                        WBXML_CHARSET_IBM278 },
+    { "IBM280",                                        WBXML_CHARSET_IBM280 },
+    { "IBM281",                                        WBXML_CHARSET_IBM281 },
+    { "IBM284",                                        WBXML_CHARSET_IBM284 },
+    { "IBM285",                                        WBXML_CHARSET_IBM285 },
+    { "IBM290",                                        WBXML_CHARSET_IBM290 },
+    { "IBM297",                                        WBXML_CHARSET_IBM297 },
+    { "IBM420",                                        WBXML_CHARSET_IBM420 },
+    { "IBM423",                                        WBXML_CHARSET_IBM423 },
+    { "IBM424",                                        WBXML_CHARSET_IBM424 },
+    { "IBM437",                                        WBXML_CHARSET_IBM437 },
+    { "IBM500",                                        WBXML_CHARSET_IBM500 },
+    { "IBM851",                                        WBXML_CHARSET_IBM851 },
+    { "IBM852",                                        WBXML_CHARSET_IBM852 },
+    { "IBM855",                                        WBXML_CHARSET_IBM855 },
+    { "IBM857",                                        WBXML_CHARSET_IBM857 },
+    { "IBM860",                                        WBXML_CHARSET_IBM860 },
+    { "IBM861",                                        WBXML_CHARSET_IBM861 },
+    { "IBM863",                                        WBXML_CHARSET_IBM863 },
+    { "IBM864",                                        WBXML_CHARSET_IBM864 },
+    { "IBM865",                                        WBXML_CHARSET_IBM865 },
+    { "IBM868",                                        WBXML_CHARSET_IBM868 },
+    { "IBM869",                                        WBXML_CHARSET_IBM869 },
+    { "IBM870",                                        WBXML_CHARSET_IBM870 },
+    { "IBM871",                                        WBXML_CHARSET_IBM871 },
+    { "IBM880",                                        WBXML_CHARSET_IBM880 },
+    { "IBM891",                                        WBXML_CHARSET_IBM891 },
+    { "IBM903",                                        WBXML_CHARSET_IBM903 },
+    { "IBM904",                                        WBXML_CHARSET_IBM904 },
+    { "IBM905",                                        WBXML_CHARSET_IBM905 },
+    { "IBM918",                                        WBXML_CHARSET_IBM918 },
+    { "IBM1026",                                       WBXML_CHARSET_IBM1026 },
+    { "EBCDIC-AT-DE",                                  WBXML_CHARSET_EBCDIC_AT_DE },
+    { "EBCDIC-AT-DE-A",                                WBXML_CHARSET_EBCDIC_AT_DE_A },
+    { "EBCDIC-CA-FR",                                  WBXML_CHARSET_EBCDIC_CA_FR },
+    { "EBCDIC-DK-NO",                                  WBXML_CHARSET_EBCDIC_DK_NO },
+    { "EBCDIC-DK-NO-A",                                WBXML_CHARSET_EBCDIC_DK_NO_A },
+    { "EBCDIC-FI-SE",                                  WBXML_CHARSET_EBCDIC_FI_SE },
+    { "EBCDIC-FI-SE-A",                                WBXML_CHARSET_EBCDIC_FI_SE_A },
+    { "EBCDIC-FR",                                     WBXML_CHARSET_EBCDIC_FR },
+    { "EBCDIC-IT",                                     WBXML_CHARSET_EBCDIC_IT },
+    { "EBCDIC-PT",                                     WBXML_CHARSET_EBCDIC_PT },
+    { "EBCDIC-ES",                                     WBXML_CHARSET_EBCDIC_ES },
+    { "EBCDIC-ES-A",                                   WBXML_CHARSET_EBCDIC_ES_A },
+    { "EBCDIC-ES-S",                                   WBXML_CHARSET_EBCDIC_ES_S },
+    { "EBCDIC-UK",                                     WBXML_CHARSET_EBCDIC_UK },
+    { "EBCDIC-US",                                     WBXML_CHARSET_EBCDIC_US },
+    { "UNKNOWN-8BIT",                                  WBXML_CHARSET_UNKNOWN_8BIT },
+    { "MNEMONIC",                                      WBXML_CHARSET_MNEMONIC },
+    { "MNEM",                                          WBXML_CHARSET_MNEM },
+    { "VISCII",                                        WBXML_CHARSET_VISCII },
+    { "VIQR",                                          WBXML_CHARSET_VIQR },
+    { "KOI8-R",                                        WBXML_CHARSET_KOI8_R },
+    { "HZ-GB-2312",                                    WBXML_CHARSET_HZ_GB_2312 },
+    { "IBM866",                                        WBXML_CHARSET_IBM866 },
+    { "IBM775",                                        WBXML_CHARSET_IBM775 },
+    { "KOI8-U",                                        WBXML_CHARSET_KOI8_U },
+    { "IBM00858",                                      WBXML_CHARSET_IBM00858 },
+    { "IBM00924",                                      WBXML_CHARSET_IBM00924 },
+    { "IBM01140",                                      WBXML_CHARSET_IBM01140 },
+    { "IBM01141",                                      WBXML_CHARSET_IBM01141 },
+    { "IBM01142",                                      WBXML_CHARSET_IBM01142 },
+    { "IBM01143",                                      WBXML_CHARSET_IBM01143 },
+    { "IBM01144",                                      WBXML_CHARSET_IBM01144 },
+    { "IBM01145",                                      WBXML_CHARSET_IBM01145 },
+    { "IBM01146",                                      WBXML_CHARSET_IBM01146 },
+    { "IBM01147",                                      WBXML_CHARSET_IBM01147 },
+    { "IBM01148",                                      WBXML_CHARSET_IBM01148 },
+    { "IBM01149",                                      WBXML_CHARSET_IBM01149 },
+    { "Big5-HKSCS",                                    WBXML_CHARSET_BIG5_HKSCS },
+    { "IBM1047",                                       WBXML_CHARSET_IBM1047 },
+    { "PTCP154",                                       WBXML_CHARSET_PTCP154 },
+    { "Amiga-1251",                                    WBXML_CHARSET_AMIGA_1251 },
+    { "KOI7-switched",                                 WBXML_CHARSET_KOI7_SWITCHED },
+    { "BRF",                                           WBXML_CHARSET_BRF },
+    { "TSCII",                                         WBXML_CHARSET_TSCII },
+    { "CP51932",                                       WBXML_CHARSET_CP51932 },
+    { "windows-874",                                   WBXML_CHARSET_WINDOWS_874 },
+    { "windows-1250",                                  WBXML_CHARSET_WINDOWS_1250 },
+    { "windows-1251",                                  WBXML_CHARSET_WINDOWS_1251 },
+    { "windows-1252",                                  WBXML_CHARSET_WINDOWS_1252 },
+    { "windows-1253",                                  WBXML_CHARSET_WINDOWS_1253 },
+    { "windows-1254",                                  WBXML_CHARSET_WINDOWS_1254 },
+    { "windows-1255",                                  WBXML_CHARSET_WINDOWS_1255 },
+    { "windows-1256",                                  WBXML_CHARSET_WINDOWS_1256 },
+    { "windows-1257",                                  WBXML_CHARSET_WINDOWS_1257 },
+    { "windows-1258",                                  WBXML_CHARSET_WINDOWS_1258 },
+    { "TIS-620",                                       WBXML_CHARSET_TIS_620 },
+    { "CP50220",                                       WBXML_CHARSET_CP50220 }
 };
 
 
@@ -86,7 +325,7 @@ WBXML_DECLARE(WB_BOOL) wbxml_charset_get_mib(const WB_TINY       *name,
                                              WBXMLCharsetMIBEnum *mib_enum)
 {
     WB_ULONG i = 0;
-  
+
     for (i = 0; i < WBXML_TABLE_SIZE(wbxml_charset_entries); i++) {
         if (WBXML_STRCASECMP(name, wbxml_charset_entries[i].name) == 0) {
             if (mib_enum != NULL) {
@@ -105,17 +344,17 @@ WBXML_DECLARE(WB_BOOL) wbxml_charset_get_name(WBXMLCharsetMIBEnum   mib_enum,
                                               const WB_TINY       **name)
 {
     WB_ULONG i = 0;
-  
+
     for (i = 0; i < WBXML_TABLE_SIZE(wbxml_charset_entries); i++) {
         if (mib_enum == wbxml_charset_entries[i].mib_enum) {
             if (name != NULL) {
                 *name = wbxml_charset_entries[i].name;
             }
-      
+
             return TRUE;
         }
     }
-  
+
     return FALSE;
 }
 
@@ -141,21 +380,21 @@ WBXML_DECLARE(WBXMLError) wbxml_charset_conv(const WB_TINY        *in_buf,
 
         /* US-ASCII and UTF-8 are NULL terminated */
         *io_bytes -= WBXML_STRLEN(in_buf) + 1;
-    
+
         return WBXML_OK;
     }
-  
+
     /**************************************
      * Ok guys, we really have to convert
      */
-  
+
 #if defined( HAVE_ICONV )
-  
+
     {
         /**********************
          * The iconv way
          */
-    
+
         const WB_TINY * inbuf_pos    = NULL;
         WB_TINY      **__restrict__ inbuf_ref = NULL;
         const WB_TINY * charset_to   = NULL;
@@ -167,26 +406,26 @@ WBXML_DECLARE(WBXMLError) wbxml_charset_conv(const WB_TINY        *in_buf,
         WBXMLError      ret          = WBXML_OK;
         iconv_t         cd           = 0;
         WB_UTINY        last_char    = 0;
-    
+
         /* Get Charsets names */
         if (!wbxml_charset_get_name(in_charset, &charset_from)) {
             return WBXML_ERROR_CHARSET_UNKNOWN;
         }
-  
+
         if (!wbxml_charset_get_name(out_charset, &charset_to)) {
             return WBXML_ERROR_CHARSET_UNKNOWN;
         }
-    
+
         /* Init iconv */
         if ((cd = iconv_open(charset_to, charset_from)) == (iconv_t)(-1))
         {
             /* Init failed */
             return WBXML_ERROR_CHARSET_CONV_INIT;
         }
-    
+
         /* Allocate maximum result buffer (4 bytes unicode) */
         tmp_len_left = tmp_buf_len = 4 * (sizeof(WB_TINY) * (*io_bytes));
-    
+
         if ((tmp_buf = wbxml_malloc(tmp_buf_len)) == NULL) {
             iconv_close(cd);
             return WBXML_ERROR_NOT_ENOUGH_MEMORY;
@@ -199,7 +438,7 @@ WBXML_DECLARE(WBXMLError) wbxml_charset_conv(const WB_TINY        *in_buf,
          */
         inbuf_pos = in_buf;
         inbuf_ref = (WB_TINY **__restrict__) &inbuf_pos;
-    
+
         /* Convert ! */
         (void) iconv(cd,
                      inbuf_ref,
@@ -227,26 +466,26 @@ WBXML_DECLARE(WBXMLError) wbxml_charset_conv(const WB_TINY        *in_buf,
             /* Not converted */
             ret = WBXML_ERROR_CHARSET_CONV;
         }
-    
+
         /* Shutdown iconv */
         iconv_close(cd);
-    
+
         /* Clean-up */
         wbxml_free(tmp_ptr);
 
         return ret;
     }
-  
+
 #else
-  
+
     {
         /***************************************************
          * Add your own charset conversion function here !
          */
-    
+
         return WBXML_ERROR_NO_CHARSET_CONV;
     }
-  
+
 #endif /* HAVE_ICONV */
 }
 
@@ -261,7 +500,7 @@ WBXML_DECLARE(WBXMLError) wbxml_charset_conv_term(const WB_TINY        *in_buf,
     WB_ULONG   new_len  = 0;
     WB_ULONG   term_len = 0;
     WBXMLError ret      = WBXML_OK;
-  
+
     /* Find length of input buffer */
     switch (in_charset)
     {
@@ -277,7 +516,7 @@ WBXML_DECLARE(WBXMLError) wbxml_charset_conv_term(const WB_TINY        *in_buf,
         /* Add termination bytes length */
         buf_len += term_len;
         break;
-    
+
     default :
         /* Terminated by a simple NULL char ('\0') */
         term_len = 1;
@@ -293,17 +532,17 @@ WBXML_DECLARE(WBXMLError) wbxml_charset_conv_term(const WB_TINY        *in_buf,
 
     /* Use a temporary length var (because it is decreased) */
     new_len = buf_len;
-  
+
     /* Convert ! */
-    ret = wbxml_charset_conv(in_buf, 
+    ret = wbxml_charset_conv(in_buf,
                              &new_len,
                              in_charset,
                              out_buf,
                              out_charset);
-  
-    /* Set input buffer length */           
+
+    /* Set input buffer length */
     *io_bytes = buf_len;
-  
+
     return ret;
 }
 

--- a/src/libwbxml/wbxml_charset.h
+++ b/src/libwbxml/wbxml_charset.h
@@ -1,0 +1,126 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_charset.h
+ * @ingroup wbxml_charset
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 04/03/24
+ *
+ * @brief Charset Functions
+ */
+
+#ifndef WBXML_CHARSET_H
+#define WBXML_CHARSET_H
+
+#include "wbxml.h"
+#include "wbxml_buffers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+  
+/** @addtogroup wbxml_charset 
+ *  @{ 
+ */
+
+
+/**
+ * @brief Get a Charset MIBEnum given a Charset Name
+ * @param name     [in]  Charset Name to search
+ * @param mib_enum [out] MIBEnum if found
+ * @return Return TRUE if Charset found, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_charset_get_mib(const WB_TINY       *name,
+                                             WBXMLCharsetMIBEnum *mib_enum);
+
+/**
+ * @brief Get a Charset Name given a Charset MIBEnum
+ * @param mib_enum [in]  MIBEnum to search
+ * @param name     [out] Charset Name if found
+ * @return Return TRUE if Charset found, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_charset_get_name(WBXMLCharsetMIBEnum   mib_enum,
+                                              const WB_TINY       **name);
+  
+/**
+ * Charset Convertion function
+ *
+ * Input is a normal pointer to buffer to convert.
+ *
+ * Result is a WBXML Buffer. If 'in_charset' and 'out_charset' are
+ * identical, and are even ASCII or UTF-8, this will be a static
+ * buffer pointing to input buffer.
+ *
+ * The 'io_bytes' parameter is decremented each time a byte is correctly
+ * converted from 'in_buf', so that it reflects the number of bytes that
+ * have been converted from 'in_buf'.
+ *
+ * @param in_buf      Buffer to convert
+ * @param io_bytes    Number of bytes in buffer
+ * @param in_charset  Original charset
+ * @param out_buf     Resulting converted Buffer
+ * @param out_charset Destination charset
+ */
+WBXML_DECLARE(WBXMLError) wbxml_charset_conv(const WB_TINY        *in_buf,
+                                             WB_ULONG             *io_bytes,
+                                             WBXMLCharsetMIBEnum   in_charset,
+                                             WBXMLBuffer         **out_buf,
+                                             WBXMLCharsetMIBEnum   out_charset);
+
+/**
+ * Charset Convertion function, for unknown length strings
+ *
+ * This is a wrapper around wbxml_charset_conv(), but to convert
+ * a buffer that have an unknown length. This function first try to find
+ * the buffer length, by finding its charset specific termination code
+ * (eg: '\0', '\0\0'), then it calls the wbxml_charset_conv() function.
+ *
+ * Set the maximum possible length of input buffer into 'io_bytes'. A check
+ * is done if length found is higher than input 'io_bytes' value.
+ *
+ * WARNING : 'io_bytes' is then set to the real length of input buffer (this is
+ * a different behaviour than with wbxml_charset_conv()).
+ *
+ * @param in_buf      Buffer to convert
+ * @param io_bytes    Number of bytes in buffer
+ * @param in_charset  Original charset
+ * @param out_buf     Resulting converted Buffer
+ * @param out_charset Destination charset
+ */
+WBXML_DECLARE(WBXMLError) wbxml_charset_conv_term(const WB_TINY        *in_buf,
+                                                  WB_ULONG             *io_bytes,
+                                                  WBXMLCharsetMIBEnum   in_charset,
+                                                  WBXMLBuffer         **out_buf,
+                                                  WBXMLCharsetMIBEnum   out_charset);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_CHARSET_H */

--- a/src/libwbxml/wbxml_config.h
+++ b/src/libwbxml/wbxml_config.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2008 Michael Bell <michael.bell@opensync.org>
+ */
+
+#ifndef WBXML_CONFIG_H
+#define WBXML_CONFIG_H
+
+/** WBXML Parser Lib Version */
+#define WBXML_LIB_VERSION "0.11.5"
+
+/* Define to 1 if you would like to enable debug, warning and error messages */
+/* #undef WBXML_LIB_VERBOSE */
+
+/* supported document types */
+#define WBXML_ENCODER_USE_STRTBL
+#define WBXML_SUPPORT_WML
+#define WBXML_SUPPORT_WTA
+#define WBXML_SUPPORT_SI
+#define WBXML_SUPPORT_SL
+#define WBXML_SUPPORT_CO
+#define WBXML_SUPPORT_PROV
+#define WBXML_SUPPORT_EMN
+#define WBXML_SUPPORT_DRMREL
+#define WBXML_SUPPORT_OTA_SETTINGS
+#define WBXML_SUPPORT_SYNCML
+#define WBXML_SUPPORT_WV
+#define WBXML_SUPPORT_AIRSYNC
+#define WBXML_SUPPORT_CONML
+
+#endif /* WBXML_CONFIG_H */

--- a/src/libwbxml/wbxml_config_internals.h
+++ b/src/libwbxml/wbxml_config_internals.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2008 Michael Bell <michael.bell@opensync.org>
+ */
+
+#ifndef WBXML_CONFIG_INTERNALS_H
+#define WBXML_CONFIG_INTERNALS_H
+
+/* These are the public details of the configuration. */
+#include "wbxml_config.h"
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
+/* #undef HAVE_DOPRNT */
+
+/* Define to 1 if you have the <expat.h> header file. */
+/* Define to 1 if you have the `expat' library (-lexpat). */
+#define HAVE_EXPAT
+
+/* Define to 1 if you have the `iconv' library (sometimes in libc). */
+#define HAVE_ICONV
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+/* #undef HAVE_INTTYPES_H */
+
+/* Define to 1 if you have the `nsl' library (-lnsl). */
+/* #undef HAVE_LIBNSL */
+
+/* Define to 1 if you have the `popt' library (-lpopt). */
+/* #undef HAVE_LIBPOPT */
+
+/* Define to 1 if you have the `z' library (-lz). */
+/* #undef HAVE_LIBZ */
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H
+
+/* Define to 1 if you have the <memory.h> header file. */
+/* #undef HAVE_MEMORY_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+/* #undef HAVE_STDINT_H */
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+/* #undef HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <string.h> header file. */
+/* #undef HAVE_STRING_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+/* #undef HAVE_SYS_STAT_H */
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+/* #undef HAVE_SYS_TYPES_H */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+/* #undef HAVE_UNISTD_H */
+
+/* Define to 1 if you have the `vprintf' function. */
+/* #undef HAVE_VPRINTF */
+
+/* Name of package */
+#define PACKAGE "libwbxml"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT " "
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libwbxml"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libwbxml 0.11.5"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libwbxml"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.11.5"
+
+/* Define to 1 if you have the ANSI C header files. */
+/* #undef STDC_HEADERS */
+
+/* Version number of package */
+#define VERSION "0.11.5"
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Includes */
+#if defined( HAVE_EXPAT)
+#include <expat.h>
+#endif /* HAVE_EXPAT */
+
+#if defined( HAVE_ICONV )
+#include <iconv.h>
+#endif /* HAVE_ICONV */
+
+
+#endif /* WBXML_CONFIG_INTERNALS_H */

--- a/src/libwbxml/wbxml_conv.c
+++ b/src/libwbxml/wbxml_conv.c
@@ -1,0 +1,386 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+
+/**
+ * @file wbxml_conv.c
+ * @ingroup wbxml_conv
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/23
+ *
+ * @brief WBXML Convertion Library (XML to WBXML, and WBXML to XML)
+ */
+
+#include "wbxml_conv.h"
+#include "wbxml_tree.h"
+#include "wbxml_log.h"
+
+/****************************
+ *    converter objects     *
+ ****************************
+ */
+
+struct WBXMLConvWBXML2XML_s {
+    WBXMLGenXMLType gen_type;    /**< WBXML_GEN_XML_COMPACT | WBXML_GEN_XML_INDENT | WBXML_GEN_XML_CANONICAL (Default: WBXML_GEN_XML_INDENT) */
+    WBXMLLanguage lang;          /**< Force document Language (overwrite document Public ID) */
+    WBXMLCharsetMIBEnum charset; /**< Set document Language (does not overwrite document character set) */
+    WB_UTINY indent;             /**< Indentation Delta, when using WBXML_GEN_XML_INDENT Generation Type (Default: 0) */
+    WB_BOOL keep_ignorable_ws;   /**< Keep Ignorable Whitespaces (Default: FALSE) */
+};
+
+struct WBXMLConvXML2WBXML_s {
+    WBXMLVersion wbxml_version; /**< WBXML Version */
+    WB_BOOL keep_ignorable_ws;  /**< Keep Ignorable Whitespaces (Default: FALSE) */
+    WB_BOOL use_strtbl;         /**< Generate String Table (Default: TRUE) */
+    WB_BOOL produce_anonymous;  /**< Produce an anonymous document (Default: FALSE) */
+};
+
+/****************************
+ *     Public Functions     *
+ ****************************
+ */
+
+WBXML_DECLARE(WBXMLError) wbxml_conv_wbxml2xml_create(WBXMLConvWBXML2XML **conv)
+{
+    if (conv == NULL) {
+        return WBXML_ERROR_BAD_PARAMETER;
+    }
+
+    *conv = wbxml_malloc(sizeof(WBXMLConvWBXML2XML));
+    if (*conv == NULL) {
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    (*conv)->gen_type = WBXML_GEN_XML_INDENT;
+    (*conv)->lang     = WBXML_LANG_UNKNOWN;
+    (*conv)->charset  = WBXML_CHARSET_UNKNOWN;
+    (*conv)->indent   = 0;
+    (*conv)->keep_ignorable_ws = FALSE;
+
+    return WBXML_OK;
+}
+
+/**
+ * @brief Set the XML generation type (default: WBXML_GEN_XML_INDENT).
+ * @param conv     [in] the converter
+ * @param gen_type [in] generation type
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_gen_type(WBXMLConvWBXML2XML *conv, WBXMLGenXMLType gen_type)
+{
+    conv->gen_type = gen_type;
+}
+
+/**
+ * @brief Set the used WBXML language.
+ *        The language is usually detected by the specified public ID in the document.
+ *        If the public ID is set then it overrides the language.
+ * @param conv [in] the converter
+ * @param lang [in] language (e.g. SYNCML12)
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_language(WBXMLConvWBXML2XML *conv, WBXMLLanguage lang)
+{
+    conv->lang = lang;
+}
+
+/**
+ * @brief Set the used character set.
+ *        The default character set is UTF-8.
+ *        If the document specifies a character set by it own
+ *        then this character set overrides the parameter charset.
+ * @param conv    [in] the converter
+ * @param charset [in] the character set
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_charset(WBXMLConvWBXML2XML *conv, WBXMLCharsetMIBEnum charset)
+{
+    conv->charset = charset;
+}
+
+/**
+ * @brief Set the indent of the generated XML document (please see EXPAT default).
+ * @param conv   [in] the converter
+ * @param indent [in] the number of blanks
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_indent(WBXMLConvWBXML2XML *conv, WB_UTINY indent)
+{
+    conv->indent = indent;
+}
+
+/**
+ * @brief Enable whitespace preservation (default: FALSE).
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_enable_preserve_whitespaces(WBXMLConvWBXML2XML *conv)
+{
+    conv->keep_ignorable_ws = TRUE;
+}
+
+/**
+ * @brief Convert WBXML to XML
+ * @param conv      [in] the converter
+ * @param wbxml     [in] WBXML Document to convert
+ * @param wbxml_len [in] Length of WBXML Document
+ * @param xml       [out] Resulting XML Document
+ * @param xml_len   [out] XML Document length
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_wbxml2xml_run(WBXMLConvWBXML2XML *conv,
+                                                   WB_UTINY  *wbxml,
+                                                   WB_ULONG   wbxml_len,
+                                                   WB_UTINY **xml,
+                                                   WB_ULONG  *xml_len)
+{
+    WBXMLGenXMLParams params;
+    WBXMLTree *wbxml_tree = NULL;
+    WB_ULONG   dummy_len = 0;
+    WBXMLError ret = WBXML_OK;
+
+    /* Copy options */
+    params.gen_type          = conv->gen_type;
+    params.lang              = conv->lang;
+    params.charset           = conv->charset;
+    params.keep_ignorable_ws = conv->keep_ignorable_ws;
+    params.indent            = conv->indent;
+
+    /* Check Parameters (we allow 'xml_len' to be NULL for backward compatibility) */
+    if ((wbxml == NULL) || (wbxml_len == 0) || (xml == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    if (xml_len == NULL)
+        xml_len = &dummy_len;
+
+    *xml = NULL;
+    *xml_len = 0;
+
+    /* Parse WBXML to WBXML Tree */
+    ret = wbxml_tree_from_wbxml(wbxml, wbxml_len, conv->lang, conv->charset, &wbxml_tree);
+    if (ret != WBXML_OK) {
+        WBXML_ERROR((WBXML_CONV, "wbxml2xml conversion failed - WBXML Parser Error: %s",
+                                 wbxml_errors_string(ret)));
+
+        return ret;
+    }
+    else {
+        /* Convert Tree to XML */
+        ret = wbxml_tree_to_xml(wbxml_tree, xml, xml_len, &params);
+        if (ret != WBXML_OK) {
+            WBXML_ERROR((WBXML_CONV, "wbxml2xml conversion failed - WBXML Encoder Error: %s",
+                                     wbxml_errors_string(ret)));
+        }
+
+        /* Clean-up */
+        wbxml_tree_destroy(wbxml_tree);
+
+        return ret;
+    }
+}
+
+/**
+ * @brief Destroy the converter object.
+ * @param [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_destroy(WBXMLConvWBXML2XML *conv)
+{
+    wbxml_free(conv);
+}
+
+/**
+ * @brief Create a new WBXML to XML converter with the default configuration.
+ * @param conv [out] a reference to the pointer of the new converter
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_xml2wbxml_create(WBXMLConvXML2WBXML **conv)
+{
+    if (conv == NULL) {
+        return WBXML_ERROR_BAD_PARAMETER;
+    }
+
+    *conv = wbxml_malloc(sizeof(WBXMLConvXML2WBXML));
+    if (*conv == NULL) {
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    (*conv)->wbxml_version     = WBXML_VERSION_13;
+    (*conv)->keep_ignorable_ws = FALSE;
+    (*conv)->use_strtbl        = TRUE;
+    (*conv)->produce_anonymous = FALSE;
+
+    return WBXML_OK;
+}
+
+/**
+ * @brief Set the WBXML version (default: 1.3).
+ * @param conv   [in] the converter
+ * @param indent [in] the number of blanks
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_set_version(WBXMLConvXML2WBXML *conv,
+                                                     WBXMLVersion wbxml_version)
+{
+    conv->wbxml_version = wbxml_version;
+}
+
+/**
+ * @brief Enable whitespace preservation (default: FALSE/DISABLED).
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_enable_preserve_whitespaces(WBXMLConvXML2WBXML *conv)
+{
+    conv->keep_ignorable_ws = TRUE;
+}
+
+/**
+ * @brief Disable string table (default: TRUE/ENABLED).
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_disable_string_table(WBXMLConvXML2WBXML *conv)
+{
+    conv->use_strtbl = FALSE;
+}
+
+/**
+ * @brief Disable public ID (default: TRUE/ENABLED).
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_disable_public_id(WBXMLConvXML2WBXML *conv)
+{
+    conv->produce_anonymous = TRUE;
+}
+
+/**
+ * @brief Convert XML to WBXML
+ * @param conv      [in] the converter
+ * @param xml       [in] XML Document to convert
+ * @param xml_len   [in] Length of XML Document
+ * @param wbxml     [out] Resulting WBXML Document
+ * @param wbxml_len [out] Length of resulting WBXML Document
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_xml2wbxml_run(WBXMLConvXML2WBXML *conv,
+                                                   WB_UTINY  *xml,
+                                                   WB_ULONG   xml_len,
+                                                   WB_UTINY **wbxml,
+                                                   WB_ULONG  *wbxml_len)
+{
+    WBXMLTree *wbxml_tree = NULL;
+    WBXMLError ret = WBXML_OK;
+    WBXMLGenWBXMLParams params;
+
+    /* Check Parameters */
+    if ((xml == NULL) || (xml_len == 0) || (wbxml == NULL) || (wbxml_len == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    /* copy options */
+    params.wbxml_version     = conv->wbxml_version;
+    params.keep_ignorable_ws = conv->keep_ignorable_ws;
+    params.use_strtbl        = conv->use_strtbl;
+    params.produce_anonymous = conv->produce_anonymous;
+
+    *wbxml = NULL;
+    *wbxml_len = 0;
+
+    /* Parse XML to WBXML Tree */
+    ret = wbxml_tree_from_xml(xml, xml_len, &wbxml_tree);
+    if (ret != WBXML_OK) {
+        WBXML_ERROR((WBXML_CONV, "xml2wbxml conversion failed - Error: %s",
+                                  wbxml_errors_string(ret)));
+
+        return ret;
+    }
+    else {
+        /* Convert Tree to WBXML */
+        ret = wbxml_tree_to_wbxml(wbxml_tree, wbxml, wbxml_len, &params);
+        if (ret != WBXML_OK) {
+            WBXML_ERROR((WBXML_CONV, "xml2wbxml conversion failed - WBXML Encoder Error: %s",
+                                     wbxml_errors_string(ret)));
+        }
+
+        /* Clean-up */
+        wbxml_tree_destroy(wbxml_tree);
+
+        return ret;
+    }
+}
+
+
+/**
+ * @brief Destroy the converter object.
+ * @param [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_destroy(WBXMLConvXML2WBXML *conv)
+{
+    wbxml_free(conv);
+}
+
+/**************************************
+ * Public Functions - DEPRECATED in API
+ */
+
+WBXML_DECLARE(WBXMLError) wbxml_conv_wbxml2xml_withlen(WB_UTINY  *wbxml,
+                                                       WB_ULONG   wbxml_len,
+                                                       WB_UTINY **xml,
+                                                       WB_ULONG  *xml_len,
+                                                       WBXMLGenXMLParams *params)
+{
+    WBXMLConvWBXML2XML *conv = NULL;
+    WBXMLError ret = WBXML_OK;
+
+    ret = wbxml_conv_wbxml2xml_create(&conv);
+    if (ret != WBXML_OK)
+        return ret;
+
+    wbxml_conv_wbxml2xml_set_gen_type(conv, params->gen_type);
+    wbxml_conv_wbxml2xml_set_language(conv, params->lang);
+    wbxml_conv_wbxml2xml_set_charset(conv, params->charset);
+    wbxml_conv_wbxml2xml_set_indent(conv, params->indent);
+    if (params->keep_ignorable_ws)
+        wbxml_conv_wbxml2xml_enable_preserve_whitespaces(conv);
+    ret = wbxml_conv_wbxml2xml_run(conv, wbxml, wbxml_len, xml, xml_len);
+    wbxml_conv_wbxml2xml_destroy(conv);
+    return ret;
+}
+
+WBXML_DECLARE(WBXMLError) wbxml_conv_xml2wbxml_withlen(WB_UTINY  *xml,
+                                                       WB_ULONG   xml_len,
+                                                       WB_UTINY **wbxml,
+                                                       WB_ULONG  *wbxml_len,
+                                                       WBXMLGenWBXMLParams *params)
+{
+    WBXMLConvXML2WBXML *conv = NULL;
+    WBXMLError ret = WBXML_OK;
+
+    ret = wbxml_conv_xml2wbxml_create(&conv);
+    if (ret != WBXML_OK)
+        return ret;
+
+    wbxml_conv_xml2wbxml_set_version(conv, params->wbxml_version);
+    if (params->keep_ignorable_ws)
+        wbxml_conv_xml2wbxml_enable_preserve_whitespaces(conv);
+    if (!params->use_strtbl)
+        wbxml_conv_xml2wbxml_disable_string_table(conv);
+    if (params->produce_anonymous)
+        wbxml_conv_xml2wbxml_disable_public_id(conv);
+    ret = wbxml_conv_xml2wbxml_run(conv, xml, xml_len, wbxml, wbxml_len);
+    wbxml_conv_xml2wbxml_destroy(conv);
+    return ret;
+}

--- a/src/libwbxml/wbxml_conv.h
+++ b/src/libwbxml/wbxml_conv.h
@@ -2,23 +2,23 @@
  * libwbxml, the WBXML Library.
  * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
  * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- * 
+ *
  * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
- * 
+ *
  * Contact: aymerick@jehanne.org
  * Home: http://libwbxml.aymerick.com
  */
@@ -70,9 +70,9 @@ typedef enum WBXMLVersion_e {
  *      WBXML_SUPPORT_DRMREL
  *      WBXML_SUPPORT_OTA_SETTINGS
  *      WBXML_SUPPORT_SYNCML
- *      WBXML_SUPPORT_WV 
- *      WBXML_SUPPORT_AIRSYNC 
- *      WBXML_SUPPORT_CONML 
+ *      WBXML_SUPPORT_WV
+ *      WBXML_SUPPORT_AIRSYNC
+ *      WBXML_SUPPORT_CONML
  */
 
 
@@ -92,7 +92,7 @@ typedef enum WBXMLLanguage_e {
     WBXML_LANG_WTA10     = 1201,           /**< WTA 1.0 */
     WBXML_LANG_WTAWML12  = 1202,        /**< WTAWML 1.2 */
     WBXML_LANG_CHANNEL11 = 1203,       /**< CHANNEL 1.1 */
-    WBXML_LANG_CHANNEL12 = 1204,       /**< CHANNEL 1.2 */ 
+    WBXML_LANG_CHANNEL12 = 1204,       /**< CHANNEL 1.2 */
 #endif /* WBXML_SUPPORT_WTA */
 
 #if defined( WBXML_SUPPORT_SI )
@@ -128,12 +128,12 @@ typedef enum WBXMLLanguage_e {
 #if defined( WBXML_SUPPORT_SYNCML )
     WBXML_LANG_SYNCML_SYNCML10 = 2001, /**< SYNCML 1.0 */
     WBXML_LANG_SYNCML_DEVINF10 = 2002, /**< DEVINF 1.0 */
-    WBXML_LANG_SYNCML_METINF10 = 2003, /**< METINF 1.0 */    
-    
+    WBXML_LANG_SYNCML_METINF10 = 2003, /**< METINF 1.0 */
+
     WBXML_LANG_SYNCML_SYNCML11 = 2101, /**< SYNCML 1.1 */
     WBXML_LANG_SYNCML_DEVINF11 = 2102, /**< DEVINF 1.1 */
     WBXML_LANG_SYNCML_METINF11 = 2103, /**< METINF 1.1 */
-    
+
     WBXML_LANG_SYNCML_SYNCML12 = 2201, /**< SYNCML 1.2 */
     WBXML_LANG_SYNCML_DEVINF12 = 2202, /**< DEVINF 1.2 */
     WBXML_LANG_SYNCML_METINF12 = 2203, /**< METINF 1.2 */
@@ -161,22 +161,261 @@ typedef enum WBXMLLanguage_e {
 
 /** Supported WBXML Charsets MIBEnum */
 typedef enum WBXMLCharsetMIBEnum_e {
-  WBXML_CHARSET_UNKNOWN         = 0,       /**< Unknown Charset */
-  WBXML_CHARSET_US_ASCII        = 3,       /**< US-ASCII */
-  WBXML_CHARSET_ISO_8859_1      = 4,       /**< ISO-8859-1 */
-  WBXML_CHARSET_ISO_8859_2      = 5,       /**< ISO-8859-2 */
-  WBXML_CHARSET_ISO_8859_3      = 6,       /**< ISO-8859-3 */
-  WBXML_CHARSET_ISO_8859_4      = 7,       /**< ISO-8859-4 */
-  WBXML_CHARSET_ISO_8859_5      = 8,       /**< ISO-8859-5 */
-  WBXML_CHARSET_ISO_8859_6      = 9,       /**< ISO-8859-6 */
-  WBXML_CHARSET_ISO_8859_7      = 10,      /**< ISO-8859-7 */
-  WBXML_CHARSET_ISO_8859_8      = 11,      /**< ISO-8859-8 */
-  WBXML_CHARSET_ISO_8859_9      = 12,      /**< ISO-8859-9 */
-  WBXML_CHARSET_SHIFT_JIS       = 17,      /**< Shift_JIS */
-  WBXML_CHARSET_UTF_8           = 106,     /**< UTF-8 */
-  WBXML_CHARSET_ISO_10646_UCS_2 = 1000,    /**< ISO-10646-UCS-2 */
-  WBXML_CHARSET_UTF_16          = 1015,    /**< UTF-16 */
-  WBXML_CHARSET_BIG5            = 2026     /**< Big5 */
+    WBXML_CHARSET_UNKNOWN                                       = 0,
+    WBXML_CHARSET_US_ASCII                                      = 3,
+    WBXML_CHARSET_ISO_8859_1                                    = 4,
+    WBXML_CHARSET_ISO_8859_2                                    = 5,
+    WBXML_CHARSET_ISO_8859_3                                    = 6,
+    WBXML_CHARSET_ISO_8859_4                                    = 7,
+    WBXML_CHARSET_ISO_8859_5                                    = 8,
+    WBXML_CHARSET_ISO_8859_6                                    = 9,
+    WBXML_CHARSET_ISO_8859_7                                    = 10,
+    WBXML_CHARSET_ISO_8859_8                                    = 11,
+    WBXML_CHARSET_ISO_8859_9                                    = 12,
+    WBXML_CHARSET_ISO_8859_10                                   = 13,
+    WBXML_CHARSET_SHIFT_JIS                                     = 17,
+    WBXML_CHARSET_EXTENDED_UNIX_CODE_PACKED_FORMAT_FOR_JAPANESE = 18,
+    WBXML_CHARSET_EXTENDED_UNIX_CODE_FIXED_WIDTH_FOR_JAPANESE   = 19,
+    WBXML_CHARSET_BS_4730                                       = 20,
+    WBXML_CHARSET_SEN_850200_C                                  = 21,
+    WBXML_CHARSET_IT                                            = 22,
+    WBXML_CHARSET_ES                                            = 23,
+    WBXML_CHARSET_DIN_66003                                     = 24,
+    WBXML_CHARSET_NS_4551_1                                     = 25,
+    WBXML_CHARSET_NF_Z_62_010                                   = 26,
+    WBXML_CHARSET_ISO_10646_UTF_1                               = 27,
+    WBXML_CHARSET_ISO_646_BASIC                                 = 28,
+    WBXML_CHARSET_INVARIANT                                     = 29,
+    WBXML_CHARSET_ISO_646_IRV                                   = 30,
+    WBXML_CHARSET_NATS_SEFI                                     = 31,
+    WBXML_CHARSET_NATS_SEFI_ADD                                 = 32,
+    WBXML_CHARSET_NATS_DANO                                     = 33,
+    WBXML_CHARSET_NATS_DANO_ADD                                 = 34,
+    WBXML_CHARSET_SEN_850200_B                                  = 35,
+    WBXML_CHARSET_KS_C_5601_1987                                = 36,
+    WBXML_CHARSET_ISO_2022_KR                                   = 37,
+    WBXML_CHARSET_EUC_KR                                        = 38,
+    WBXML_CHARSET_ISO_2022_JP                                   = 39,
+    WBXML_CHARSET_ISO_2022_JP_2                                 = 40,
+    WBXML_CHARSET_JIS_C6220_1969_JP                             = 41,
+    WBXML_CHARSET_JIS_C6220_1969_RO                             = 42,
+    WBXML_CHARSET_PT                                            = 43,
+    WBXML_CHARSET_GREEK7_OLD                                    = 44,
+    WBXML_CHARSET_LATIN_GREEK                                   = 45,
+    WBXML_CHARSET_NF_Z_62_010_1973                              = 46,
+    WBXML_CHARSET_LATIN_GREEK_1                                 = 47,
+    WBXML_CHARSET_ISO_5427                                      = 48,
+    WBXML_CHARSET_JIS_C6226_1978                                = 49,
+    WBXML_CHARSET_BS_VIEWDATA                                   = 50,
+    WBXML_CHARSET_INIS                                          = 51,
+    WBXML_CHARSET_INIS_8                                        = 52,
+    WBXML_CHARSET_INIS_CYRILLIC                                 = 53,
+    WBXML_CHARSET_ISO_5427_1981                                 = 54,
+    WBXML_CHARSET_ISO_5428                                      = 55,
+    WBXML_CHARSET_GB_1988_80                                    = 56,
+    WBXML_CHARSET_GB_2312_80                                    = 57,
+    WBXML_CHARSET_NS_4551_2                                     = 58,
+    WBXML_CHARSET_VIDEOTEX_SUPPL                                = 59,
+    WBXML_CHARSET_PT2                                           = 60,
+    WBXML_CHARSET_ES2                                           = 61,
+    WBXML_CHARSET_MSZ_7795_3                                    = 62,
+    WBXML_CHARSET_JIS_C6226_1983                                = 63,
+    WBXML_CHARSET_GREEK7                                        = 64,
+    WBXML_CHARSET_ASMO_449                                      = 65,
+    WBXML_CHARSET_ISO_IR_90                                     = 66,
+    WBXML_CHARSET_JIS_C6229_1984_A                              = 67,
+    WBXML_CHARSET_JIS_C6229_1984_B                              = 68,
+    WBXML_CHARSET_JIS_C6229_1984_B_ADD                          = 69,
+    WBXML_CHARSET_JIS_C6229_1984_HAND                           = 70,
+    WBXML_CHARSET_JIS_C6229_1984_HAND_ADD                       = 71,
+    WBXML_CHARSET_JIS_C6229_1984_KANA                           = 72,
+    WBXML_CHARSET_ISO_2033_1983                                 = 73,
+    WBXML_CHARSET_ANSI_X3_110_1983                              = 74,
+    WBXML_CHARSET_T_61_7BIT                                     = 75,
+    WBXML_CHARSET_T_61_8BIT                                     = 76,
+    WBXML_CHARSET_ECMA_CYRILLIC                                 = 77,
+    WBXML_CHARSET_CSA_Z243_4_1985_1                             = 78,
+    WBXML_CHARSET_CSA_Z243_4_1985_2                             = 79,
+    WBXML_CHARSET_CSA_Z243_4_1985_GR                            = 80,
+    WBXML_CHARSET_ISO_8859_6_E                                  = 81,
+    WBXML_CHARSET_ISO_8859_6_I                                  = 82,
+    WBXML_CHARSET_T_101_G2                                      = 83,
+    WBXML_CHARSET_ISO_8859_8_E                                  = 84,
+    WBXML_CHARSET_ISO_8859_8_I                                  = 85,
+    WBXML_CHARSET_CSN_369103                                    = 86,
+    WBXML_CHARSET_JUS_I_B1_002                                  = 87,
+    WBXML_CHARSET_IEC_P27_1                                     = 88,
+    WBXML_CHARSET_JUS_I_B1_003_SERB                             = 89,
+    WBXML_CHARSET_JUS_I_B1_003_MAC                              = 90,
+    WBXML_CHARSET_GREEK_CCITT                                   = 91,
+    WBXML_CHARSET_NC_NC00_10                                    = 92,
+    WBXML_CHARSET_ISO_6937_2_25                                 = 93,
+    WBXML_CHARSET_GOST_19768_74                                 = 94,
+    WBXML_CHARSET_ISO_8859_SUPP                                 = 95,
+    WBXML_CHARSET_ISO_10367_BOX                                 = 96,
+    WBXML_CHARSET_LATIN_LAP                                     = 97,
+    WBXML_CHARSET_JIS_X0212_1990                                = 98,
+    WBXML_CHARSET_DS_2089                                       = 99,
+    WBXML_CHARSET_US_DK                                         = 100,
+    WBXML_CHARSET_DK_US                                         = 101,
+    WBXML_CHARSET_KSC5636                                       = 102,
+    WBXML_CHARSET_UNICODE_1_1_UTF_7                             = 103,
+    WBXML_CHARSET_ISO_2022_CN                                   = 104,
+    WBXML_CHARSET_ISO_2022_CN_EXT                               = 105,
+    WBXML_CHARSET_UTF_8                                         = 106,
+    WBXML_CHARSET_ISO_8859_13                                   = 109,
+    WBXML_CHARSET_ISO_8859_14                                   = 110,
+    WBXML_CHARSET_ISO_8859_15                                   = 111,
+    WBXML_CHARSET_ISO_8859_16                                   = 112,
+    WBXML_CHARSET_GBK                                           = 113,
+    WBXML_CHARSET_GB18030                                       = 114,
+    WBXML_CHARSET_OSD_EBCDIC_DF04_15                            = 115,
+    WBXML_CHARSET_OSD_EBCDIC_DF03_IRV                           = 116,
+    WBXML_CHARSET_OSD_EBCDIC_DF04_1                             = 117,
+    WBXML_CHARSET_ISO_11548_1                                   = 118,
+    WBXML_CHARSET_KZ_1048                                       = 119,
+    WBXML_CHARSET_ISO_10646_UCS_2                               = 1000,
+    WBXML_CHARSET_ISO_10646_UCS_4                               = 1001,
+    WBXML_CHARSET_ISO_10646_UCS_BASIC                           = 1002,
+    WBXML_CHARSET_ISO_10646_UNICODE_LATIN1                      = 1003,
+    WBXML_CHARSET_ISO_10646_J_1                                 = 1004,
+    WBXML_CHARSET_ISO_UNICODE_IBM_1261                          = 1005,
+    WBXML_CHARSET_ISO_UNICODE_IBM_1268                          = 1006,
+    WBXML_CHARSET_ISO_UNICODE_IBM_1276                          = 1007,
+    WBXML_CHARSET_ISO_UNICODE_IBM_1264                          = 1008,
+    WBXML_CHARSET_ISO_UNICODE_IBM_1265                          = 1009,
+    WBXML_CHARSET_UNICODE_1_1                                   = 1010,
+    WBXML_CHARSET_SCSU                                          = 1011,
+    WBXML_CHARSET_UTF_7                                         = 1012,
+    WBXML_CHARSET_UTF_16BE                                      = 1013,
+    WBXML_CHARSET_UTF_16LE                                      = 1014,
+    WBXML_CHARSET_UTF_16                                        = 1015,
+    WBXML_CHARSET_CESU_8                                        = 1016,
+    WBXML_CHARSET_UTF_32                                        = 1017,
+    WBXML_CHARSET_UTF_32BE                                      = 1018,
+    WBXML_CHARSET_UTF_32LE                                      = 1019,
+    WBXML_CHARSET_BOCU_1                                        = 1020,
+    WBXML_CHARSET_ISO_8859_1_WINDOWS_3_0_LATIN_1                = 2000,
+    WBXML_CHARSET_ISO_8859_1_WINDOWS_3_1_LATIN_1                = 2001,
+    WBXML_CHARSET_ISO_8859_2_WINDOWS_LATIN_2                    = 2002,
+    WBXML_CHARSET_ISO_8859_9_WINDOWS_LATIN_5                    = 2003,
+    WBXML_CHARSET_HP_ROMAN8                                     = 2004,
+    WBXML_CHARSET_ADOBE_STANDARD_ENCODING                       = 2005,
+    WBXML_CHARSET_VENTURA_US                                    = 2006,
+    WBXML_CHARSET_VENTURA_INTERNATIONAL                         = 2007,
+    WBXML_CHARSET_DEC_MCS                                       = 2008,
+    WBXML_CHARSET_IBM850                                        = 2009,
+    WBXML_CHARSET_PC8_DANISH_NORWEGIAN                          = 2012,
+    WBXML_CHARSET_IBM862                                        = 2013,
+    WBXML_CHARSET_PC8_TURKISH                                   = 2014,
+    WBXML_CHARSET_IBM_SYMBOLS                                   = 2015,
+    WBXML_CHARSET_IBM_THAI                                      = 2016,
+    WBXML_CHARSET_HP_LEGAL                                      = 2017,
+    WBXML_CHARSET_HP_PI_FONT                                    = 2018,
+    WBXML_CHARSET_HP_MATH8                                      = 2019,
+    WBXML_CHARSET_ADOBE_SYMBOL_ENCODING                         = 2020,
+    WBXML_CHARSET_HP_DESKTOP                                    = 2021,
+    WBXML_CHARSET_VENTURA_MATH                                  = 2022,
+    WBXML_CHARSET_MICROSOFT_PUBLISHING                          = 2023,
+    WBXML_CHARSET_WINDOWS_31J                                   = 2024,
+    WBXML_CHARSET_GB2312                                        = 2025,
+    WBXML_CHARSET_BIG5                                          = 2026,
+    WBXML_CHARSET_MACINTOSH                                     = 2027,
+    WBXML_CHARSET_IBM037                                        = 2028,
+    WBXML_CHARSET_IBM038                                        = 2029,
+    WBXML_CHARSET_IBM273                                        = 2030,
+    WBXML_CHARSET_IBM274                                        = 2031,
+    WBXML_CHARSET_IBM275                                        = 2032,
+    WBXML_CHARSET_IBM277                                        = 2033,
+    WBXML_CHARSET_IBM278                                        = 2034,
+    WBXML_CHARSET_IBM280                                        = 2035,
+    WBXML_CHARSET_IBM281                                        = 2036,
+    WBXML_CHARSET_IBM284                                        = 2037,
+    WBXML_CHARSET_IBM285                                        = 2038,
+    WBXML_CHARSET_IBM290                                        = 2039,
+    WBXML_CHARSET_IBM297                                        = 2040,
+    WBXML_CHARSET_IBM420                                        = 2041,
+    WBXML_CHARSET_IBM423                                        = 2042,
+    WBXML_CHARSET_IBM424                                        = 2043,
+    WBXML_CHARSET_IBM437                                        = 2011,
+    WBXML_CHARSET_IBM500                                        = 2044,
+    WBXML_CHARSET_IBM851                                        = 2045,
+    WBXML_CHARSET_IBM852                                        = 2010,
+    WBXML_CHARSET_IBM855                                        = 2046,
+    WBXML_CHARSET_IBM857                                        = 2047,
+    WBXML_CHARSET_IBM860                                        = 2048,
+    WBXML_CHARSET_IBM861                                        = 2049,
+    WBXML_CHARSET_IBM863                                        = 2050,
+    WBXML_CHARSET_IBM864                                        = 2051,
+    WBXML_CHARSET_IBM865                                        = 2052,
+    WBXML_CHARSET_IBM868                                        = 2053,
+    WBXML_CHARSET_IBM869                                        = 2054,
+    WBXML_CHARSET_IBM870                                        = 2055,
+    WBXML_CHARSET_IBM871                                        = 2056,
+    WBXML_CHARSET_IBM880                                        = 2057,
+    WBXML_CHARSET_IBM891                                        = 2058,
+    WBXML_CHARSET_IBM903                                        = 2059,
+    WBXML_CHARSET_IBM904                                        = 2060,
+    WBXML_CHARSET_IBM905                                        = 2061,
+    WBXML_CHARSET_IBM918                                        = 2062,
+    WBXML_CHARSET_IBM1026                                       = 2063,
+    WBXML_CHARSET_EBCDIC_AT_DE                                  = 2064,
+    WBXML_CHARSET_EBCDIC_AT_DE_A                                = 2065,
+    WBXML_CHARSET_EBCDIC_CA_FR                                  = 2066,
+    WBXML_CHARSET_EBCDIC_DK_NO                                  = 2067,
+    WBXML_CHARSET_EBCDIC_DK_NO_A                                = 2068,
+    WBXML_CHARSET_EBCDIC_FI_SE                                  = 2069,
+    WBXML_CHARSET_EBCDIC_FI_SE_A                                = 2070,
+    WBXML_CHARSET_EBCDIC_FR                                     = 2071,
+    WBXML_CHARSET_EBCDIC_IT                                     = 2072,
+    WBXML_CHARSET_EBCDIC_PT                                     = 2073,
+    WBXML_CHARSET_EBCDIC_ES                                     = 2074,
+    WBXML_CHARSET_EBCDIC_ES_A                                   = 2075,
+    WBXML_CHARSET_EBCDIC_ES_S                                   = 2076,
+    WBXML_CHARSET_EBCDIC_UK                                     = 2077,
+    WBXML_CHARSET_EBCDIC_US                                     = 2078,
+    WBXML_CHARSET_UNKNOWN_8BIT                                  = 2079,
+    WBXML_CHARSET_MNEMONIC                                      = 2080,
+    WBXML_CHARSET_MNEM                                          = 2081,
+    WBXML_CHARSET_VISCII                                        = 2082,
+    WBXML_CHARSET_VIQR                                          = 2083,
+    WBXML_CHARSET_KOI8_R                                        = 2084,
+    WBXML_CHARSET_HZ_GB_2312                                    = 2085,
+    WBXML_CHARSET_IBM866                                        = 2086,
+    WBXML_CHARSET_IBM775                                        = 2087,
+    WBXML_CHARSET_KOI8_U                                        = 2088,
+    WBXML_CHARSET_IBM00858                                      = 2089,
+    WBXML_CHARSET_IBM00924                                      = 2090,
+    WBXML_CHARSET_IBM01140                                      = 2091,
+    WBXML_CHARSET_IBM01141                                      = 2092,
+    WBXML_CHARSET_IBM01142                                      = 2093,
+    WBXML_CHARSET_IBM01143                                      = 2094,
+    WBXML_CHARSET_IBM01144                                      = 2095,
+    WBXML_CHARSET_IBM01145                                      = 2096,
+    WBXML_CHARSET_IBM01146                                      = 2097,
+    WBXML_CHARSET_IBM01147                                      = 2098,
+    WBXML_CHARSET_IBM01148                                      = 2099,
+    WBXML_CHARSET_IBM01149                                      = 2100,
+    WBXML_CHARSET_BIG5_HKSCS                                    = 2101,
+    WBXML_CHARSET_IBM1047                                       = 2102,
+    WBXML_CHARSET_PTCP154                                       = 2103,
+    WBXML_CHARSET_AMIGA_1251                                    = 2104,
+    WBXML_CHARSET_KOI7_SWITCHED                                 = 2105,
+    WBXML_CHARSET_BRF                                           = 2106,
+    WBXML_CHARSET_TSCII                                         = 2107,
+    WBXML_CHARSET_CP51932                                       = 2108,
+    WBXML_CHARSET_WINDOWS_874                                   = 2109,
+    WBXML_CHARSET_WINDOWS_1250                                  = 2250,
+    WBXML_CHARSET_WINDOWS_1251                                  = 2251,
+    WBXML_CHARSET_WINDOWS_1252                                  = 2252,
+    WBXML_CHARSET_WINDOWS_1253                                  = 2253,
+    WBXML_CHARSET_WINDOWS_1254                                  = 2254,
+    WBXML_CHARSET_WINDOWS_1255                                  = 2255,
+    WBXML_CHARSET_WINDOWS_1256                                  = 2256,
+    WBXML_CHARSET_WINDOWS_1257                                  = 2257,
+    WBXML_CHARSET_WINDOWS_1258                                  = 2258,
+    WBXML_CHARSET_TIS_620                                       = 2259,
+    WBXML_CHARSET_CP50220                                       = 2260,
 } WBXMLCharsetMIBEnum;
 
 

--- a/src/libwbxml/wbxml_conv.h
+++ b/src/libwbxml/wbxml_conv.h
@@ -1,0 +1,414 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+
+/**
+ * @file wbxml_conv.h
+ * @ingroup wbxml_conv
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/23
+ *
+ * @brief WBXML Convertion Library (XML to WBXML, and WBXML to XML)
+ */
+
+#ifndef WBXML_CONV_H
+#define WBXML_CONV_H
+
+#include "wbxml.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_conv
+ *  @{
+ */
+
+/** WBXML Versions (WBXML tokens) */
+typedef enum WBXMLVersion_e {
+    WBXML_VERSION_UNKNOWN = -1, /**< Unknown WBXML Version */
+    WBXML_VERSION_10 = 0x00,    /**< WBXML 1.0 Token */
+    WBXML_VERSION_11 = 0x01,    /**< WBXML 1.1 Token */
+    WBXML_VERSION_12 = 0x02,    /**< WBXML 1.2 Token */
+    WBXML_VERSION_13 = 0x03     /**< WBXML 1.3 Token */
+} WBXMLVersion;
+
+
+/*
+ * Possible Compilation Flags:
+ * ---------------------------
+ *
+ *      WBXML_SUPPORT_WML
+ *      WBXML_SUPPORT_WTA
+ *      WBXML_SUPPORT_SI
+ *      WBXML_SUPPORT_SL
+ *      WBXML_SUPPORT_CO
+ *      WBXML_SUPPORT_PROV
+ *      WBXML_SUPPORT_EMN
+ *      WBXML_SUPPORT_DRMREL
+ *      WBXML_SUPPORT_OTA_SETTINGS
+ *      WBXML_SUPPORT_SYNCML
+ *      WBXML_SUPPORT_WV 
+ *      WBXML_SUPPORT_AIRSYNC 
+ *      WBXML_SUPPORT_CONML 
+ */
+
+
+/** Supported WBXML Languages */
+typedef enum WBXMLLanguage_e {
+    WBXML_LANG_UNKNOWN = 0,     /**< Unknown / Not Specified */
+
+    /* WAP */
+#if defined( WBXML_SUPPORT_WML )
+    WBXML_LANG_WML10 = 1101,           /**< WML 1.0 */
+    WBXML_LANG_WML11 = 1102,           /**< WML 1.1 */
+    WBXML_LANG_WML12 = 1103,           /**< WML 1.2 */
+    WBXML_LANG_WML13 = 1104,           /**< WML 1.3 */
+#endif /* WBXML_SUPPORT_WML */
+
+#if defined( WBXML_SUPPORT_WTA )
+    WBXML_LANG_WTA10     = 1201,           /**< WTA 1.0 */
+    WBXML_LANG_WTAWML12  = 1202,        /**< WTAWML 1.2 */
+    WBXML_LANG_CHANNEL11 = 1203,       /**< CHANNEL 1.1 */
+    WBXML_LANG_CHANNEL12 = 1204,       /**< CHANNEL 1.2 */ 
+#endif /* WBXML_SUPPORT_WTA */
+
+#if defined( WBXML_SUPPORT_SI )
+    WBXML_LANG_SI10 = 1301,            /**< SI 1.0 */
+#endif /* WBXML_SUPPORT_SI */
+
+#if defined( WBXML_SUPPORT_SL )
+    WBXML_LANG_SL10 = 1401,            /**< SL 1.0 */
+#endif /* WBXML_SUPPORT_SL */
+
+#if defined( WBXML_SUPPORT_CO )
+    WBXML_LANG_CO10 = 1501,            /**< CO 1.0 */
+#endif /* WBXML_SUPPORT_CO */
+
+#if defined( WBXML_SUPPORT_PROV )
+    WBXML_LANG_PROV10 = 1601,          /**< PROV 1.0 */
+#endif /* WBXML_SUPPORT_PROV */
+
+#if defined( WBXML_SUPPORT_EMN )
+    WBXML_LANG_EMN10 = 1701,           /**< EMN 1.0 */
+#endif /* WBXML_SUPPORT_EMN */
+
+#if defined( WBXML_SUPPORT_DRMREL )
+    WBXML_LANG_DRMREL10 = 1801,        /**< DRMREL 1.0 */
+#endif /* WBXML_SUPPORT_DRMREL */
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+    /* Ericsson / Nokia OTA Settings v7.0 */
+    WBXML_LANG_OTA_SETTINGS = 1901,    /**< OTA Settings */
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+    /* SyncML */
+#if defined( WBXML_SUPPORT_SYNCML )
+    WBXML_LANG_SYNCML_SYNCML10 = 2001, /**< SYNCML 1.0 */
+    WBXML_LANG_SYNCML_DEVINF10 = 2002, /**< DEVINF 1.0 */
+    WBXML_LANG_SYNCML_METINF10 = 2003, /**< METINF 1.0 */    
+    
+    WBXML_LANG_SYNCML_SYNCML11 = 2101, /**< SYNCML 1.1 */
+    WBXML_LANG_SYNCML_DEVINF11 = 2102, /**< DEVINF 1.1 */
+    WBXML_LANG_SYNCML_METINF11 = 2103, /**< METINF 1.1 */
+    
+    WBXML_LANG_SYNCML_SYNCML12 = 2201, /**< SYNCML 1.2 */
+    WBXML_LANG_SYNCML_DEVINF12 = 2202, /**< DEVINF 1.2 */
+    WBXML_LANG_SYNCML_METINF12 = 2203, /**< METINF 1.2 */
+    WBXML_LANG_SYNCML_DMDDF12  = 2204, /**< DMDDF  1.2 */
+#endif /* WBXML_SUPPORT_SYNCML */
+
+    /* Wireless-Village */
+#if defined( WBXML_SUPPORT_WV )
+    WBXML_LANG_WV_CSP11 = 2301,        /**< WV CSP 1.1 */
+    WBXML_LANG_WV_CSP12 = 2302,        /**< WV CSP 1.2 */
+#endif /* WBXML_SUPPORT_WV */
+
+    /* Microsoft AirSync */
+#if defined( WBXML_SUPPORT_AIRSYNC )
+    WBXML_LANG_AIRSYNC    = 2401,      /**< AirSync */
+    WBXML_LANG_ACTIVESYNC = 2402,      /**< ActiveSync */
+#endif /* WBXML_SUPPORT_AIRSYNC */
+
+    /* Nokia ConML */
+#if defined( WBXML_SUPPORT_CONML )
+    WBXML_LANG_CONML = 2501            /**< ConML */
+#endif /* WBXML_SUPPORT_CONML */
+} WBXMLLanguage;
+
+
+/** Supported WBXML Charsets MIBEnum */
+typedef enum WBXMLCharsetMIBEnum_e {
+  WBXML_CHARSET_UNKNOWN         = 0,       /**< Unknown Charset */
+  WBXML_CHARSET_US_ASCII        = 3,       /**< US-ASCII */
+  WBXML_CHARSET_ISO_8859_1      = 4,       /**< ISO-8859-1 */
+  WBXML_CHARSET_ISO_8859_2      = 5,       /**< ISO-8859-2 */
+  WBXML_CHARSET_ISO_8859_3      = 6,       /**< ISO-8859-3 */
+  WBXML_CHARSET_ISO_8859_4      = 7,       /**< ISO-8859-4 */
+  WBXML_CHARSET_ISO_8859_5      = 8,       /**< ISO-8859-5 */
+  WBXML_CHARSET_ISO_8859_6      = 9,       /**< ISO-8859-6 */
+  WBXML_CHARSET_ISO_8859_7      = 10,      /**< ISO-8859-7 */
+  WBXML_CHARSET_ISO_8859_8      = 11,      /**< ISO-8859-8 */
+  WBXML_CHARSET_ISO_8859_9      = 12,      /**< ISO-8859-9 */
+  WBXML_CHARSET_SHIFT_JIS       = 17,      /**< Shift_JIS */
+  WBXML_CHARSET_UTF_8           = 106,     /**< UTF-8 */
+  WBXML_CHARSET_ISO_10646_UCS_2 = 1000,    /**< ISO-10646-UCS-2 */
+  WBXML_CHARSET_UTF_16          = 1015,    /**< UTF-16 */
+  WBXML_CHARSET_BIG5            = 2026     /**< Big5 */
+} WBXMLCharsetMIBEnum;
+
+
+/**
+ * @brief Type of XML Generation
+ * @note Canonical Form is defined here: http://www.jclark.com/xml/canonxml.html
+ */
+typedef enum WBXMLGenXMLType_e {
+    WBXML_GEN_XML_COMPACT   = 0,  /**< Compact XML generation */
+    WBXML_GEN_XML_INDENT    = 1,  /**< Indented XML generation */
+    WBXML_GEN_XML_CANONICAL = 2   /**< Canonical XML generation */
+} WBXMLGenXMLType;
+
+
+/**
+ * @brief Parameters when generating an XML document
+ */
+typedef struct WBXMLGenXMLParams_s {
+    WBXMLGenXMLType gen_type;    /**< WBXML_GEN_XML_COMPACT | WBXML_GEN_XML_INDENT | WBXML_GEN_XML_CANONICAL (Default: WBXML_GEN_XML_INDENT) */
+    WBXMLLanguage lang;          /**< Force document Language (overwrite document Public ID) */
+    WBXMLCharsetMIBEnum charset; /**< Set document Language (does not overwrite document character set) */
+    WB_UTINY indent;             /**< Indentation Delta, when using WBXML_GEN_XML_INDENT Generation Type (Default: 0) */
+    WB_BOOL keep_ignorable_ws;   /**< Keep Ignorable Whitespaces (Default: FALSE) */
+} WBXMLGenXMLParams;
+
+/**
+ * @brief Parameters when generating a WBXML document
+ */
+typedef struct WBXMLGenWBXMLParams_s {
+    WBXMLVersion wbxml_version; /**< WBXML Version */
+    WB_BOOL keep_ignorable_ws;  /**< Keep Ignorable Whitespaces (Default: FALSE) */
+    WB_BOOL use_strtbl;         /**< Generate String Table (Default: TRUE) */
+    WB_BOOL produce_anonymous;  /**< Produce an anonymous document (Default: FALSE) */
+} WBXMLGenWBXMLParams;
+
+/**
+ * Wrapper around wbxml_conv_wbxml2_withlen()
+ *
+ * This macro is provided for backward compatibility. You can use it if you are
+ * sure that the output XML document will be encoded in a charset that is NULL
+ * terminated and that can't contains any NULL character in it. For example
+ * this macro works for US-ASCII or UTF-8 encoded documents, but not for UTF-16
+ * encoded documents.
+ */
+#define wbxml_conv_wbxml2xml(a,b,c,d) wbxml_conv_wbxml2xml_withlen(a,b,c,NULL,d)
+
+/**
+ * @brief Convert WBXML to XML
+ * @param wbxml     [in] WBXML Document to convert
+ * @param wbxml_len [in] Length of WBXML Document
+ * @param xml       [out] Resulting XML Document
+ * @param xml_len   [out] XML Document length
+ * @param params    [in] Parameters (if NULL, default values are used)
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_wbxml2xml_withlen(WB_UTINY  *wbxml,
+                                                       WB_ULONG   wbxml_len,
+                                                       WB_UTINY **xml,
+                                                       WB_ULONG  *xml_len,
+                                                       WBXMLGenXMLParams *params) LIBWBXML_DEPRECATED;
+
+/**
+ * Wrapper around wbxml_conv_xml2wbxml_withlen()
+ *
+ * This macro is provided for backward compatibility. You can use it if you are
+ * sure that the input XML document is encoded in a charset that is NULL terminated
+ * and that can't contains any NULL character in it. For example this macro
+ * works for US-ASCII or UTF-8 encoded documents, but not for UTF-16 encoded
+ * documents.
+ */
+#define wbxml_conv_xml2wbxml(a,b,c,d) wbxml_conv_xml2wbxml_withlen(a,WBXML_STRLEN(a),b,c,d)
+
+/**
+ * @brief Convert XML to WBXML
+ * @param xml       [in] XML Document to convert
+ * @param xml_len   [in] Length of XML Document
+ * @param wbxml     [out] Resulting WBXML Document
+ * @param wbxml_len [out] Length of resulting WBXML Document
+ * @param params    [in] Parameters (if NULL, default values are used)
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_xml2wbxml_withlen(WB_UTINY  *xml,
+                                                       WB_ULONG   xml_len,
+                                                       WB_UTINY **wbxml,
+                                                       WB_ULONG  *wbxml_len,
+                                                       WBXMLGenWBXMLParams *params) LIBWBXML_DEPRECATED;
+
+/**
+ * @description This is a container for the WBXML to XML conversion parameters.
+ *              An object style is used because it is much better expandable
+ *              in terms of downward binary compatibility.
+ */
+typedef struct WBXMLConvWBXML2XML_s WBXMLConvWBXML2XML;
+
+/**
+ * @brief Create a new WBXML to XML converter with the default configuration.
+ * @param conv [out] a reference to the pointer of the new converter
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_wbxml2xml_create(WBXMLConvWBXML2XML **conv);
+
+/**
+ * @brief Set the XML generation type (default: WBXML_GEN_XML_INDENT).
+ * @param conv     [in] the converter
+ * @param gen_type [in] generation type
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_gen_type(WBXMLConvWBXML2XML *conv, WBXMLGenXMLType gen_type);
+
+/**
+ * @brief Set the used WBXML language.
+ *        The language is usually detected by the specified public ID in the document.
+ *        If the public ID is set then it overrides the language.
+ * @param conv [in] the converter
+ * @param lang [in] language (e.g. SYNCML12)
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_language(WBXMLConvWBXML2XML *conv, WBXMLLanguage lang);
+
+/**
+ * @brief Set the used character set.
+ *        The default character set is UTF-8.
+ *        If the document specifies a character set by it own
+ *        then this character set overrides the parameter charset.
+ * @param conv    [in] the converter
+ * @param charset [in] the character set
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_charset(WBXMLConvWBXML2XML *conv, WBXMLCharsetMIBEnum charset);
+
+/**
+ * @brief Set the indent of the generated XML document (please see EXPAT default).
+ * @param conv   [in] the converter
+ * @param indent [in] the number of blanks
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_set_indent(WBXMLConvWBXML2XML *conv, WB_UTINY indent);
+
+/**
+ * @brief Enable whitespace preservation (default: FALSE).
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_enable_preserve_whitespaces(WBXMLConvWBXML2XML *conv);
+
+/**
+ * @brief Convert WBXML to XML
+ * @param conv      [in] the converter
+ * @param wbxml     [in] WBXML Document to convert
+ * @param wbxml_len [in] Length of WBXML Document
+ * @param xml       [out] Resulting XML Document
+ * @param xml_len   [out] XML Document length
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_wbxml2xml_run(WBXMLConvWBXML2XML *conv,
+                                                   WB_UTINY  *xml,
+                                                   WB_ULONG   xml_len,
+                                                   WB_UTINY **wbxml,
+                                                   WB_ULONG  *wbxml_len);
+
+/**
+ * @brief Destroy the converter object.
+ * @param [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_wbxml2xml_destroy(WBXMLConvWBXML2XML *conv);
+
+/**
+ * @description This is a container for the XML to WBXML conversion parameters.
+ *              An object style is used because it is much better expandable
+ *              in terms of downward binary compatibility.
+ */
+typedef struct WBXMLConvXML2WBXML_s WBXMLConvXML2WBXML;
+
+/**
+ * @brief Create a new WBXML to XML converter with the default configuration.
+ * @param conv [out] a reference to the pointer of the new converter
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_xml2wbxml_create(WBXMLConvXML2WBXML **conv);
+
+/**
+ * @brief Set the WBXML version (default: 1.3).
+ * @param conv   [in] the converter
+ * @param indent [in] the number of blanks
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_set_version(WBXMLConvXML2WBXML *conv,
+                                                     WBXMLVersion wbxml_version);
+
+/**
+ * @brief Enable whitespace preservation (default: FALSE/DISABLED).
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_enable_preserve_whitespaces(WBXMLConvXML2WBXML *conv);
+
+/**
+ * @brief Disable string table (default: TRUE/ENABLED).
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_disable_string_table(WBXMLConvXML2WBXML *conv);
+
+/**
+ * @desription: Disable public ID (default: TRUE/ENABLED).
+ *              Usually you don't want to produce WBXML documents which are
+ *              really anonymous. You want a known public ID or a DTD name
+ *              to determine the document type. Some specifications like
+ *              Microsoft's ActiveSync explicitely require fully anonymous
+ *              WBXML documents. If you need this then you must disable
+ *              the public ID mechanism.
+ * @param conv     [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_disable_public_id(WBXMLConvXML2WBXML *conv);
+
+/**
+ * @brief Convert XML to WBXML
+ * @param conv      [in] the converter
+ * @param xml       [in] XML Document to convert
+ * @param xml_len   [in] Length of XML Document
+ * @param wbxml     [out] Resulting WBXML Document
+ * @param wbxml_len [out] Length of resulting WBXML Document
+ * @return WBXML_OK if conversion succeeded, an Error Code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_conv_xml2wbxml_run(WBXMLConvXML2WBXML *conv,
+                                                   WB_UTINY  *xml,
+                                                   WB_ULONG   xml_len,
+                                                   WB_UTINY **wbxml,
+                                                   WB_ULONG  *wbxml_len);
+
+/**
+ * @brief Destroy the converter object.
+ * @param [in] the converter
+ */
+WBXML_DECLARE(void) wbxml_conv_xml2wbxml_destroy(WBXMLConvXML2WBXML *conv);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_CONV_H */

--- a/src/libwbxml/wbxml_defines.h
+++ b/src/libwbxml/wbxml_defines.h
@@ -1,0 +1,142 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml.h
+ * @ingroup wbxml
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/11/11
+ *
+ * @brief WBXML Library Main Header
+ */
+
+#ifndef WBXML_DEFINES_H
+#define WBXML_DEFINES_H
+
+#if defined( __SYMBIAN32__ )
+/* For basic Symbian Types */
+#include <e32def.h>
+#endif /* __SYMBIAN32__ */
+
+/*
+ * This sytem includes are here instead of the *.c files because
+ * we want them to be included AFTER 'e32def.h' on Symbian. If not so,
+ * a lot of Warnings are displayed ('NULL' : macro redefinition)
+ */
+#include <stdlib.h>
+#include <string.h>
+
+
+/** @addtogroup wbxml
+ *  @{ 
+ */
+
+/* WBXML Lib basic types redefinition */
+#define WB_BOOL unsigned char
+#define WB_UTINY unsigned char
+#define WB_TINY char
+#define WB_ULONG unsigned int
+#define WB_LONG int
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+/* Define NULL string */
+#define WBXML_UTINY_NULL_STRING ((WB_UTINY *)"")
+
+/* WBXML Lib string functions */
+#define WBXML_STRLEN(a) strlen((const WB_TINY*)a)
+#define WBXML_STRCMP(a,b) strcmp((const WB_TINY*)a,(const WB_TINY*)b)
+#define WBXML_STRNCMP(a,b,c) strncmp((const WB_TINY*)a,(const WB_TINY*)b,c)
+#define WBXML_STRSTR(a,b) strstr((const WB_TINY*)a,(const WB_TINY*)b)
+#if defined( WIN32 )
+#define WBXML_STRCASECMP(a,b) _stricmp((const WB_TINY*)a,(const WB_TINY*)b)
+#define WBXML_STRNCASECMP(a,b,c) _strnicmp((const WB_TINY*)a,(const WB_TINY*)b,c)
+#else
+#define WBXML_STRCASECMP(a,b) strcasecmp((const WB_TINY*)a,(const WB_TINY*)b)
+#define WBXML_STRNCASECMP(a,b,c) strncasecmp((const WB_TINY*)a,(const WB_TINY*)b,c)
+#endif /* WIN32 */
+
+#define WBXML_ISDIGIT(a) isdigit(a)
+
+/* For DLL exported functions */
+#if defined( __SYMBIAN32__ )
+#define WBXML_DECLARE(type) EXPORT_C type
+#define WBXML_DECLARE_NONSTD(type) EXPORT_C type
+#else  /* __SYMBIAN32__ */
+#if defined( WIN32 )
+#define WBXML_DECLARE(type) __declspec(dllexport) type __stdcall
+#define WBXML_DECLARE_NONSTD(type) __declspec(dllexport) type
+#else  /* WIN32 */
+#define WBXML_DECLARE(type) type
+#define WBXML_DECLARE_NONSTD(type) type
+#endif /* WIN32 */
+#endif /* __SYMBIAN32__ */
+
+#if __GNUC__ - 0 > 3 || (__GNUC__ - 0 == 3 && __GNUC_MINOR__ - 0 >= 2)
+  /* gcc >= 3.2 */
+# define LIBWBXML_DEPRECATED __attribute__ ((deprecated))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1300) && (_MSC_VER < 1400)
+  /* msvc >= 7 */
+# define LIBWBXML_DEPRECATED __declspec(deprecated)
+#elif defined(_MSV_VER) && (_MSC_VER >= 1400)
+  /* MS Visual Studio 2005 */
+# define LIBWBXML_DEPRECATED
+#else
+# define LIBWBXML_DEPRECATED
+#endif
+
+/** Backward compatibility flag */
+#define WBXML_BACKWARD_COMPAT
+
+#if defined( WBXML_BACKWARD_COMPAT )
+
+/* 0.9.2 */
+#define WBXML_ENCODER_XML_GEN_COMPACT   WBXML_GEN_XML_COMPACT
+#define WBXML_ENCODER_XML_GEN_INDENT    WBXML_GEN_XML_INDENT
+#define WBXML_ENCODER_XML_GEN_CANONICAL WBXML_GEN_XML_CANONICAL
+
+#define WBXMLEncoderXMLGenType   WBXMLGenXMLType     LIBWBXML_DEPRECATED
+#define WBXMLConvWBXML2XMLParams WBXMLGenXMLParams   LIBWBXML_DEPRECATED
+#define WBXMLConvXML2WBXMLParams WBXMLGenWBXMLParams LIBWBXML_DEPRECATED
+
+// #define WBXMLTag      WBXMLTagName
+// #define WBXMLTagEntry WBXMLTagNameEntry
+
+#endif /* WBXML_BACKWARD_COMPAT */
+
+/** @} */
+
+#endif /* WBXML_DEFINES_H */

--- a/src/libwbxml/wbxml_elt.c
+++ b/src/libwbxml/wbxml_elt.c
@@ -1,0 +1,332 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_elt.c
+ * @ingroup wbxml_elt
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/22
+ *
+ * @brief WBXML Elements
+ */
+
+#include "wbxml_elt.h"
+
+
+/** For an unknown XML Name */
+#define WBXML_ELT_UNKNOWN_NAME ((WB_UTINY *)"unknown")
+
+
+
+/***************************************************
+ *    Public Functions
+ */
+ 
+/* WBXMLTag */
+
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_create(WBXMLValueType type)
+{
+    WBXMLTag *result = NULL;
+    
+    if ((result = wbxml_malloc(sizeof(WBXMLTag))) == NULL)
+        return NULL;
+
+    result->type = type;
+    result->u.token = NULL;
+    result->u.literal = NULL;
+
+    return result;
+}
+
+
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_create_token(const WBXMLTagEntry *value)
+{
+    WBXMLTag *result = NULL;
+
+    if ((result = wbxml_tag_create(WBXML_VALUE_TOKEN)) == NULL)
+        return NULL;
+
+    result->u.token = value;
+
+    return result;
+}
+
+
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_create_literal(WB_UTINY *value)
+{
+    WBXMLTag *result = NULL;
+
+    if ((result = wbxml_tag_create(WBXML_VALUE_LITERAL)) == NULL)
+        return NULL;
+
+    if (value == NULL)
+        result->u.literal = NULL;
+    else {
+        result->u.literal = wbxml_buffer_create(value, WBXML_STRLEN(value), WBXML_STRLEN(value));
+        if (result->u.literal == NULL) {
+            wbxml_tag_destroy(result);
+            return NULL;
+        }
+    }
+
+    return result;
+}
+
+
+WBXML_DECLARE(void) wbxml_tag_destroy(WBXMLTag *tag)
+{
+    if (tag == NULL)
+        return;
+
+    if (tag->type == WBXML_VALUE_LITERAL)
+        wbxml_buffer_destroy(tag->u.literal);
+
+    wbxml_free(tag);
+}
+
+
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_duplicate(WBXMLTag *tag)
+{
+    WBXMLTag *result = NULL;
+
+    if (tag == NULL)
+        return NULL;
+
+    if ((result = wbxml_malloc(sizeof(WBXMLTag))) == NULL)
+        return NULL;
+
+    result->type = tag->type;
+
+    switch (result->type) {
+    case WBXML_VALUE_TOKEN:
+        result->u.token = tag->u.token;
+        break;
+    case WBXML_VALUE_LITERAL:
+        result->u.literal = wbxml_buffer_duplicate(tag->u.literal);
+        break;
+    default:
+        /* Must Never Happen ! */
+        wbxml_free(result);
+        return NULL;
+    }
+
+    return result;
+}
+
+
+WBXML_DECLARE(const WB_UTINY *) wbxml_tag_get_xml_name(WBXMLTag *tag)
+{
+    if (tag == NULL)
+        return WBXML_ELT_UNKNOWN_NAME;
+
+    switch (tag->type) {
+    case WBXML_VALUE_TOKEN:
+        return (const WB_UTINY *) tag->u.token->xmlName;
+        break;
+    case WBXML_VALUE_LITERAL:
+        return (const WB_UTINY *) wbxml_buffer_get_cstr(tag->u.literal);
+    default:
+        return WBXML_ELT_UNKNOWN_NAME;
+    }
+}
+
+
+/* WBXMLAttributeName */
+
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_create(WBXMLValueType type)
+{
+    WBXMLAttributeName *result = NULL;
+    
+    if ((result = wbxml_malloc(sizeof(WBXMLAttributeName))) == NULL)
+        return NULL;
+
+    result->type = type;
+    result->u.token = NULL;
+    result->u.literal = NULL;
+
+    return result;
+}
+
+
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_create_token(const WBXMLAttrEntry *value)
+{
+    WBXMLAttributeName *result = NULL;
+
+    if ((result = wbxml_attribute_name_create(WBXML_VALUE_TOKEN)) == NULL)
+        return NULL;
+
+    result->u.token = value;
+
+    return result;
+}
+
+
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_create_literal(WB_UTINY *value)
+{
+    WBXMLAttributeName *result = NULL;
+
+    if ((result = wbxml_attribute_name_create(WBXML_VALUE_LITERAL)) == NULL)
+        return NULL;
+
+    if (value == NULL)
+        result->u.literal = NULL;
+    else {
+        result->u.literal = wbxml_buffer_create(value, WBXML_STRLEN(value), WBXML_STRLEN(value));
+        if (result->u.literal == NULL) {
+            wbxml_attribute_name_destroy(result);
+            return NULL;
+        }
+    }
+
+    return result;
+}
+
+
+WBXML_DECLARE(void) wbxml_attribute_name_destroy(WBXMLAttributeName *name)
+{
+    if (name == NULL)
+        return;
+
+    if (name->type == WBXML_VALUE_LITERAL)
+        wbxml_buffer_destroy(name->u.literal);
+
+    wbxml_free(name);
+}
+
+
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_duplicate(WBXMLAttributeName *name)
+{
+    WBXMLAttributeName *result = NULL;
+
+    if (name == NULL)
+        return NULL;
+
+    if ((result = wbxml_malloc(sizeof(WBXMLAttributeName))) == NULL)
+        return NULL;
+
+    result->type = name->type;
+
+    switch (result->type) {
+    case WBXML_VALUE_TOKEN:
+        result->u.token = name->u.token;
+        break;
+    case WBXML_VALUE_LITERAL:
+        result->u.literal = wbxml_buffer_duplicate(name->u.literal);
+        break;
+    default:
+        /* Must Never Happen ! */
+        wbxml_free(result);
+        return NULL;
+    }
+
+    return result;
+}
+
+
+WBXML_DECLARE(const WB_UTINY *) wbxml_attribute_name_get_xml_name(WBXMLAttributeName *name)
+{
+    if (name == NULL)
+        return WBXML_ELT_UNKNOWN_NAME;
+
+    switch (name->type) {
+    case WBXML_VALUE_TOKEN:
+        return (const WB_UTINY *) name->u.token->xmlName;
+        break;
+    case WBXML_VALUE_LITERAL:
+        return (const WB_UTINY *) wbxml_buffer_get_cstr(name->u.literal);
+    default:
+        return WBXML_ELT_UNKNOWN_NAME;
+    }
+}
+
+
+/* WBXMLAttribute */
+
+WBXML_DECLARE(WBXMLAttribute *) wbxml_attribute_create(void)
+{
+    WBXMLAttribute *result = NULL;
+    
+    if ((result = wbxml_malloc(sizeof(WBXMLAttribute))) == NULL)
+        return NULL;
+
+    result->name = NULL;
+    result->value = NULL;
+
+    return result;
+}
+
+
+WBXML_DECLARE(void) wbxml_attribute_destroy(WBXMLAttribute *attr)
+{
+    if (attr == NULL)
+        return;
+
+    wbxml_attribute_name_destroy(attr->name);
+    wbxml_buffer_destroy(attr->value);     
+
+    wbxml_free(attr);
+}
+
+
+WBXML_DECLARE_NONSTD(void) wbxml_attribute_destroy_item(void *attr)
+{
+    wbxml_attribute_destroy((WBXMLAttribute *) attr);
+}
+
+
+WBXML_DECLARE(WBXMLAttribute *) wbxml_attribute_duplicate(WBXMLAttribute *attr)
+{
+    WBXMLAttribute *result = NULL;
+
+    if (attr == NULL)
+        return NULL;
+
+    if ((result = wbxml_malloc(sizeof(WBXMLAttribute))) == NULL)
+        return NULL;
+
+    result->name = wbxml_attribute_name_duplicate(attr->name);
+    result->value = wbxml_buffer_duplicate(attr->value);
+
+    return result;
+}
+
+
+WBXML_DECLARE(const WB_UTINY *) wbxml_attribute_get_xml_name(WBXMLAttribute *attr)
+{
+    if (attr == NULL)
+        return WBXML_ELT_UNKNOWN_NAME;
+
+    return wbxml_attribute_name_get_xml_name(attr->name);
+}
+
+
+WBXML_DECLARE(const WB_UTINY *) wbxml_attribute_get_xml_value(WBXMLAttribute *attr)
+{
+    if ((attr == NULL) || (attr->value == NULL))
+        return WBXML_UTINY_NULL_STRING;
+
+    return wbxml_buffer_get_cstr(attr->value);
+}

--- a/src/libwbxml/wbxml_elt.h
+++ b/src/libwbxml/wbxml_elt.h
@@ -1,0 +1,241 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_elt.h
+ * @ingroup wbxml_elt
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/22
+ *
+ * @brief WBXML Elements
+ */
+
+#ifndef WBXML_ELT_H
+#define WBXML_ELT_H
+
+#include "wbxml.h"
+#include "wbxml_buffers.h"
+#include "wbxml_tables.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_elt 
+ *  @{ 
+ */
+
+/**
+ * @brief WBXML Value Type
+ */
+typedef enum WBXMLValueType_e {
+    WBXML_VALUE_TOKEN = 0, /**< WBXML Token value */
+    WBXML_VALUE_LITERAL    /**< WBXML Literal value */
+} WBXMLValueType;
+
+
+/** @brief WBXML Tag structure */
+typedef struct WBXMLTag_s {
+    WBXMLValueType type;   /**< Tag Type (Token or Literal) */
+    union {
+        const WBXMLTagEntry *token;   /**< Token Tag (MUST be const structure, ie from wbxml_tables.c) */
+        WBXMLBuffer         *literal; /**< Literal Tag (MUST be dynamically allocated WBXMLBuffer) */
+    } u;
+} WBXMLTag;
+
+
+/** @brief WBXML Attribute Name structure */
+typedef struct WBXMLAttributeName_s {
+    WBXMLValueType type;   /**< Attribute Name Type (Token or Literal) */
+    union {
+        const WBXMLAttrEntry *token;   /**< Token Attribute Name (MUST be const structure, ie from wbxml_tables.c) */
+        WBXMLBuffer          *literal; /**< Literal Attribute Name (MUST be dynamically allocated WBXMLBuffer) */
+    } u;
+} WBXMLAttributeName;
+
+
+/** 
+ * @brief WBXML Attribute structure 
+ * @note The 'value' part contain the FULL attribute value
+ *  For example, with the attribute: url="http://127.0.0.1/"
+ *  If the 'name' part is this:
+ *      - name->u.token->wbxmlCodePage: 0x00
+ *      - name->u.token->wbxmlToken : 0x4b
+ *      - name->u.token->xmlName : "url"
+ *      - name->u.token->xmlValue: "http://"
+ *
+ *  Then, 'value' is still: "http://127.0.0.1/"
+ *
+ *  Of course (in this example) it should be better to have the wbxmlToken 0x4a ("url" / NULL). So you mustn't take into
+ *  account the 'xmlValue' field for 'name' to get the Attribute Value of this Attribute.
+ */
+typedef struct WBXMLAttribute_s {
+    WBXMLAttributeName *name;  /**< Attribute Name */
+    WBXMLBuffer        *value; /**< Full Attribute Value */
+} WBXMLAttribute;
+
+
+/****************************************************
+ *    WBXML Elt Functions
+ */
+
+/* WBXMLTag */
+
+/**
+ * @brief Create a Tag structure
+ * @param type WBXML Value Type
+ * @return The newly created Tag, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_create(WBXMLValueType type);
+
+/**
+ * @brief Additional function to create directly a Token Tag structure
+ * @param value The WBXMLTagEntry value
+ * @return The newly created Tag, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_create_token(const WBXMLTagEntry *value);
+
+/**
+ * @brief Additional function to create directly a Literal Tag structure
+ * @param value The Literal value
+ * @return The newly created Tag, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_create_literal(WB_UTINY *value);
+
+/**
+ * @brief Destroy a Tag structure
+ * @param tag The Tag structure to destroy
+ */
+WBXML_DECLARE(void) wbxml_tag_destroy(WBXMLTag *tag);
+
+/**
+ * @brief Duplicate a Tag structure
+ * @param tag The Tag structure to duplicate
+ * @return The duplicated Tag structure, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTag *) wbxml_tag_duplicate(WBXMLTag *tag);
+
+/**
+ * @brief Get the XML Name of a WBXML Tag
+ * @param tag The WBXML Tag
+ * @return The XML Name, or "unknown" if not found
+ */
+WBXML_DECLARE(const WB_UTINY *) wbxml_tag_get_xml_name(WBXMLTag *tag);
+
+
+/* WBXMLAttributeName */
+
+/**
+ * @brief Create an Attribute Name structure
+ * @param type WBXML Value Type
+ * @return The newly created Attribute Name, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_create(WBXMLValueType type);
+
+/**
+ * @brief Additional function to create directly a Token Attribute Name structure
+ * @param value The WBXMLTagEntry value
+ * @return The newly created Attribute Name, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_create_token(const WBXMLAttrEntry *value);
+
+/**
+ * @brief Additional function to create directly a Literal Attribute Name structure
+ * @param value The Literal value
+ * @return The newly created Attribute Name, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_create_literal(WB_UTINY *value);
+
+/**
+ * @brief Destroy an Attribute Name structure
+ * @param name The Attribute Name structure to destroy
+ */
+WBXML_DECLARE(void) wbxml_attribute_name_destroy(WBXMLAttributeName *name);
+
+/**
+ * @brief Duplicate a Attribute Name structure
+ * @param name The Attribute Name structure to duplicate
+ * @return The duplicated Attribute Name structure, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLAttributeName *) wbxml_attribute_name_duplicate(WBXMLAttributeName *name);
+
+/**
+ * @brief Get the XML Name of a WBXML Attribute Name
+ * @param name The WBXML Attribute Name
+ * @return The XML Name, or "unknown" if not found
+ */
+WBXML_DECLARE(const WB_UTINY *) wbxml_attribute_name_get_xml_name(WBXMLAttributeName *name);
+
+
+/* WBXMLAttribute */
+
+/**
+ * @brief Create an Attribute structure
+ * @return The newly created Attribute, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLAttribute *) wbxml_attribute_create(void);
+
+/**
+ * @brief Destroy an Attribute structure
+ * @param attr The Attribute structure to destroy
+ */
+WBXML_DECLARE(void) wbxml_attribute_destroy(WBXMLAttribute *attr);
+
+/**
+ * @brief Destroy an Attribute structure (used for wbxml_list_destroy())
+ * @param attr The Attribute structure to destroy
+ */
+WBXML_DECLARE_NONSTD(void) wbxml_attribute_destroy_item(void *attr);
+
+/**
+ * @brief Duplicate an Attribute structure
+ * @param attr The Attribute structure to duplicate
+ * @return The duplicated Attribute, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLAttribute *) wbxml_attribute_duplicate(WBXMLAttribute *attr);
+
+/**
+ * @brief Get the XML Attribute Name of a WBXML Attribute
+ * @param attr The WBXML Attribute
+ * @return The XML Attribute Name, or "unknown" if not found
+ */
+WBXML_DECLARE(const WB_UTINY *) wbxml_attribute_get_xml_name(WBXMLAttribute *attr);
+
+/**
+ * @brief Get the XML Attribute Value of a WBXML Attribute
+ * @param attr The WBXML Attribute
+ * @return The XML Attribute Value, or "" if none
+ */
+WBXML_DECLARE(const WB_UTINY *) wbxml_attribute_get_xml_value(WBXMLAttribute *attr);
+
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_ELT_H */

--- a/src/libwbxml/wbxml_encoder.c
+++ b/src/libwbxml/wbxml_encoder.c
@@ -1,0 +1,4695 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2008-2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+
+/**
+ * @file wbxml_encoder.c
+ * @ingroup wbxml_encoder
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 11/11/02
+ *
+ * @brief WBXML Encoder - Encodes a WBXML Tree to WBXML or to XML
+ *
+ * @note Inspired from kannel WML Encoder (http://www.kannel.org)
+ *
+ * @note [OMA WV 1.1] : OMA-WV-CSP_WBXML-V1_1-20021001-A.pdf
+ *
+ * @todo Parse CDDATA
+ * @todo Parse PI
+ * @todo Handle Charsets Encoding
+ * @todo Really generate ENTITY tokens
+ * @todo Handle Namespaces !
+ * @todo For canonical XML output: Sort the Attributes
+ * @todo When adding string to String Table, check that this is not a Content Text that will be tokenized
+ * @todo For Wireless-Village CSP :
+ *              - Encode "Date and Time" in OPAQUE (OMA-WV-CSP_WBXML-V1_1-20021001-A.pdf - 6.6)
+ *
+ * @todo Review the canonical XML generation:
+ *       - http://www.jclark.com/xml/canonxml.html
+*        - http://www.w3.org/TR/2004/REC-xml-20040204/
+ */
+
+#include <ctype.h> /* For isdigit() */
+
+#include "wbxml_encoder.h"
+#include "wbxml_log.h"
+#include "wbxml_internals.h"
+#include "wbxml_base64.h"
+
+
+/**
+ * Compilation Flag: WBXML_ENCODER_USE_STRTBL
+ * -----------------
+ * Do We Use String Table when Encoding to WBXML ?
+ * (NOTE: We still use String Table for Unknown Public ID, even if this flag is not set)
+ */
+
+/* WBXML Header:    version     publicid    charset     length
+ *                  u_int8      mb_u_int32  mb_u_int32  mb_u_int32
+ *                  1 octet     5 octets    5 octets    5 octets   :  16 octets
+ * mb_u_int32: 5 octets (to handle continuation bits)
+ */
+#define WBXML_HEADER_MAX_LEN 16
+
+/* Memory management related defines */
+#define WBXML_ENCODER_XML_DOC_MALLOC_BLOCK 5000
+#define WBXML_ENCODER_WBXML_DOC_MALLOC_BLOCK 1000
+
+#define WBXML_ENCODER_XML_HEADER_MALLOC_BLOCK 250
+#define WBXML_ENCODER_WBXML_HEADER_MALLOC_BLOCK WBXML_HEADER_MAX_LEN
+
+/* WBXML Default Charset: UTF-8 (106) */
+#define WBXML_ENCODER_DEFAULT_CHARSET 0x6a
+
+/* String Terminating NULL Char */
+#define WBXML_STR_END '\0'
+
+/* Minimum String Size needed for String Table - @note Set to '3' for Prov 1.0 */
+#define WBXML_ENCODER_STRING_TABLE_MIN 3
+
+/**
+ * Default charset of the outputed WBXML document. Used only in this case :
+ *  - No charset was indicated thanks to the function 'wbxml_encoder_set_output_charset()'
+ *  - and the WBXML Tree field 'orig_charset' is set to WBXML_CHARSET_UNKNOWN (ie. charset
+ *    information not found in original document)
+ */
+#define WBXML_ENCODER_WBXML_DEFAULT_CHARSET WBXML_CHARSET_UTF_8
+
+/**
+ * Default charset of the outputed XML document. Used only in this case :
+ *  - No charset was indicated thanks to the function 'wbxml_encoder_set_output_charset()'
+ *  - and the WBXML Tree field 'orig_charset' is set to WBXML_CHARSET_UNKNOWN (ie. charset
+ *    information not found in original document)
+ */
+#define WBXML_ENCODER_XML_DEFAULT_CHARSET WBXML_CHARSET_UTF_8
+
+/**
+ * If defined, generate empty XML elements (eg: &lt;foo /&gt;), else generate
+ * full "end element" (eg: &lt;foo&gt;&lt;/foo&gt;)
+ *
+ * @todo This must be a 'WBXMLGenXMLParams' parameter
+ */
+#define WBXML_ENCODER_XML_GEN_EMPTY_ELT
+
+/**
+ * If defined, do not indent elements that have no element child (eg: &lt;foo&gt;bar&lt;/foo&gt;),
+ * else indent anyway (eg: &lt;foo&gt;
+ *                           bar
+ *                         &lt;/foo&gt;)
+ *
+ * @todo This must be a 'WBXMLGenXMLParams' parameter
+ */
+#define WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT
+
+
+/**
+ * @warning For now 'current_tag' field is only used for WV Content Encoding. And for this use, it works.
+ *          But this field is reset after End Tag, and as there is no Linked List mecanism, this is bad for
+ *          cascading elements: we don't fill this field with parent Tag when parsing End Tag.
+ *
+ * @warning For now 'current_text_parent' field is only used for DRM REL Content Encoding. It should not be
+ *          used for another purpose.
+ *
+ * @warning For now 'current_node' field is a hack. It is reset after End Tag, and as there is no Linked List
+ *          mecanism, this is bad for cascading elements: we don't fill this field with parent Tag
+ *          when parsing End Tag.
+ */
+struct WBXMLEncoder_s {
+    WBXMLTree *tree;                        /**< WBXML Tree to Encode */
+    const WBXMLLangEntry *lang;             /**< Language table to use */
+    WBXMLBuffer *output;                    /**< The output (wbxml or xml) we are producing */
+    WBXMLBuffer *output_header;             /**< The output header (used if Flow Mode encoding is activated) */
+    const WBXMLTagEntry *current_tag;       /**< Current Tag (See The Warning For This Field !) */
+    const WBXMLTreeNode *current_text_parent; /**< Text parent of current Node (See The Warning For This Field !) */
+    const WBXMLAttrEntry *current_attr;     /**< Current Attribute */
+    WBXMLTreeNode *current_node;            /**< Current Node (See The Warning For This Field !) */
+    WB_UTINY tagCodePage;                   /**< Current Tag Code Page */
+    WB_UTINY attrCodePage;                  /**< Current Attribute Code Page */
+    WB_BOOL ignore_empty_text;              /**< Do we ignore empty text nodes (ie: ignorable whitespaces)? */
+    WB_BOOL remove_text_blanks;             /**< Do we remove leading and trailing blanks in text nodes ? */
+    WBXMLEncoderOutputType output_type;     /**< Output Type */
+    WBXMLGenXMLType xml_gen_type;           /**< XML Generation Type */
+    WB_UTINY indent_delta;                  /**< Indent Delta (number of spaces) */
+    WB_UTINY indent;                        /**< Current Indent */
+    WB_BOOL in_content;                     /**< We are in Content Text (used for indentation when generating XML output) */
+    WB_BOOL in_cdata;                       /**< We are in a CDATA section (and so, content must be generaed "as is") */
+    WBXMLBuffer *cdata;                     /**< Current CDATA Buffer */
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    WBXMLList *strstbl;                     /**< String Table we are creating */
+    WB_ULONG strstbl_len;                   /**< String Table Length */
+    WB_BOOL use_strtbl;                     /**< Do we use String Table when generating WBXML output ? (default: YES) */
+#endif /* WBXML_ENCODER_USE_STRTBL */
+    WB_BOOL xml_encode_header;              /**< Do we generate XML Header ? */
+    WB_BOOL produce_anonymous;              /**< Do we produce anonymous documents? (default: NO) */
+    WBXMLVersion wbxml_version;             /**< WBXML Version to use (when generating WBXML output) */
+    WBXMLCharsetMIBEnum output_charset;     /**< Output charset encoding */
+    WB_BOOL flow_mode;                      /**< Is Flow Mode encoding activated ? */
+    WB_ULONG pre_last_node_len;             /**< Output buffer length before last node encoding */
+    WB_BOOL textual_publicid;               /**< Generate textual Public ID instead of token (when generating WBXML output) */
+};
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+/**
+ * @brief The WBXML String Table Element
+ */
+typedef struct WBXMLStringTableElement_t {
+    WBXMLBuffer *string; /**< String */
+    WB_ULONG offset;     /**< Offset of String in String Table */
+    WB_ULONG count;      /**< Number of times this String is referenced in the XML Document */
+    WB_BOOL stat;        /**< If set to TRUE, this is a static String that we must not destroy in wbxml_strtbl_element_destroy() function */
+} WBXMLStringTableElement;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+/**
+ * @brief WBXML Value Element Context: In Content or in Attribute Value
+ */
+typedef enum WBXMLValueElementCtx_e {
+    WBXML_VALUE_ELEMENT_CTX_CONTENT = 0,    /**< Text Content */
+    WBXML_VALUE_ELEMENT_CTX_ATTR            /**< Attribute Value */
+} WBXMLValueElementCtx;
+
+/**
+ * @brief WBXML Value Element Type: string / tableref / extension / opaque
+ */
+typedef enum WBXMLValueElementType_e {
+    WBXML_VALUE_ELEMENT_STRING = 0, /**< Inline String */
+    WBXML_VALUE_ELEMENT_EXTENSION,  /**< Extension Token */
+    WBXML_VALUE_ELEMENT_OPAQUE,     /**< Opaque Buffer */
+    WBXML_VALUE_ELEMENT_ATTR_TOKEN /**< Attribute Value Token */
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    , WBXML_VALUE_ELEMENT_TABLEREF   /**< String Table Reference */
+#endif /* WBXML_ENCODER_USE_STRTBL */
+} WBXMLValueElementType;
+
+/**
+ * @brief WBXML Value Element Structure
+ */
+typedef struct WBXMLValueElement_t {
+    WBXMLValueElementType type;     /**< Cf WBXMLValueElementType enum */
+    union {
+        WBXMLBuffer *str;                   /**< WBXML_VALUE_ELEMENT_STRING */
+        const WBXMLExtValueEntry *ext;      /**< WBXML_VALUE_ELEMENT_EXTENSION */
+        WBXMLBuffer *buff;                  /**< WBXML_VALUE_ELEMENT_OPAQUE */
+        const WBXMLAttrValueEntry *attr;    /**< WBXML_VALUE_ELEMENT_ATTR_TOKEN */
+#if defined( WBXML_ENCODER_USE_STRTBL )
+        WB_ULONG    index;                  /**< WBXML_VALUE_ELEMENT_TABLEREF */
+#endif /* WBXML_ENCODER_USE_STRTBL */
+    } u;
+} WBXMLValueElement;
+
+
+/***************************************************
+ *    Private Functions prototypes
+ */
+
+/*******************************
+ * Common Functions
+ */
+
+#if 0
+static WB_BOOL convert_char_to_ucs4(WB_UTINY ch, WB_ULONG *result);
+#endif /* 0 */
+
+static WBXMLEncoder *encoder_duplicate(WBXMLEncoder *encoder);
+static WBXMLError encoder_encode_tree(WBXMLEncoder *encoder);
+static WB_BOOL encoder_init_output(WBXMLEncoder *encoder);
+
+
+/*******************************
+ * WBXML Tree Parsing Functions
+ */
+
+static WBXMLError parse_node(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL enc_end);
+static WBXMLError parse_element(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content);
+static WBXMLError parse_element_end(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content);
+static WBXMLError parse_attribute(WBXMLEncoder *encoder, WBXMLAttribute *attribute);
+static WBXMLError parse_text(WBXMLEncoder *encoder, WBXMLTreeNode *node);
+static WBXMLError parse_cdata(WBXMLEncoder *encoder);
+static WBXMLError parse_pi(WBXMLEncoder *encoder, WBXMLTreeNode *node);
+static WBXMLError parse_tree(WBXMLEncoder *encoder, WBXMLTreeNode *node);
+
+
+/*******************************
+ * WBXML Output Functions
+ */
+
+/* Build WBXML Result */
+static WBXMLError wbxml_build_result(WBXMLEncoder *encoder, WB_UTINY **wbxml, WB_ULONG *wbxml_len);
+static WBXMLError wbxml_fill_header(WBXMLEncoder *encoder, WBXMLBuffer *header);
+
+/* WBXML Encoding Functions */
+static WBXMLError wbxml_encode_end(WBXMLEncoder *encoder);
+
+static WBXMLError wbxml_encode_tag(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content);
+static WBXMLError wbxml_encode_tag_literal(WBXMLEncoder *encoder, const WB_UTINY *tag, WB_UTINY mask);
+static WBXMLError wbxml_encode_tag_token(WBXMLEncoder *encoder, WB_UTINY token, WB_UTINY page);
+
+static WBXMLError wbxml_encode_attr(WBXMLEncoder *encoder, WBXMLAttribute *attribute);
+static WBXMLError wbxml_encode_attr_start(WBXMLEncoder *encoder, WBXMLAttribute *attribute, WB_UTINY **value);
+static WBXMLError wbxml_encode_value_element_buffer(WBXMLEncoder *encoder, WB_UTINY *value, WBXMLValueElementCtx ctx);
+static WBXMLError wbxml_encode_value_element_list(WBXMLEncoder *encoder, WBXMLList *list);
+static WBXMLError wbxml_encode_attr_start_literal(WBXMLEncoder *encoder, const WB_UTINY *attr);
+static WBXMLError wbxml_encode_attr_token(WBXMLEncoder *encoder, WB_UTINY token, WB_UTINY page);
+
+static WBXMLError wbxml_encode_inline_string(WBXMLEncoder *encoder, WBXMLBuffer *str);
+static WBXMLError wbxml_encode_inline_integer_extension_token(WBXMLEncoder *encoder, WB_UTINY ext, WB_UTINY value);
+#if 0
+static WBXMLError wbxml_encode_entity(WBXMLEncoder *encoder, WB_ULONG value);
+#endif /* 0 */
+static WBXMLError wbxml_encode_opaque(WBXMLEncoder *encoder, WBXMLBuffer *buff);
+static WBXMLError wbxml_encode_opaque_data(WBXMLEncoder *encoder, WB_UTINY *data, WB_ULONG data_len);
+#if defined( WBXML_ENCODER_USE_STRTBL )
+static WBXMLError wbxml_encode_tableref(WBXMLEncoder *encoder, WB_ULONG offset);
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+static WBXMLValueElement *wbxml_value_element_create(void);
+static void wbxml_value_element_destroy(WBXMLValueElement *elt);
+static void wbxml_value_element_destroy_item(void *elt);
+
+static WBXMLError wbxml_encode_tree(WBXMLEncoder *encoder, WBXMLTree *tree);
+
+#if ( defined( WBXML_SUPPORT_SI ) || defined( WBXML_SUPPORT_EMN ) )
+static WBXMLError wbxml_encode_datetime(WBXMLEncoder *encoder, WB_UTINY *buffer);
+#endif /* WBXML_SUPPORT_SI || WBXML_SUPPORT_EMN */
+
+#if defined( WBXML_SUPPORT_WV )
+static WBXMLError wbxml_encode_wv_content(WBXMLEncoder *encoder, WB_UTINY *buffer);
+static WBXMLError wbxml_encode_wv_integer(WBXMLEncoder *encoder, WB_UTINY *buffer);
+static WBXMLError wbxml_encode_wv_datetime(WBXMLEncoder *encoder, WB_UTINY *buffer);
+#endif /* WBXML_SUPPORT_WV */
+
+#if defined( WBXML_SUPPORT_DRMREL )
+static WBXMLError wbxml_encode_drmrel_content(WBXMLEncoder *encoder, WB_UTINY *buffer);
+#endif /* WBXML_SUPPORT_DRMREL */
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS ) 
+static WBXMLError wbxml_encode_ota_nokia_icon(WBXMLEncoder *encoder, WB_UTINY *buffer);
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+/* WBXML String Table Functions */
+static WBXMLStringTableElement *wbxml_strtbl_element_create(WBXMLBuffer *string, WB_BOOL is_stat);
+static void wbxml_strtbl_element_destroy(WBXMLStringTableElement *element);
+static void wbxml_strtbl_element_destroy_item(void *element);
+
+static WBXMLError wbxml_strtbl_initialize(WBXMLEncoder *encoder, WBXMLTreeNode *root);
+static void wbxml_strtbl_collect_strings(WBXMLEncoder *encoder, WBXMLTreeNode *node, WBXMLList *strings);
+static WBXMLError wbxml_strtbl_collect_words(WBXMLList *elements, WBXMLList **result);
+static WBXMLError wbxml_strtbl_construct(WBXMLBuffer *buff, WBXMLList *strstbl);
+static WBXMLError wbxml_strtbl_check_references(WBXMLEncoder *encoder, WBXMLList **strings, WBXMLList **one_ref, WB_BOOL stat_buff);
+static WB_BOOL wbxml_strtbl_add_element(WBXMLEncoder *encoder, WBXMLStringTableElement *elt, WB_ULONG *index, WB_BOOL *added);
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+
+/*******************************
+ * XML Output Functions
+ */
+
+/** New Line */
+#define WBXML_ENCODER_XML_NEW_LINE ((WB_UTINY *)"\n")
+
+/* XML Header Macros */
+#define WBXML_ENCODER_XML_HEADER "<?xml version=\"1.0\"?>"
+#define WBXML_ENCODER_XML_DOCTYPE "<!DOCTYPE "
+#define WBXML_ENCODER_XML_PUBLIC_START " PUBLIC \""
+#define WBXML_ENCODER_XML_PUBLIC_END "\""
+#define WBXML_ENCODER_XML_SYSTEM " SYSTEM"
+#define WBXML_ENCODER_XML_DTD " \""
+#define WBXML_ENCODER_XML_END_DTD "\">"
+
+/* Global vars for XML Normalization */
+const WB_UTINY xml_lt[5]     = "&lt;";   /**< &lt; */
+const WB_UTINY xml_gt[5]     = "&gt;";   /**< &gt; */
+const WB_UTINY xml_amp[6]    = "&amp;";  /**< &amp; */
+const WB_UTINY xml_quot[7]   = "&quot;"; /**< &quot; */
+const WB_UTINY xml_apos[7]   = "&apos;"; /**< &apos; */
+const WB_UTINY xml_slashr[6] = "&#13;";  /**< &#13; */
+const WB_UTINY xml_slashn[6] = "&#10;";  /**< &#10; */
+const WB_UTINY xml_tab[5]    = "&#9;";   /**< &#9; */
+
+/* Build XML Result */
+static WBXMLError xml_build_result(WBXMLEncoder *encoder, WB_UTINY **xml, WB_ULONG *xml_len);
+static WBXMLError xml_fill_header(WBXMLEncoder *encoder, WBXMLBuffer *header);
+
+/* XML Encoding Functions */
+static WBXMLError xml_encode_tag(WBXMLEncoder *encoer, WBXMLTreeNode *node);
+static WBXMLError xml_encode_end_tag(WBXMLEncoder *encoder, WBXMLTreeNode *node);
+
+static WBXMLError xml_encode_attr(WBXMLEncoder *encoder, WBXMLAttribute *attribute);
+static WBXMLError xml_encode_end_attrs(WBXMLEncoder *encoder, WBXMLTreeNode *node);
+
+static WBXMLError xml_encode_text(WBXMLEncoder *encoder, WBXMLTreeNode *node);
+static WBXMLError xml_encode_text_entities(WBXMLEncoder *encoder, WBXMLBuffer *buff);
+static WB_BOOL xml_encode_new_line(WBXMLBuffer *buff);
+
+static WBXMLError xml_encode_cdata(WBXMLEncoder *encoder);
+static WBXMLError xml_encode_end_cdata(WBXMLEncoder *encoder);
+
+static WBXMLError xml_encode_tree(WBXMLEncoder *encoder, WBXMLTree *tree);
+
+
+/***************************************************
+ *    Public Functions
+ */
+
+WBXML_DECLARE(WBXMLEncoder *) wbxml_encoder_create_real(void)
+{
+    WBXMLEncoder *encoder = NULL;
+
+    encoder = wbxml_malloc(sizeof(WBXMLEncoder));
+    if (encoder == NULL) {
+        return NULL;
+    }
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    if ((encoder->strstbl = wbxml_list_create()) == NULL) {
+        wbxml_free(encoder);
+        return NULL;
+    }
+    encoder->use_strtbl = TRUE;
+    encoder->strstbl_len = 0;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    encoder->tree = NULL;
+    encoder->lang = NULL;
+    encoder->output = NULL;
+    encoder->output_header = NULL;
+
+    encoder->current_tag = NULL;
+    encoder->current_text_parent = NULL;
+    encoder->current_attr = NULL;
+    encoder->current_node = NULL;
+
+    encoder->tagCodePage = 0;
+    encoder->attrCodePage = 0;
+
+    encoder->ignore_empty_text = FALSE;
+    encoder->remove_text_blanks = FALSE;
+
+    encoder->output_type = WBXML_ENCODER_OUTPUT_WBXML;
+    encoder->xml_gen_type = WBXML_GEN_XML_COMPACT;
+
+    encoder->indent_delta = 1;
+    encoder->indent = 0;
+    encoder->in_content = FALSE;
+    encoder->in_cdata = FALSE;
+    encoder->cdata = NULL;
+
+    encoder->xml_encode_header = TRUE;
+    encoder->produce_anonymous = FALSE;
+
+    /* Default Version: WBXML 1.3 */
+    encoder->wbxml_version = WBXML_VERSION_13;
+
+    /**
+     * Default Output Charset Encoding is the one found in WBXML Tree,
+     * so set it as 'unknown' for now.
+     */
+    encoder->output_charset = WBXML_CHARSET_UNKNOWN;
+    
+    encoder->flow_mode = FALSE;
+    encoder->pre_last_node_len = 0;
+    encoder->textual_publicid = FALSE;
+
+    return encoder;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_destroy(WBXMLEncoder *encoder)
+{
+    if (encoder == NULL)
+        return;
+
+    wbxml_buffer_destroy(encoder->output);
+    wbxml_buffer_destroy(encoder->output_header);
+    wbxml_buffer_destroy(encoder->cdata);
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    wbxml_list_destroy(encoder->strstbl, wbxml_strtbl_element_destroy_item);
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    wbxml_free(encoder);
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_reset(WBXMLEncoder *encoder)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->tree = NULL;
+
+    wbxml_buffer_destroy(encoder->output);
+    encoder->output = NULL;
+    
+    wbxml_buffer_destroy(encoder->output_header);
+    encoder->output_header = NULL;
+    
+    encoder->current_tag = NULL;
+    encoder->current_attr = NULL;
+    encoder->current_node = NULL;
+    
+    encoder->tagCodePage = 0;
+    encoder->attrCodePage = 0;
+    
+    encoder->in_content = FALSE;
+    encoder->in_cdata = FALSE;
+    
+    wbxml_buffer_destroy(encoder->cdata);
+    encoder->cdata = NULL;
+    
+    encoder->pre_last_node_len = 0;
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    wbxml_list_destroy(encoder->strstbl, wbxml_strtbl_element_destroy_item);
+    encoder->strstbl = NULL;
+    encoder->strstbl_len = 0;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_ignore_empty_text(WBXMLEncoder *encoder, WB_BOOL set_ignore)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->ignore_empty_text = set_ignore;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_remove_text_blanks(WBXMLEncoder *encoder, WB_BOOL set_remove)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->remove_text_blanks = set_remove;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_output_charset(WBXMLEncoder *encoder, WBXMLCharsetMIBEnum charset)
+{
+  if (encoder == NULL)
+    return;
+
+  /* Tell which Output Charset Encoding to use (this overides the Charset Encoding found in WBXML Tree) */
+  encoder->output_charset = charset;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_use_strtbl(WBXMLEncoder *encoder, WB_BOOL use_strtbl)
+{
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    if (encoder == NULL)
+        return;
+
+    encoder->use_strtbl = use_strtbl;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_produce_anonymous(WBXMLEncoder *encoder, WB_BOOL set_anonymous)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->produce_anonymous = set_anonymous;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_wbxml_version(WBXMLEncoder *encoder, WBXMLVersion version)
+{
+    if (encoder == NULL)
+        return;
+
+    if (version != WBXML_VERSION_UNKNOWN)
+        encoder->wbxml_version = version;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_xml_gen_type(WBXMLEncoder *encoder, WBXMLGenXMLType gen_type)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->xml_gen_type = gen_type;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_indent(WBXMLEncoder *encoder, WB_UTINY indent)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->indent_delta = indent;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_tree(WBXMLEncoder *encoder, WBXMLTree *tree)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->tree = tree;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_tree_to_wbxml(WBXMLEncoder *encoder, WB_UTINY **wbxml, WB_ULONG *wbxml_len)
+{
+    WBXMLError ret = WBXML_OK;
+
+    /* Check Parameters */
+    if (encoder == NULL)
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    /* Init ret values */
+    *wbxml = NULL;
+    *wbxml_len = 0;
+
+    /* We output WBXML */
+    wbxml_encoder_set_output_type(encoder, WBXML_ENCODER_OUTPUT_WBXML);
+
+    /* Encode */
+    if ((ret = encoder_encode_tree(encoder)) != WBXML_OK)
+        return ret;
+
+    /* Get result */
+    return wbxml_encoder_get_output(encoder, wbxml, wbxml_len);
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_tree_to_xml(WBXMLEncoder *encoder, WB_UTINY **xml, WB_ULONG *xml_len)
+{
+    WBXMLError ret = WBXML_OK;
+
+    /* Check Parameters */
+    if (encoder == NULL)
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    /* Init ret values */
+    *xml = NULL;
+    *xml_len = 0;
+
+    /* We output WBXML */
+    wbxml_encoder_set_output_type(encoder, WBXML_ENCODER_OUTPUT_XML);
+
+    /* Encode */
+    if ((ret = encoder_encode_tree(encoder)) != WBXML_OK)
+        return ret;
+
+    /* Get result */
+    return wbxml_encoder_get_output(encoder, xml, xml_len);
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_set_flow_mode(WBXMLEncoder *encoder, WB_BOOL flow_mode)
+{
+    if (encoder == NULL)
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    encoder->flow_mode = flow_mode;
+    
+    /* The string tables must only be disabled during flow mode. */
+    if (flow_mode)
+    {
+        /* Don't use String Tables */
+        wbxml_encoder_set_use_strtbl(encoder, FALSE);
+    }
+    
+    return WBXML_OK;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_output_type(WBXMLEncoder *encoder, WBXMLEncoderOutputType output_type)
+{
+    if (encoder == NULL)
+        return;
+    
+    encoder->output_type = output_type;
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_lang(WBXMLEncoder *encoder, WBXMLLanguage lang)
+{
+    if (encoder == NULL)
+        return;
+
+    encoder->lang = wbxml_tables_get_table(lang);
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_set_text_public_id(WBXMLEncoder *encoder, WB_BOOL gen_text)
+{
+    if (encoder == NULL)
+        return;
+    
+    encoder->textual_publicid = gen_text;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_node(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+    if (encoder->flow_mode == FALSE) {
+        WBXML_WARNING((WBXML_ENCODER, "You should NOT call wbxml_encoder_encode_node() if you are not in Flow Mode encoding ! (use wbxml_encoder_set_flow_mode(encoder, TRUE))"));
+    }
+
+    return wbxml_encoder_encode_node_with_elt_end(encoder, node, TRUE);
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_node_with_elt_end(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL enc_end)
+{
+    WB_ULONG   prev_len = 0;
+    WBXMLError ret      = WBXML_OK;
+    
+    if ((encoder == NULL) || (node == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    /* Check that language table has been set */
+    if (encoder->lang == NULL)
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    /* Init Output Buffer if needed */
+    if (!encoder_init_output(encoder))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    
+    /* Backup length */
+    prev_len = wbxml_buffer_len(encoder->output);
+    
+    /* Check if result header is not already built */
+    if ((encoder->flow_mode == TRUE) && (encoder->output_header == NULL) &&
+        !((encoder->xml_encode_header == FALSE) && (encoder->output_type == WBXML_ENCODER_OUTPUT_XML)))
+    {
+        /* Build result header */
+        switch (encoder->output_type) {
+        case WBXML_ENCODER_OUTPUT_XML:
+            if ((encoder->output_header = wbxml_buffer_create("", 0, WBXML_ENCODER_XML_HEADER_MALLOC_BLOCK)) == NULL)
+                ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            else
+                ret = xml_fill_header(encoder, encoder->output_header);
+            break;
+            
+        case WBXML_ENCODER_OUTPUT_WBXML:
+            if ((encoder->output_header = wbxml_buffer_create("", 0, WBXML_ENCODER_WBXML_HEADER_MALLOC_BLOCK)) == NULL)
+                ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            else
+                ret = wbxml_fill_header(encoder, encoder->output_header);
+            break;
+            
+        default:
+            ret = WBXML_ERROR_BAD_PARAMETER;
+            break;
+        }
+    }
+    
+    if (ret != WBXML_OK)
+        return ret;
+    
+    if ((ret = parse_node(encoder, node, enc_end)) == WBXML_OK)
+        encoder->pre_last_node_len = prev_len;
+    
+    return ret;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_tree(WBXMLEncoder *encoder, WBXMLTree *tree)
+{
+    const WBXMLLangEntry *lang = NULL;
+    WBXMLError            ret  = WBXML_OK;
+    
+    if ((encoder == NULL) || (tree == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    /* Backup encoder lang */
+    lang = encoder->lang;
+    
+    /* Set Tree lang to encoder */
+    encoder->lang = tree->lang;
+    
+    /* Encode root node */
+    ret = wbxml_encoder_encode_node(encoder, tree->root);
+    
+    /* Revert encoder lang */
+    encoder->lang = lang;
+    
+    return ret;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_raw_elt_start(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content)
+{
+    /* Init Output Buffer if needed */
+    if (!encoder_init_output(encoder))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    
+    return parse_element(encoder, node, has_content);
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_raw_elt_end(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content)
+{
+    /* Init Output Buffer if needed */
+    if (!encoder_init_output(encoder))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    
+    return parse_element_end(encoder, node, has_content);
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_encoder_get_output(WBXMLEncoder *encoder, WB_UTINY **result, WB_ULONG *result_len)
+{
+    if ((encoder == NULL) || (result == NULL) || (result_len == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    switch (encoder->output_type) {
+    case WBXML_ENCODER_OUTPUT_XML:
+        return xml_build_result(encoder, result, result_len);
+        
+    case WBXML_ENCODER_OUTPUT_WBXML:
+        return wbxml_build_result(encoder, result, result_len);
+        
+    default:
+        return WBXML_ERROR_BAD_PARAMETER;
+    }
+}
+
+
+WBXML_DECLARE(WB_ULONG) wbxml_encoder_get_output_len(WBXMLEncoder *encoder)
+{
+    if (encoder == NULL)
+        return 0;
+    
+    return wbxml_buffer_len(encoder->output_header) + wbxml_buffer_len(encoder->output);
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_delete_output_bytes(WBXMLEncoder *encoder, WB_ULONG nb)
+{
+    if (encoder == NULL)
+        return;
+    
+    wbxml_buffer_delete(encoder->output, wbxml_buffer_len(encoder->output) - nb, nb);
+}
+
+
+WBXML_DECLARE(void) wbxml_encoder_delete_last_node(WBXMLEncoder *encoder)
+{
+    if (encoder == NULL)
+        return;
+    
+    wbxml_encoder_delete_output_bytes(encoder, wbxml_buffer_len(encoder->output) - encoder->pre_last_node_len);
+}
+
+
+/***************************************************
+ *    Private Functions
+ */
+
+/****************************
+ * Common Functions
+ */
+
+#if 0
+/**
+ * @brief Convert a char to UCS-4
+ * @param ch [in] The character to convert
+ * @param result [out] The UCS-4 code
+ * @return TRUE if convertion succeeded, FALSE otherwise
+ */
+static WB_BOOL convert_char_to_ucs4(WB_UTINY ch, WB_ULONG *result)
+{
+    /** @todo convert_char_to_ucs4() */
+
+    return FALSE;
+}
+#endif /* 0 */
+
+/**
+ * @brief Duplicate a WBXML Encoder
+ * @param encoder [in] The WBXML Encoder to Duplicate
+ * @return The duplicated WBXML Encoder, or NULL if error
+ * @note Only options (parameters) fields are duplicated, others are reset
+ */
+static WBXMLEncoder *encoder_duplicate(WBXMLEncoder *encoder)
+{
+    WBXMLEncoder *result = NULL;
+
+    if ((result = wbxml_encoder_create()) == NULL)
+        return NULL;
+
+    result->ignore_empty_text = encoder->ignore_empty_text;
+    result->remove_text_blanks = encoder->remove_text_blanks;
+
+    result->output_type = encoder->output_type;
+    result->xml_gen_type = encoder->xml_gen_type;
+
+    result->indent_delta = encoder->indent_delta;
+    result->indent = encoder->indent;
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    result->use_strtbl = encoder->use_strtbl;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    /* Do NOT generate XML Header */
+    result->xml_encode_header = FALSE;
+
+    result->wbxml_version = encoder->wbxml_version;
+
+    return result;
+}
+
+
+static WBXMLError encoder_encode_tree(WBXMLEncoder *encoder)
+{
+    WBXMLError ret = WBXML_OK;
+
+    /* Check Parameters */
+    if ((encoder == NULL) || (encoder->tree == NULL) || ((encoder->lang == NULL) && (encoder->tree->lang == NULL)) ||
+        ((encoder->output_type != WBXML_ENCODER_OUTPUT_XML) && (encoder->output_type != WBXML_ENCODER_OUTPUT_WBXML)))
+    {
+        return WBXML_ERROR_BAD_PARAMETER;
+    }
+    
+    if (encoder->lang == NULL)
+        encoder->lang = encoder->tree->lang;
+
+    /* Choose Output Charset */
+    if (encoder->output_charset == WBXML_CHARSET_UNKNOWN) {
+        /* User has not choosen the Output Charset Encoding */
+        if (encoder->tree->orig_charset != WBXML_CHARSET_UNKNOWN) {
+            /* Use the original Charset Encoding found when we have parsed the original document */
+            encoder->output_charset = encoder->tree->orig_charset;
+        }
+        else {
+            /* Use default charset */
+            encoder->output_charset = WBXML_ENCODER_XML_DEFAULT_CHARSET;
+        }
+    }
+
+    /* Init Output Buffer */
+    if (!encoder_init_output(encoder)) {
+        wbxml_encoder_destroy(encoder);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+    
+#if defined( WBXML_ENCODER_USE_STRTBL )
+
+    if (encoder->output_type == WBXML_ENCODER_OUTPUT_WBXML) {
+        /* Choose if we will use String Table */
+        switch (encoder->lang->langID)
+        {
+    #if defined( WBXML_SUPPORT_WV )
+        /* Wireless-Village CSP 1.1 / 1.2: content can be tokenized, so we mustn't interfere with String Table stuff */
+        case WBXML_LANG_WV_CSP11:
+        case WBXML_LANG_WV_CSP12:
+            encoder->use_strtbl = FALSE;
+            break;
+    #endif /* WBXML_SUPPORT_WV */
+
+    #if defined( WBXML_SUPPORT_OTA_SETTINGS )
+        /* Nokia Ericsson OTA Settings : string tables are not supported */
+        case WBXML_LANG_OTA_SETTINGS:
+            encoder->use_strtbl = FALSE;
+            break;
+    #endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+        default:
+            /* Use Default Value */
+            break;
+        }
+
+        /* Init String Table */
+        if (encoder->use_strtbl) {
+            /**
+             * @bug If 'output_charset' is different from UTF-8, the string table initialization
+             *      also is erroneous !!!
+             */
+            if ((ret = wbxml_strtbl_initialize(encoder, encoder->tree->root)) != WBXML_OK)
+                return ret;
+        }
+    }
+    
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    /* Let's begin WBXML Tree Parsing */
+    return parse_node(encoder, encoder->tree->root, TRUE);
+}
+
+
+static WB_BOOL encoder_init_output(WBXMLEncoder *encoder)
+{
+    WB_ULONG malloc_block = 0;
+    
+    if (encoder == NULL)
+        return FALSE;
+    
+    /* Check if output already inited */
+    if (encoder->output != NULL)
+        return TRUE;
+    
+    /* Get malloc block */
+    if (encoder->output_type == WBXML_ENCODER_OUTPUT_WBXML)
+        malloc_block = WBXML_ENCODER_WBXML_DOC_MALLOC_BLOCK;
+    else
+        malloc_block = WBXML_ENCODER_XML_DOC_MALLOC_BLOCK;
+
+    /* Init Output Buffer */
+    encoder->output = wbxml_buffer_create("", 0, malloc_block);
+    if (encoder->output == NULL)
+        return FALSE;
+    
+    return TRUE;
+}
+
+
+/*********************************
+ * WBXML Tree Parsing Functions
+ */
+
+/**
+ * @brief Parse an XML Node
+ * @param encoder The WBXML Encoder
+ * @param node    The node to parse
+ * @param enc_end If node is an element, do we encoded its end ?
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note We have recurrency in this function
+ */
+static WBXMLError parse_node(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL enc_end)
+{
+    WBXMLError ret = WBXML_OK;
+    
+    /* Set current node */
+    encoder->current_node = node;
+
+    /* Parse this node */
+    switch (node->type) {
+        case WBXML_TREE_ELEMENT_NODE:
+            ret = parse_element(encoder, node, node->children != NULL);
+            break;
+        case WBXML_TREE_TEXT_NODE:
+            ret = parse_text(encoder, node);
+            break;
+        case WBXML_TREE_CDATA_NODE:
+            ret = parse_cdata(encoder);
+            break;
+        case WBXML_TREE_PI_NODE:
+            ret = parse_pi(encoder, node);
+            break;
+        case WBXML_TREE_TREE_NODE:
+            ret = parse_tree(encoder, node);
+            break;
+        default:
+            return WBXML_ERROR_XML_NODE_NOT_ALLOWED;
+    }
+
+    if (ret != WBXML_OK)
+        return ret;
+
+    /* Check if node has children */
+    if (node->children != NULL) {
+        /* Parse Child */
+        if ((ret = parse_node(encoder, node->children, TRUE)) != WBXML_OK)
+            return ret;
+    }
+
+    /* Handle end of Element or CDATA section */
+    switch (node->type) {
+    case WBXML_TREE_ELEMENT_NODE:
+        if (enc_end) {
+            switch(encoder->output_type) {
+            case WBXML_ENCODER_OUTPUT_XML:
+#if defined( WBXML_ENCODER_XML_GEN_EMPTY_ELT )
+                if (node->children != NULL) {
+#endif /* WBXML_ENCODER_XML_GEN_EMPTY_ELT */
+
+                    /* Encode end tag */
+                    if ((ret = xml_encode_end_tag(encoder, node)) != WBXML_OK)
+                        return ret;
+
+                    WBXML_DEBUG((WBXML_ENCODER, "End Element"));
+
+#if defined( WBXML_ENCODER_XML_GEN_EMPTY_ELT )
+                }
+#endif /* WBXML_ENCODER_XML_GEN_EMPTY_ELT */
+                break;
+
+            case WBXML_ENCODER_OUTPUT_WBXML:
+                if (node->children != NULL) {
+                    /* Add a WBXML End tag */
+                    if ((ret = wbxml_encode_end(encoder)) != WBXML_OK)
+                        return ret;
+
+                    WBXML_DEBUG((WBXML_ENCODER, "End Element"));
+                }
+                break;
+
+            default:
+                /* hu ? */
+                break;
+            } /* switch */
+        } /* if */
+        break;
+
+    case WBXML_TREE_CDATA_NODE:
+        /* End of CDATA section */
+        encoder->in_cdata = FALSE;
+
+        WBXML_DEBUG((WBXML_ENCODER, "End CDATA"));
+
+        switch(encoder->output_type) {
+        case WBXML_ENCODER_OUTPUT_XML:
+            /* Encode XML "End of CDATA section" */
+            if ((ret = xml_encode_end_cdata(encoder)) != WBXML_OK)
+                return ret;
+            break;
+
+        case WBXML_ENCODER_OUTPUT_WBXML:
+            if (encoder->cdata == NULL) {
+                /* Must never happen */
+                return WBXML_ERROR_INTERNAL;
+            }
+
+            /* Encode CDATA Buffer into Opaque */
+            /* NOTE: A CDATA section is not necessarily opaque data.
+             * NOTE: CDATA is only character data which can be NULL terminated.
+             * NOTE: Nevertheless it is not wrong to handle it like opaque data.
+             */
+            if (wbxml_buffer_len(encoder->cdata) > 0) {
+                if ((ret = wbxml_encode_opaque(encoder, encoder->cdata)) != WBXML_OK)
+                    return ret;
+            }
+
+            /* Reset CDATA Buffer */
+            wbxml_buffer_destroy(encoder->cdata);
+            encoder->cdata = NULL;
+            break;
+
+        default:
+            /* hu ? */
+            break;
+        } /* switch */
+        break;
+
+    default:
+        /* NOP */
+        break;
+    }
+
+    /* Reset Current Tag and Current Node */
+    encoder->current_tag = NULL;
+    encoder->current_node = NULL;
+
+    /* Parse next node */
+    if (node->next != NULL)
+        return parse_node(encoder, node->next, TRUE);
+    else
+        return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse an XML Element
+ * @param encoder The WBXML Encoder
+ * @param node The element to parse
+ * @param has_content Does the element has content ?
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ */
+static WBXMLError parse_element(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content)
+{
+    WB_ULONG i = 0;
+    WBXMLError ret = WBXML_OK;
+    WBXMLAttribute *attr = NULL;
+
+    WBXML_DEBUG((WBXML_ENCODER, "Element: <%s>", wbxml_tag_get_xml_name(node->name)));
+
+    /* Encode: Element Name */
+    switch (encoder->output_type) {
+    case WBXML_ENCODER_OUTPUT_WBXML:
+        if ((ret = wbxml_encode_tag(encoder, node, has_content)) != WBXML_OK)
+            return ret;
+        break;
+
+    case WBXML_ENCODER_OUTPUT_XML:
+        if ((ret = xml_encode_tag(encoder, node)) != WBXML_OK)
+            return ret;
+        break;
+
+    default:
+        return WBXML_ERROR_INTERNAL;
+    }
+
+    /** @todo Check handling of Namespaces */
+
+    /** @todo For Canonical XML Output: Attributes MUST be sorted */
+
+    /* Parse: Attributes List */
+    if (node->attrs != NULL)
+    {
+        for (i = 0; i < wbxml_list_len(node->attrs); i++) {
+            /* Parse: Attribute */
+            attr = wbxml_list_get(node->attrs, i);
+            if (attr == NULL)
+            	return WBXML_ERROR_INTERNAL;
+            if ((ret = parse_attribute(encoder, attr)) != WBXML_OK)
+                return ret;
+        }
+    }
+
+    /* Encode: End of attributes */
+    switch (encoder->output_type) {
+    case WBXML_ENCODER_OUTPUT_WBXML:
+        /** @todo Check if the attributes will really be tokenized. There can be ignored attributes, and so NO attribute
+         *        tokenized at all.
+         */
+        if ((node->attrs != NULL) && (encoder->lang->attrTable != NULL) /** @todo Fast patch for SyncML (change this) */) {
+            if ((ret = wbxml_encode_end(encoder)) != WBXML_OK)
+                return ret;
+
+            WBXML_DEBUG((WBXML_ENCODER, "End Attributes"));
+        }
+        break;
+
+    case WBXML_ENCODER_OUTPUT_XML:
+        /* Encode end of attributes */
+        if ((ret = xml_encode_end_attrs(encoder, node)) != WBXML_OK)
+            return ret;
+
+        WBXML_DEBUG((WBXML_ENCODER, "End Attributes"));
+        break;
+
+    default:
+        return WBXML_ERROR_INTERNAL;
+    }
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse an Element End
+ * @param encoder The WBXML Encoder
+ * @param node The element to parse
+ * @param has_content Does the element has content ?
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ */
+static WBXMLError parse_element_end(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content)
+{
+    WBXMLError ret = WBXML_OK;
+    
+    if (encoder->output_type == WBXML_ENCODER_OUTPUT_XML) {
+#if defined( WBXML_ENCODER_XML_GEN_EMPTY_ELT )
+        if (has_content) {
+#endif /* WBXML_ENCODER_XML_GEN_EMPTY_ELT */
+
+            /* Encode end tag */
+            ret = xml_encode_end_tag(encoder, node);
+
+            WBXML_DEBUG((WBXML_ENCODER, "End Element"));
+
+#if defined( WBXML_ENCODER_XML_GEN_EMPTY_ELT )
+        }
+#endif /* WBXML_ENCODER_XML_GEN_EMPTY_ELT */
+    }
+    else if (encoder->output_type == WBXML_ENCODER_OUTPUT_WBXML) {
+        if (has_content) {
+            /* Add a WBXML End tag */
+            ret = wbxml_encode_end(encoder);
+
+            WBXML_DEBUG((WBXML_ENCODER, "End Element"));
+        }
+    }
+    
+    return ret;
+}
+
+
+/**
+ * @brief Parse an XML Attribute
+ * @param encoder The WBXML Encoder
+ * @param attribute The XML Attribute to parse
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ */
+static WBXMLError parse_attribute(WBXMLEncoder *encoder, WBXMLAttribute *attribute)
+{
+    if (encoder->lang == NULL)
+        return WBXML_ERROR_LANG_TABLE_UNDEFINED;
+
+    if (encoder->lang->attrTable == NULL)
+        return WBXML_OK;
+
+    /* Check that this attribute has a name */
+    if (attribute->name == NULL)
+        return WBXML_ERROR_XML_NULL_ATTR_NAME;
+
+    WBXML_DEBUG((WBXML_ENCODER, "Attribute: %s = %s", wbxml_attribute_get_xml_name(attribute), wbxml_attribute_get_xml_value(attribute)));
+
+    /* Encode: Attribute */
+    switch (encoder->output_type) {
+    case WBXML_ENCODER_OUTPUT_WBXML:
+        return wbxml_encode_attr(encoder, attribute);
+
+    case WBXML_ENCODER_OUTPUT_XML:
+        return xml_encode_attr(encoder, attribute);
+
+    default:
+        return WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+/**
+ * @brief Parse an XML Text
+ * @param encoder The WBXML Encoder
+ * @param node The text to parse
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ */
+static WBXMLError parse_text(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+    WBXMLError ret = WBXML_OK;
+    
+    /* Some elements should be transferred as opaque data */
+    if (encoder->output_type == WBXML_ENCODER_OUTPUT_WBXML &&
+        encoder->current_tag != NULL &&
+        encoder->current_tag->options & WBXML_TAG_OPTION_BINARY)
+    {
+        return wbxml_encode_opaque(encoder, node->content);
+    }
+
+    /* Do not modify text inside a CDATA section */
+    /* Do not modify text inside a BINARY section */
+    if (!encoder->in_cdata &&
+        ! (encoder->current_tag != NULL && encoder->current_tag->options & WBXML_TAG_OPTION_BINARY)) {
+        /* If Canonical Form: "Ignorable white space is considered significant and is treated equivalently to data" */
+        if ((encoder->output_type != WBXML_ENCODER_OUTPUT_XML) || (encoder->xml_gen_type != WBXML_GEN_XML_CANONICAL)) {
+            /* Ignore blank nodes */
+            if ((encoder->ignore_empty_text) && (wbxml_buffer_contains_only_whitespaces(node->content)))
+                return WBXML_OK;
+
+            /* Strip Blanks */
+            if (encoder->remove_text_blanks)
+                wbxml_buffer_strip_blanks(node->content);
+        }
+    }
+
+    WBXML_DEBUG((WBXML_ENCODER, "Text: <%s>", wbxml_buffer_get_cstr(node->content)));
+
+    /* Encode Text */
+    switch (encoder->output_type) {
+    case WBXML_ENCODER_OUTPUT_WBXML:
+        if (encoder->in_cdata) {
+            if (encoder->cdata == NULL) {
+                /* Must never happen */
+                return WBXML_ERROR_INTERNAL;
+            }
+
+#if defined( WBXML_SUPPORT_SYNCML )
+
+            if ((encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML10) ||
+                (encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML11) ||
+                (encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML12))
+            {
+                /** @todo We suppose that Opaque Data in SyncML messages can only be vCard or vCal documents. CHANGE THAT ! */
+                if (node->content != NULL) {
+                    if (wbxml_buffer_get_cstr(node->content)[0] == 0x0a && wbxml_buffer_len(node->content) == 1) {
+                        wbxml_buffer_insert_cstr(node->content, (WB_UTINY*) "\r", 0);
+                    }
+                }
+            }
+
+#endif /* WBXML_SUPPORT_SYNCML */
+
+            /* Add text into CDATA Buffer */
+            if (!wbxml_buffer_append(encoder->cdata, node->content))
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+            return WBXML_OK;
+        }
+        else {
+            /* Encode text */
+            encoder->current_text_parent = node->parent;
+            ret = wbxml_encode_value_element_buffer(encoder, wbxml_buffer_get_cstr(node->content), WBXML_VALUE_ELEMENT_CTX_CONTENT);
+            encoder->current_text_parent = NULL;
+            return ret;
+        }
+
+    case WBXML_ENCODER_OUTPUT_XML:
+        return xml_encode_text(encoder, node);
+
+    default:
+        return WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+/**
+ * @brief Parse an XML CDATA
+ * @param encoder The WBXML Encoder
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note There is no node parameter because the content is not
+ *       handled by this function and CDATA has no "attributes". 
+ */
+static WBXMLError parse_cdata(WBXMLEncoder *encoder)
+{
+    WBXML_DEBUG((WBXML_ENCODER, "CDATA Begin"));
+
+    /* Keep in mind that we are in a CDATA section */
+    encoder->in_cdata = TRUE;
+
+    /* Encode CDATA */
+    switch (encoder->output_type) {
+    case WBXML_ENCODER_OUTPUT_WBXML:
+        if (encoder->cdata != NULL) {
+            /* Must never happend */
+            return WBXML_ERROR_INTERNAL;
+        }
+
+        /* Create a new CDATA Buffer */
+        if ((encoder->cdata = wbxml_buffer_create("", 0, 0)) == NULL) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        return WBXML_OK;
+    case WBXML_ENCODER_OUTPUT_XML:
+        return xml_encode_cdata(encoder);
+    default:
+        return WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+/**
+ * @brief Parse an XML PI
+ * @param encoder The WBXML Encoder
+ * @param node The PI to parse
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ */
+static WBXMLError parse_pi(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+    /** @todo parse_pi() */
+
+    return WBXML_ERROR_NOT_IMPLEMENTED;
+}
+
+
+/**
+ * @brief Parse a WBXML Tree
+ * @param encoder The WBXML Encoder
+ * @param node The WBXML Tree to parse
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ */
+static WBXMLError parse_tree(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+    switch (encoder->output_type) {
+    case WBXML_ENCODER_OUTPUT_WBXML:
+        return wbxml_encode_tree(encoder, node->tree);
+    case WBXML_ENCODER_OUTPUT_XML:
+        return xml_encode_tree(encoder, node->tree);
+    default:
+        return WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+/*****************************************
+ *  WBXML Output Functions
+ */
+
+/****************************
+ * Build WBXML Result
+ */
+
+/**
+ * @brief Build WBXML Result
+ * @param encoder [in] The WBXML Encoder
+ * @param wbxml [out] Resulting WBXML document
+ * @param wbxml_len [out] The resulting WBXML document length
+ * @return WBXML_OK if built is OK, an error code otherwise
+ * @note WBXML Header = version publicid charset length
+ */
+static WBXMLError wbxml_build_result(WBXMLEncoder *encoder, WB_UTINY **wbxml, WB_ULONG *wbxml_len)
+{
+    WBXMLBuffer *header = NULL;
+    WBXMLError ret = WBXML_OK;
+    
+    if (encoder->flow_mode == TRUE) {
+        /* Header already built */
+        header = encoder->output_header;
+    }
+    else {
+        /* Create WBXML Header buffer */
+        if ((header = wbxml_buffer_create("", 0, WBXML_ENCODER_WBXML_HEADER_MALLOC_BLOCK)) == NULL)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        
+        /* Fill Header Buffer */
+        if ((ret = wbxml_fill_header(encoder, header)) != WBXML_OK) {
+            wbxml_buffer_destroy(header);
+            return ret;
+        }
+    }
+
+    /* Result Buffer Length */
+    *wbxml_len = wbxml_buffer_len(header) + wbxml_buffer_len(encoder->output);
+
+    /* Create Result Buffer */
+    *wbxml = wbxml_malloc(*wbxml_len * sizeof(WB_UTINY));
+    if (*wbxml == NULL) {
+        if (encoder->flow_mode == FALSE)
+            wbxml_buffer_destroy(header);
+        
+        *wbxml_len = 0;
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Copy WBXML Header */
+    memcpy(*wbxml, wbxml_buffer_get_cstr(header), wbxml_buffer_len(header));
+
+    /* Copy WBXML Buffer */
+    memcpy(*wbxml + wbxml_buffer_len(header), wbxml_buffer_get_cstr(encoder->output), wbxml_buffer_len(encoder->output));
+
+    if (encoder->flow_mode == FALSE)
+        wbxml_buffer_destroy(header);
+
+    return WBXML_OK;
+}
+
+
+static WBXMLError wbxml_fill_header(WBXMLEncoder *encoder, WBXMLBuffer *header)
+{
+    WBXMLBuffer *pid = NULL;
+    WB_ULONG public_id = 0, public_id_index = 0, strstbl_len = 0;
+    WB_BOOL pi_in_strtbl = FALSE;
+    WBXMLError ret = WBXML_OK;
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    WBXMLStringTableElement *elt = NULL;
+    WB_BOOL added = FALSE;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    if ((encoder == NULL) || (encoder->lang == NULL) || (encoder->lang->publicID == NULL) || (header == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    strstbl_len = encoder->strstbl_len;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    /* WBXML Public ID */
+    public_id = encoder->lang->publicID->wbxmlPublicID;
+
+    /* Encode WBXML Version */
+    if (!wbxml_buffer_append_char(header, (WB_UTINY) encoder->wbxml_version))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Prepare string table - adding Public ID */
+    /* If WBXML Public Id is '0x01' (unknown), or we forced it, add the XML Public ID in the String Table */
+    if ((encoder->textual_publicid || (public_id == WBXML_PUBLIC_ID_UNKNOWN)) &&
+        !encoder->produce_anonymous)
+    {
+        if (encoder->lang->publicID->xmlPublicID != NULL)
+        {
+            if ((pid = wbxml_buffer_create(encoder->lang->publicID->xmlPublicID,
+                                           WBXML_STRLEN(encoder->lang->publicID->xmlPublicID),
+                                           WBXML_STRLEN(encoder->lang->publicID->xmlPublicID))) == NULL)
+            {
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+            if (encoder->use_strtbl) {
+                if ((elt = wbxml_strtbl_element_create(pid, FALSE)) == NULL)
+                {
+                    wbxml_buffer_destroy(pid);
+                    return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                }
+
+                if (!wbxml_strtbl_add_element(encoder,
+                                              elt,
+                                              &public_id_index,
+                                              &added))
+                {
+                    wbxml_strtbl_element_destroy(elt);
+                    if (pid) wbxml_buffer_destroy(pid);
+                    return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                }
+
+                /* "added" means that pid was consumed by encoder.
+                 * So never free pid if added is TRUE.
+                 */
+                if (!added)
+                    wbxml_strtbl_element_destroy(elt);
+
+                strstbl_len = encoder->strstbl_len;
+            }
+            else {
+#endif /* WBXML_ENCODER_USE_STRTBL */
+                /* Length of String Table is length of XML Public ID (plus the NULL char) */
+                strstbl_len = wbxml_buffer_len(pid) + 1;
+
+                /* There is only the XML Public ID in String Table */
+                public_id_index = 0;
+#if defined( WBXML_ENCODER_USE_STRTBL )
+            }
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+            pi_in_strtbl = TRUE;
+        }
+    }
+
+    /* Encode Public ID */
+    /* publicid = mb_u_int32 | ( zero index ) */
+    if (pi_in_strtbl) {
+        /* Encode XML Public ID String Table index */
+        if (!wbxml_buffer_append_char(header, 0x00) ||
+            !wbxml_buffer_append_mb_uint_32(header, public_id_index))
+        {
+            if (pid && !added) wbxml_buffer_destroy(pid);	
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    }
+    else {
+        /* Encode WBXML Public ID */
+        if (!wbxml_buffer_append_mb_uint_32(header, public_id))
+        {
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+    }
+
+    /* Encode Charset (default: UTF-8) and String Table Length */
+    /** @todo Handle correctly the charset */
+    if (!wbxml_buffer_append_mb_uint_32(header, WBXML_ENCODER_DEFAULT_CHARSET) ||
+        !wbxml_buffer_append_mb_uint_32(header, strstbl_len))
+    {
+        if (pid && !added) wbxml_buffer_destroy(pid);
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+
+    /* Encode WBXML String Table */
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    if (encoder->use_strtbl) {
+        if ((ret = wbxml_strtbl_construct(header,(WBXMLList *) encoder->strstbl)) != WBXML_OK)
+        {
+            if (pid && !added) wbxml_buffer_destroy(pid);
+            return ret;
+        }
+    }
+    else {
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+        if (pid != NULL) {
+            if (!wbxml_buffer_append(header, pid))
+            {
+                wbxml_buffer_destroy(pid);
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+            }
+            
+            if (!wbxml_buffer_append_char(header, WBXML_STR_END))
+            {
+                wbxml_buffer_destroy(pid);
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+            }
+
+            /* Clean up */
+            wbxml_buffer_destroy(pid);
+            pid = NULL;
+        }
+            
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    }
+    if (pid && !added) wbxml_buffer_destroy(pid);
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    return WBXML_OK;
+}
+
+
+/****************************
+ * WBXML Encoding Functions
+ */
+
+/**
+ * @brief Encode a WBXML End Token
+ * @param encoder The WBXML Encoder
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError wbxml_encode_end(WBXMLEncoder *encoder)
+{
+    /* Append END */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_END))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a WBXML Tag
+ * @param encoder The WBXML Encoder
+ * @param node The element to encode
+ * @param has_content Does the element has content ?
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError wbxml_encode_tag(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content)
+{
+    const WBXMLTagEntry *tag = NULL;
+    WB_UTINY token = 0x00, page = 0x00;
+
+    if (!node || !node->name) {
+    	return WBXML_ERROR_UNKNOWN_TAG;
+    }
+    if (node->name->type == WBXML_VALUE_TOKEN) {
+        token = node->name->u.token->wbxmlToken;
+        page = node->name->u.token->wbxmlCodePage;
+
+        /* Current Tag */
+        encoder->current_tag = node->name->u.token;
+    }
+    else {
+        /* Search tag in Tags Table */
+        if ((tag = wbxml_tables_get_tag_from_xml(encoder->lang, encoder->tagCodePage, wbxml_tag_get_xml_name(node->name))) != NULL)
+        {
+            token = tag->wbxmlToken;
+            page = tag->wbxmlCodePage;
+
+            /* Current Tag */
+            encoder->current_tag = tag;
+        }
+        else
+            encoder->current_tag = NULL;
+    }
+
+    /* Check if this element has content */
+    if (has_content)
+        token |= WBXML_TOKEN_WITH_CONTENT;
+
+    /* Check if this element has attributes */
+    /** @todo Check if the attributes will really be tokenized. There can be ignored attributes, and so NO attribute
+     *        tokenized at all.
+     */
+    if ((node->attrs != NULL) && (encoder->lang->attrTable != NULL) /** @todo Fast patch for SyncML (change this) */)
+        token |= WBXML_TOKEN_WITH_ATTRS;
+
+    /* Encode Token */
+    if ((token & WBXML_TOKEN_MASK) == 0x00)
+        return wbxml_encode_tag_literal(encoder, (WB_UTINY *) wbxml_tag_get_xml_name(node->name), token);
+    else
+        return wbxml_encode_tag_token(encoder, token, page);
+}
+
+
+/**
+ * @brief Encode a WBXML Literal Token
+ * @param encoder The WBXML Encoder
+ * @param tag The literal tag to encode
+ * @param mask The WBXML Mask for this tag
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note    stag = (literalTag index)
+ *          literalTag = LITERAL | LITERAL_A | LITERAL_C | LITERAL_AC
+ *          index = mb_u_int32
+ */
+static WBXMLError wbxml_encode_tag_literal(WBXMLEncoder *encoder, const WB_UTINY *tag, WB_UTINY mask)
+{
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    WBXMLStringTableElement *elt = NULL;
+    WBXMLBuffer *buff = NULL;
+    WB_ULONG index = 0;
+    WB_BOOL added = FALSE;
+
+    /* If String Table generation is disabled, we can't generate this Literal Tag */
+    if (!encoder->use_strtbl)
+        return WBXML_ERROR_STRTBL_DISABLED;
+
+    /* Add tag in String Table */
+    if (((buff = wbxml_buffer_create(tag, WBXML_STRLEN(tag), WBXML_STRLEN(tag))) == NULL) ||
+        ((elt = wbxml_strtbl_element_create(buff, FALSE)) == NULL) ||
+        (!wbxml_strtbl_add_element(encoder, elt, &index, &added)))
+    {
+        wbxml_strtbl_element_destroy(elt);
+        wbxml_buffer_destroy(buff);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* If already exists in String Table: clean-up */
+    if (!added)
+        wbxml_strtbl_element_destroy(elt);
+
+    /* Encode literalTag index */
+    if ((!wbxml_buffer_append_char(encoder->output, (WB_UTINY) (WBXML_LITERAL | mask))) ||
+        (!wbxml_buffer_append_mb_uint_32(encoder->output, index)))
+    {
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+
+    return WBXML_OK;
+#else
+    /* No String Table Support */
+    return WBXML_ERROR_STRTBL_DISABLED;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+}
+
+
+/**
+ * @brief Encode a WBXML Tag Token
+ * @param encoder The WBXML Encoder
+ * @param token The WBXML Tag Token to encode
+ * @param page The WBXML CodePage for this Token
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note    element = ([switchPage] stag)
+ *          switchPage = SWITCH_PAGE pageindex
+ *          stag = TAG
+ *          pageindex = u_int8
+ */
+static WBXMLError wbxml_encode_tag_token(WBXMLEncoder *encoder, WB_UTINY token, WB_UTINY page)
+{
+    /* Switch Page if needed */
+    if (encoder->tagCodePage != page)
+    {
+        if ((!wbxml_buffer_append_char(encoder->output, WBXML_SWITCH_PAGE)) ||
+            (!wbxml_buffer_append_char(encoder->output, page)))
+        {
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+
+        encoder->tagCodePage = page;
+    }
+
+    /* Add Token */
+    if (!wbxml_buffer_append_char(encoder->output, token))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a WBXML Attribute
+ * @param encoder [in] The WBXML Encoder
+ * @param attribute [in] The Attribute to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note    attribute = attrStart *attrValue
+ */
+static WBXMLError wbxml_encode_attr(WBXMLEncoder *encoder, WBXMLAttribute *attribute)
+{
+    WB_UTINY *value = NULL;
+    WBXMLError ret = WBXML_OK;
+
+    /* Encode Attribute Start */
+    if ((ret = wbxml_encode_attr_start(encoder, attribute, &value)) != WBXML_OK)
+        return ret;
+
+    /* Encode Attribute Value */
+    if (value != NULL) {
+        if ((ret = wbxml_encode_value_element_buffer(encoder, value, WBXML_VALUE_ELEMENT_CTX_ATTR)) != WBXML_OK)
+            return ret;
+    }
+
+    /* Reset Current Attribute */
+    encoder->current_attr = NULL;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a WBXML Attribute Start
+ * @param encoder [in] The WBXML Encoder
+ * @param attribute [in] The Attribute
+ * @param value [out] Pointer to the value to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note The 'value' result correspond to the value there is still to encode
+ *       For example, in Wireless-Village, to encode:
+ *              xmlns="http://www.wireless-village.org/CSP1.1"
+ *       We first encode:
+ *              xmlns="http://www.wireless-village.org/CSP (start token: 0x05)
+ *       Then:
+ *              "1.1" as an inline string
+ */
+static WBXMLError wbxml_encode_attr_start(WBXMLEncoder *encoder, WBXMLAttribute *attribute, WB_UTINY **value)
+{
+    const WBXMLAttrEntry *attr = NULL;
+    WB_UTINY *value_left = NULL;
+    WB_UTINY token = 0x00, page = 0x00;
+
+    *value = wbxml_buffer_get_cstr(attribute->value);
+
+    if (attribute->name->type == WBXML_VALUE_TOKEN) {
+        /* We already have Token / Page pair for this Attribute Start */
+        token = attribute->name->u.token->wbxmlToken;
+        page = attribute->name->u.token->wbxmlCodePage;
+
+        /* Current Attribute */
+        encoder->current_attr = attribute->name->u.token;
+
+        /* If there is a Start Value associated to the Attribute Name token... */
+        if (attribute->name->u.token->xmlValue != NULL)
+        {
+            /* ... Check that we have it at start of full Attribute Value */
+            if (WBXML_STRNCMP(wbxml_buffer_get_cstr(attribute->value),
+                              attribute->name->u.token->xmlValue,
+                              WBXML_STRLEN(attribute->name->u.token->xmlValue)) == 0)
+            {
+                /* Check if you have still a part in the Attribute Value to encode */
+                if (wbxml_buffer_len(attribute->value) > WBXML_STRLEN(attribute->name->u.token->xmlValue))
+                {
+                    /* There is still a part in the Value to encode */
+                    *value = wbxml_buffer_get_cstr(attribute->value) + WBXML_STRLEN(attribute->name->u.token->xmlValue);
+                }
+                else
+                    *value = NULL;
+            }
+            else {
+                /** @todo Should we stop everything and generate an error ? */
+                WBXML_WARNING((WBXML_ENCODER, "wbxml_encode_attr_start() => Attribute Value doesn't match Attribute Token"));
+
+                /* Current Attribute */
+                encoder->current_attr = NULL;
+
+                /* Encode Attribute Literal */
+                return wbxml_encode_attr_start_literal(encoder, wbxml_attribute_get_xml_name(attribute));
+            }
+        }
+
+        /* Encode Attribute Token */
+        return wbxml_encode_attr_token(encoder, token, page);
+    }
+    else {
+        /* Search in Attribute table */
+        if ((attr = wbxml_tables_get_attr_from_xml(encoder->lang,
+                                                   (WB_UTINY *)attribute->name->u.token->xmlName,
+                                                   wbxml_buffer_get_cstr(attribute->value),
+                                                   &value_left)) != NULL)
+        {
+            token = attr->wbxmlToken;
+            page = attr->wbxmlCodePage;
+
+            /* Current Attribute */
+            encoder->current_attr = attr;
+
+            /* If there is still a part in Attribute Value to encode */
+            *value = value_left;
+
+            /* Encode Attribute Token */
+            return wbxml_encode_attr_token(encoder, token, page);
+        }
+        else {
+            /* Current Attribute */
+            encoder->current_attr = NULL;
+
+            /* Encode Attribute Literal */
+            return wbxml_encode_attr_start_literal(encoder, wbxml_attribute_get_xml_name(attribute));
+        }
+    }
+}
+
+
+/**
+ * @brief Encode a WBXML Attribute Value
+ * @param encoder The WBXML Encoder
+ * @param buffer The Value Element Buffer to encode
+ * @param ctx Value Element Context (Attribute Value or Content)
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note    attrStart = *attrValue
+ *          attrValue = string | extension | entity | opaque
+ *
+ *   AND:   element = *content
+ *          content = string | extension | entity | opaque
+ */
+static WBXMLError wbxml_encode_value_element_buffer(WBXMLEncoder *encoder, WB_UTINY *buffer, WBXMLValueElementCtx ctx)
+{
+    WBXMLList *lresult = NULL;
+    WBXMLBuffer *buff = NULL;
+    WBXMLValueElement *elt = NULL, *new_elt = NULL;
+    WB_ULONG i = 0, j = 0, index = 0;
+    WB_UTINY *the_buffer = buffer;
+    WBXMLError ret = WBXML_OK;
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    WBXMLStringTableElement *strtbl_elt = NULL;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+    if ((buffer == NULL) || (*buffer == '\0'))
+        return WBXML_OK;
+
+
+    /*********************************************************
+     *  Encoder Language Specific Attribute Values
+     */
+
+    if (ctx == WBXML_VALUE_ELEMENT_CTX_ATTR) {
+        switch (encoder->lang->langID) {
+#if defined( WBXML_SUPPORT_SI )
+        case WBXML_LANG_SI10:
+            /* SI 1.0: Encode date for 'created' and 'si-expires' attributes */
+            if (encoder->current_attr == NULL)
+                break;
+
+            if ((encoder->current_attr->wbxmlCodePage == 0x00) &&
+                ((encoder->current_attr->wbxmlToken == 0x0a) || (encoder->current_attr->wbxmlToken == 0x10)))
+            {
+                return wbxml_encode_datetime(encoder, buffer);
+            }
+            break;
+#endif /* WBXML_SUPPORT_SI */
+
+#if defined( WBXML_SUPPORT_EMN )
+        case WBXML_LANG_EMN10:
+            /* EMN 1.0: Encode date for 'timestamp' attribute */
+            if (encoder->current_attr == NULL)
+                break;
+
+            if ((encoder->current_attr->wbxmlCodePage == 0x00) && (encoder->current_attr->wbxmlToken == 0x05))
+            {
+                return wbxml_encode_datetime(encoder, buffer);
+            }
+            break;
+#endif /* WBXML_SUPPORT_EMN */
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+        case WBXML_LANG_OTA_SETTINGS:
+            /**
+             * Nokia OTA Settings support for the ICON value in bookmarks.
+             * The encoding is done using base64 encoded images in XML, and encoding it as OPAQUE data in the WBXML. 
+             * The icon is embedded using an PARM element with name ICON.
+             */
+            if ((encoder->current_attr->wbxmlCodePage == 0x00) &&
+                (encoder->current_attr->wbxmlToken == 0x11)) 
+            {
+                if ((ret = wbxml_encode_ota_nokia_icon(encoder, buffer)) != WBXML_NOT_ENCODED)
+                    return ret;
+            }
+            break;
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+        default:
+            break;
+        }
+    }
+
+
+    /*********************************************************
+     *  Encoder Language Specific Content Text Values
+     */
+
+    /* If this is a Text Content (not in a CDATA section) */
+    if ((ctx == WBXML_VALUE_ELEMENT_CTX_CONTENT) && (!encoder->in_cdata))
+    {
+#if defined( WBXML_SUPPORT_WV )
+        /* If this is a Wireless-Village 1.1 / 1.2 document */
+        if ((encoder->lang->langID == WBXML_LANG_WV_CSP11) ||
+            (encoder->lang->langID == WBXML_LANG_WV_CSP12))
+        {
+            /* Here we try to encode Specific WV Content. If this buffer is not a WV Data Type buffer, or
+             * if it can't be FULLY encoded as an Extension Token, then this function returns WBXML_NOT_ENCODED.
+             * If so, the buffer will be encoded as String latter.
+             */
+            if ((ret = wbxml_encode_wv_content(encoder, buffer)) != WBXML_NOT_ENCODED)
+                return ret;
+        }
+#endif /* WBXML_SUPPORT_WV */
+
+#if defined( WBXML_SUPPORT_DRMREL )
+        /* If this is a DRMREL 1.0 document */
+        if (encoder->lang->langID == WBXML_LANG_DRMREL10)
+        {
+            /* Here we try to encode Specific DRMREL Content. If this buffer is not a DRMREL Data Type buffer
+             * this function returns WBXML_NOT_ENCODED.
+             * If so, the buffer will be encoded as String latter.
+             */
+            if ((ret = wbxml_encode_drmrel_content(encoder, buffer)) != WBXML_NOT_ENCODED)
+                return ret;
+        }
+#endif /* WBXML_SUPPORT_DRMREL */
+
+#if defined( WBXML_SUPPORT_SYNCML )
+        /* If this is a SyncML document ? */
+        if ((encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML10) ||
+            (encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML11) ||
+            (encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML12))
+        {
+            /** @todo We must check too if we are in a <Type> */
+
+            /* Change text in <Type> from "application/vnd.syncml-devinf+xml" to "application/vnd.syncml-devinf+wbxml" */
+            if (WBXML_STRCASECMP(buffer, "application/vnd.syncml-devinf+xml") == 0) {
+                the_buffer = (WB_UTINY*) "application/vnd.syncml-devinf+wbxml";
+            }
+            /* Change text in <Type> from "application/vnd.syncml.dmtnds+xml" to "application/vnd.syncml.dmtnds+wbxml" */
+            if (WBXML_STRCASECMP(buffer, "application/vnd.syncml.dmtnds+xml") == 0) {
+                the_buffer = (WB_UTINY*) "application/vnd.syncml.dmtnds+wbxml";
+            }
+        }
+#endif /* WBXML_SUPPORT_SYNCML */
+    }
+
+
+    /*********************************************************
+     * @todo Search first for simple cases !
+     */
+
+
+    /*********************************************************
+     *  We search the list of Value Elements that represents
+     *  this Value buffer
+     */
+
+    /* Create Result List */
+    if ((lresult = wbxml_list_create()) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Create primary Buffer */
+    if ((buff = wbxml_buffer_create_from_cstr(the_buffer)) == NULL) {
+        wbxml_list_destroy(lresult, NULL);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Create Value Element for this buffer */
+    if ((elt = wbxml_value_element_create()) == NULL) {
+        wbxml_buffer_destroy(buff);
+        wbxml_list_destroy(lresult, NULL);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    elt->type = WBXML_VALUE_ELEMENT_STRING;
+    elt->u.str = buff;
+
+    /* Append this Buffer to Result List */
+    if (!wbxml_list_append(lresult, elt)) {
+        wbxml_value_element_destroy(elt);
+        wbxml_list_destroy(lresult, NULL);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* If this is an Attribute Value */
+    if (ctx == WBXML_VALUE_ELEMENT_CTX_ATTR)
+    {
+        /*********************************************************
+         *  Search for Attribute Value Tokens
+         */
+
+        if (encoder->lang->attrValueTable != NULL) {
+            /* For each Attribute Value Token */
+            j = 0;
+            while (encoder->lang->attrValueTable[j].xmlName != NULL)
+            {
+                /* For each Value Element */
+                for (i = 0; i < wbxml_list_len(lresult); i++) {
+                    if ((elt = (WBXMLValueElement *) wbxml_list_get(lresult, i)) == NULL)
+                        continue;
+
+                    if (elt->type != WBXML_VALUE_ELEMENT_STRING)
+                        continue;
+
+                    /* Is this Attribute Value contained in this Buffer ? */
+                    if (wbxml_buffer_search_cstr(elt->u.str, (WB_UTINY *)encoder->lang->attrValueTable[j].xmlName, 0, &index)) {
+                        /* Create new Value Element */
+                        if ((new_elt = wbxml_value_element_create()) == NULL) {
+                            wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                        }
+
+                        new_elt->type = WBXML_VALUE_ELEMENT_ATTR_TOKEN;
+                        new_elt->u.attr = &(encoder->lang->attrValueTable[j]);
+
+                        /* Insert new Value Element in List */
+                        if (!wbxml_list_insert(lresult, (void *) new_elt, i + 1)) {
+                            wbxml_value_element_destroy(new_elt);
+                            wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                        }
+
+                        /* Check if there is still the end of the String to encode */
+                        if (index + WBXML_STRLEN(encoder->lang->attrValueTable[j].xmlName) < wbxml_buffer_len(elt->u.str)) {
+                            /* Create new Value Element */
+                            if ((new_elt = wbxml_value_element_create()) == NULL) {
+                                wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                            }
+
+                            new_elt->type = WBXML_VALUE_ELEMENT_STRING;
+                            new_elt->u.str = wbxml_buffer_create_from_cstr(wbxml_buffer_get_cstr(elt->u.str) + index + WBXML_STRLEN(encoder->lang->attrValueTable[j].xmlName));
+
+                            /* Insert new Value Element in List */
+                            if ((new_elt->u.str == NULL) ||
+                                !wbxml_list_insert(lresult, (void *) new_elt, i + 2))
+                            {
+                                wbxml_value_element_destroy(new_elt);
+                                wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                            }
+                        }
+
+                        /* Remove the Attribute Value found in Value Element */
+                        wbxml_buffer_delete(elt->u.str, index, wbxml_buffer_len(elt->u.str) - index);
+                    } /* if */
+                } /* for */
+                j++;
+            } /* while */
+        } /* if */
+    }
+
+    /* If this is a Text Content (not in a CDATA section) */
+    if ((ctx == WBXML_VALUE_ELEMENT_CTX_CONTENT) && (!encoder->in_cdata))
+    {
+        /*********************************************************
+         *  Search for Extension Tokens
+         */
+
+        /** @todo Finish Extension Tokens Search */
+
+        if (encoder->lang->extValueTable != NULL) {
+            /* For each Extension Token */
+            j = 0;
+            while (encoder->lang->extValueTable[j].xmlName != NULL)
+            {
+                /* For each Value Element */
+                for (i = 0; i < wbxml_list_len(lresult); i++) {
+                    if ((elt = (WBXMLValueElement *) wbxml_list_get(lresult, i)) == NULL)
+                        continue;
+
+                    if (elt->type != WBXML_VALUE_ELEMENT_STRING)
+                        continue;
+
+                    /* Ignores the "1 char Extension Tokens" */
+                    if (WBXML_STRLEN(encoder->lang->extValueTable[j].xmlName) < 2)
+                        continue;
+
+                    /* Is this Extension Token contained in this Buffer ?
+		     * 
+		     * The Extension Token must start at the beginning of
+		     * the buffer. Otherwise we can damage normal text
+		     * entities like 'My IM-application.' If 'IM' is an
+		     * Extension Token.
+		     *
+		     * Assumption: The buffer is already normalized.
+		     */
+                    if (wbxml_buffer_compare_cstr(elt->u.str, (WB_TINY *) encoder->lang->extValueTable[j].xmlName) == 0)
+                    {
+                        /* Create new Value Element */
+                        if ((new_elt = wbxml_value_element_create()) == NULL) {
+                            wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                        }
+
+                        new_elt->type = WBXML_VALUE_ELEMENT_EXTENSION;
+                        new_elt->u.ext = &(encoder->lang->extValueTable[j]);
+
+                        /* Insert new Value Element in List */
+                        if (!wbxml_list_insert(lresult, (void *) new_elt, i + 1)) {
+                            wbxml_value_element_destroy(new_elt);
+                            wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                        }
+
+                        /* Check if there is still the end of the String to encode */
+                        if (index + WBXML_STRLEN(encoder->lang->extValueTable[j].xmlName) < wbxml_buffer_len(elt->u.str)) {
+                            /* Create new Value Element */
+                            if ((new_elt = wbxml_value_element_create()) == NULL) {
+                                wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                            }
+
+                            new_elt->type = WBXML_VALUE_ELEMENT_STRING;
+                            new_elt->u.str = wbxml_buffer_create_from_cstr(wbxml_buffer_get_cstr(elt->u.str) + index + WBXML_STRLEN(encoder->lang->extValueTable[j].xmlName));
+
+                            /* Insert new Value Element in List */
+                            if ((new_elt->u.str == NULL) ||
+                                !wbxml_list_insert(lresult, (void *) new_elt, i + 2))
+                            {
+                                wbxml_value_element_destroy(new_elt);
+                                wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                            }
+                        }
+
+                        /* Remove the Attribute Value found in Value Element */
+                        wbxml_buffer_delete(elt->u.str, index, wbxml_buffer_len(elt->u.str) - index);
+                    } /* if */
+                } /* for */
+                j++;
+            } /* while */
+        } /* if */
+    }
+
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+
+    /***********************************************************************
+     *  Search for String Table References
+     *  (except if this is a Content string and we are in a CDATA section)
+     */
+
+    if (encoder->use_strtbl && !(encoder->in_cdata && (ctx == WBXML_VALUE_ELEMENT_CTX_CONTENT))) {
+        /* For each String Table Element */
+        for (j = 0; j < wbxml_list_len(encoder->strstbl); j++) {
+            if ((strtbl_elt = (WBXMLStringTableElement *) wbxml_list_get(encoder->strstbl, j)) == NULL)
+                continue;
+
+            /* For each Value Element */
+            for (i = 0; i < wbxml_list_len(lresult); i++) {
+                if ((elt = (WBXMLValueElement *) wbxml_list_get(lresult, i)) == NULL)
+                    continue;
+
+                if (elt->type != WBXML_VALUE_ELEMENT_STRING)
+                    continue;
+
+                /* Is the String Table Element contained in this Buffer ? */
+                if (wbxml_buffer_search(elt->u.str, strtbl_elt->string, 0, &index)) {
+                    /* Create new Value Element */
+                    if ((new_elt = wbxml_value_element_create()) == NULL) {
+                        wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                    }
+
+                    new_elt->type = WBXML_VALUE_ELEMENT_TABLEREF;
+                    new_elt->u.index = strtbl_elt->offset;
+
+                    /* Insert new Value Element in List */
+                    if (!wbxml_list_insert(lresult, (void *) new_elt, i + 1)) {
+                        wbxml_value_element_destroy(new_elt);
+                        wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                    }
+
+                    /* Check if there is still the end of the String to encode */
+                    if (index + wbxml_buffer_len(strtbl_elt->string) < wbxml_buffer_len(elt->u.str)) {
+                        /* Create new Value Element */
+                        if ((new_elt = wbxml_value_element_create()) == NULL) {
+                            wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                        }
+
+                        new_elt->type = WBXML_VALUE_ELEMENT_STRING;
+                        new_elt->u.str = wbxml_buffer_create_from_cstr(wbxml_buffer_get_cstr(elt->u.str) + index + wbxml_buffer_len(strtbl_elt->string));
+
+                        /* Insert new Value Element in List */
+                        if ((new_elt->u.str == NULL) ||
+                            !wbxml_list_insert(lresult, (void *) new_elt, i + 2))
+                        {
+                            wbxml_value_element_destroy(new_elt);
+                            wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+                            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                        }
+                    }
+
+                    /* Remove the Attribute Value found in Value Element */
+                    wbxml_buffer_delete(elt->u.str, index, wbxml_buffer_len(elt->u.str) - index);
+                } /* if */
+            } /* for */
+        } /* for */
+    } /* if */
+
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+
+    /*********************************************************
+     *  Encode Value Element Buffer
+     */
+
+    ret = wbxml_encode_value_element_list(encoder, lresult);
+
+    /* Clean-up */
+    wbxml_list_destroy(lresult, wbxml_value_element_destroy_item);
+
+    return ret;
+}
+
+
+/**
+ * @brief Encode a WBXML Value Element List
+ * @param encoder The WBXML Encoder
+ * @param list The Value Element list
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError wbxml_encode_value_element_list(WBXMLEncoder *encoder, WBXMLList *list)
+{
+    WBXMLValueElement *elt = NULL;
+    WB_ULONG i = 0;
+    WBXMLError ret = WBXML_OK;
+
+    if (encoder == NULL)
+        return WBXML_ERROR_INTERNAL;
+
+    if (list == NULL)
+        return WBXML_OK;
+
+    for (i = 0; i < wbxml_list_len(list); i++) {
+        if ((elt = (WBXMLValueElement *) wbxml_list_get(list, i)) == NULL)
+            continue;
+
+        switch (elt->type) {
+        case WBXML_VALUE_ELEMENT_STRING:
+            /* Inline String */
+            if (wbxml_buffer_len(elt->u.str) > 0) {
+                if ((ret = wbxml_encode_inline_string(encoder, elt->u.str)) != WBXML_OK)
+                    return ret;
+            }
+            break;
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+        case WBXML_VALUE_ELEMENT_TABLEREF:
+            /* String Table Reference */
+            if ((ret = wbxml_encode_tableref(encoder, elt->u.index)) != WBXML_OK)
+                return ret;
+            break;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+        case WBXML_VALUE_ELEMENT_EXTENSION:
+            /* Encode Extension Token */
+            if ((ret = wbxml_encode_inline_integer_extension_token(encoder, WBXML_EXT_T_0, elt->u.ext->wbxmlToken)) != WBXML_OK)
+                return ret;
+            break;
+
+        case WBXML_VALUE_ELEMENT_OPAQUE:
+            /** @todo Opaque */
+            break;
+
+        case WBXML_VALUE_ELEMENT_ATTR_TOKEN:
+            /* Attribute Value Token */
+            if ((ret = wbxml_encode_attr_token(encoder, elt->u.attr->wbxmlToken,  elt->u.attr->wbxmlCodePage)) != WBXML_OK)
+                return ret;
+            break;
+
+        default:
+            return WBXML_ERROR_INTERNAL;
+        }
+    }
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a WBXML Literal Attribute Start
+ * @param encoder The WBXML Encoder
+ * @param attr The literal attr name to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note    attrStart = (LITERAL index)
+ *          index = mb_u_int32
+ */
+static WBXMLError wbxml_encode_attr_start_literal(WBXMLEncoder *encoder, const WB_UTINY *attr)
+{
+#if defined( WBXML_ENCODER_USE_STRTBL )
+    WBXMLStringTableElement *elt = NULL;
+    WBXMLBuffer *buff = NULL;
+    WB_ULONG index = 0;
+    WB_BOOL added = FALSE;
+
+    /* If String Table generation is disabled, we can't generate this Literal */
+    if (!encoder->use_strtbl)
+        return WBXML_ERROR_STRTBL_DISABLED;
+
+    /* Add tag in String Table */
+    if (((buff = wbxml_buffer_create(attr, WBXML_STRLEN(attr), WBXML_STRLEN(attr))) == NULL) ||
+        ((elt = wbxml_strtbl_element_create(buff, FALSE)) == NULL) ||
+        (!wbxml_strtbl_add_element(encoder, elt, &index, &added)))
+    {
+        wbxml_strtbl_element_destroy(elt);
+        wbxml_buffer_destroy(buff);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* If already exists in String Table: clean-up */
+    if (!added)
+        wbxml_strtbl_element_destroy(elt);
+
+    /* Encode LITERAL index */
+    if ((!wbxml_buffer_append_char(encoder->output, WBXML_LITERAL)) ||
+        (!wbxml_buffer_append_mb_uint_32(encoder->output, index)))
+    {
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+
+    return WBXML_OK;
+#else
+    /* No String Table Support */
+    return WBXML_ERROR_STRTBL_DISABLED;
+#endif /* WBXML_ENCODER_USE_STRTBL */
+}
+
+
+/**
+ * @brief Encode a WBXML Attribute Token
+ * @param encoder The WBXML Encoder
+ * @param token The WBXML Attribute Token to encode
+ * @param page The WBXML CodePage for this Token
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note    attrStart = ([switchPage] ATTRSTART)
+ *          switchPage = SWITCH_PAGE pageindex
+ *          pageindex = u_int8
+ *
+ *  And:    attrValue = ([switchPage] ATTRVALUE)
+ */
+static WBXMLError wbxml_encode_attr_token(WBXMLEncoder *encoder, WB_UTINY token, WB_UTINY page)
+{
+    /* Switch Page if needed */
+    if (encoder->attrCodePage != page)
+    {
+        if ((!wbxml_buffer_append_char(encoder->output, WBXML_SWITCH_PAGE)) ||
+            (!wbxml_buffer_append_char(encoder->output, page)))
+        {
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+
+        encoder->attrCodePage = page;
+    }
+
+    /* Add Token */
+    if (!wbxml_buffer_append_char(encoder->output, token))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a WBXML Inline String
+ * @param encoder The WBXML Encoder
+ * @param str The String to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError wbxml_encode_inline_string(WBXMLEncoder *encoder, WBXMLBuffer *str)
+{
+    /* Add STR_I */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_STR_I))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add String */
+    if (!wbxml_buffer_append(encoder->output, str))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add Null Termination */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_STR_END))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a WBXML Inline Integer Extension Token
+ * @param encoder The WBXML Encoder
+ * @param ext Extension Type (WBXML_EXT_T_0, WBXML_EXT_T_1 or WBXML_EXT_T_2)
+ * @param value The Extension Token Value
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note  (WBXML 1.3 - 5.8.4.2) Inline integrer extension token = EXT_T* mb_u_int32
+ */
+static WBXMLError wbxml_encode_inline_integer_extension_token(WBXMLEncoder *encoder, WB_UTINY ext, WB_UTINY value)
+{
+    /* Add EXT_T* */
+    if (!wbxml_buffer_append_char(encoder->output, ext))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add Value */
+    if (!wbxml_buffer_append_mb_uint_32(encoder->output, (WB_ULONG) value))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+#if 0
+/**
+ * @brief Encode a WBXML Entity
+ * @param encoder The WBXML Encoder
+ * @param value The Entity to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note  (WBXML 1.3 - 5.8.4.3) entity = ENTITY entcode
+ *                              entcode = mb_u_int32
+ */
+static WBXMLError wbxml_encode_entity(WBXMLEncoder *encoder, WB_ULONG value)
+{
+    /* Add ENTITY */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_ENTITY))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add entcode */
+    if (!wbxml_buffer_append_mb_uint_32(encoder->output, value))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+#endif /* 0 */
+
+
+/**
+ * @brief Encode a WBXML Opaque, given a Buffer
+ * @param encoder The WBXML Encoder
+ * @param buff The Buffer to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note This function is simple a wrapper to wbxml_encode_opaque_data()
+ */
+static WBXMLError wbxml_encode_opaque(WBXMLEncoder *encoder, WBXMLBuffer *buff)
+{
+    return wbxml_encode_opaque_data(encoder, wbxml_buffer_get_cstr(buff), wbxml_buffer_len(buff));
+}
+
+
+/**
+ * @brief Encode a WBXML Opaque
+ * @param encoder The WBXML Encoder
+ * @param data The data to encode
+ * @param data_len The data length to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note  opaque = OPAQUE length *byte
+ *        length = mb_u_int32
+ */
+static WBXMLError wbxml_encode_opaque_data(WBXMLEncoder *encoder, WB_UTINY *data, WB_ULONG data_len)
+{
+    /* Add WBXML_OPAQUE */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_OPAQUE))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add Length */
+    if (!wbxml_buffer_append_mb_uint_32(encoder->output, data_len))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add Buffer */
+    if (!wbxml_buffer_append_data(encoder->output, data, data_len))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+/**
+ * @brief Encode a WBXML String Table Reference
+ * @param encoder The WBXML Encoder
+ * @param offset The String Table offset
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ * @note tableref = STR_T index
+ */
+static WBXMLError wbxml_encode_tableref(WBXMLEncoder *encoder, WB_ULONG offset)
+{
+    /* Add WBXML_STR_T */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_STR_T))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add String */
+    if (!wbxml_buffer_append_mb_uint_32(encoder->output, offset))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+
+/**
+ * @brief Create a WBXMLValueElement structure
+ * @return The newly created WBXMLValueElement structure, or NULL if not enough memory
+ */
+static WBXMLValueElement *wbxml_value_element_create(void)
+{
+    WBXMLValueElement *elt = NULL;
+
+    if ((elt = wbxml_malloc(sizeof(WBXMLValueElement))) == NULL)
+        return NULL;
+
+    elt->type = WBXML_VALUE_ELEMENT_STRING;
+    elt->u.str = NULL;
+
+    return elt;
+}
+
+
+/**
+ * @brief Destroy a WBXMLValueElement structure
+ * @param elt The WBXMLValueElement structure to destroy
+ */
+static void wbxml_value_element_destroy(WBXMLValueElement *elt)
+{
+    if (elt == NULL)
+        return;
+
+    switch (elt->type) {
+    case WBXML_VALUE_ELEMENT_STRING:
+        wbxml_buffer_destroy(elt->u.str);
+        break;
+    case WBXML_VALUE_ELEMENT_OPAQUE:
+        wbxml_buffer_destroy(elt->u.buff);
+        break;
+    default:
+        /* Nothing to destroy */
+        break;
+    }
+
+    wbxml_free((void*) elt);
+}
+
+
+/**
+ * @brief Destroy a WBXMLValueElement structure (for wbxml_list_destroy() function)
+ * @param elt The WBXMLValueElement structure to destroy
+ */
+static void wbxml_value_element_destroy_item(void *elt)
+{
+    wbxml_value_element_destroy((WBXMLValueElement *) elt);
+}
+
+
+/**
+ * @brief Encode an encapsulated WBXML Tree to WBXML
+ * @param encoder [in] The WBXML Encoder
+ * @param tree    [in] The WBXML Tree to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError wbxml_encode_tree(WBXMLEncoder *encoder, WBXMLTree *tree)
+{
+    WBXMLEncoder *new_encoder = NULL;
+    WB_UTINY *wbxml = NULL;
+    WB_ULONG wbxml_len = 0;
+    WBXMLError ret = WBXML_OK;
+
+    if ((new_encoder = encoder_duplicate(encoder)) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Set Tree */
+    new_encoder->tree = tree;
+
+    /* Encode to WBXML */
+    if ((ret = wbxml_encoder_encode_tree_to_wbxml(new_encoder, &wbxml, &wbxml_len)) != WBXML_OK) {
+        wbxml_encoder_destroy(new_encoder);
+        return ret;
+    }
+
+    /* Clean-up */
+    wbxml_encoder_destroy(new_encoder);
+
+    /* Add WBXML_OPAQUE */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_OPAQUE)) {
+        wbxml_free(wbxml);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Add Length */
+    if (!wbxml_buffer_append_mb_uint_32(encoder->output, wbxml_len)) {
+        wbxml_free(wbxml);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Append wbxml to output */
+    if (!wbxml_buffer_append_data(encoder->output, wbxml, wbxml_len)) {
+        wbxml_free(wbxml);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Clean-up */
+    wbxml_free(wbxml);
+
+    return WBXML_OK;
+}
+
+
+/****************************************
+ * Language Specific Encoding Functions
+ */
+
+#if ( defined( WBXML_SUPPORT_SI ) || defined( WBXML_SUPPORT_EMN ) )
+
+/*******************
+ * SI 1.0 / EMN 1.0
+ */
+
+/**
+ * @brief Encode SI %Datetime attribute value
+ * @param encoder The WBXML Encoder
+ * @param buffer The %Datetime value to encode
+ * @return WBXML_OK if encoded, another error code otherwise
+ * @note [SI] - 8.2.2. Encoding of %Datetime
+ */
+static WBXMLError wbxml_encode_datetime(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    WBXMLBuffer *tmp = NULL;
+    WB_ULONG i = 0;
+    WB_UTINY ch = 0;
+    WBXMLError ret = WBXML_OK;
+
+
+    if ((tmp = wbxml_buffer_create_from_cstr(buffer)) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Remove non-digit characters */
+    while (i < wbxml_buffer_len(tmp)) {
+        /* Get char */
+        if (!wbxml_buffer_get_char(tmp, i, &ch)) {
+            wbxml_buffer_destroy(tmp);
+            return WBXML_ERROR_INTERNAL;
+        }
+
+        if (!WBXML_ISDIGIT(ch)) {
+            if ((ch != 'T') && (ch != 'Z') && (ch != '-') && (ch != ':')) {
+                wbxml_buffer_destroy(tmp);
+                return WBXML_ERROR_BAD_DATETIME;
+            }
+
+            /* Remove it */
+            wbxml_buffer_delete(tmp, i, 1);
+        }
+        else
+            i++;
+    }
+
+    /* Convert Ascii to Binary buffer */
+    wbxml_buffer_hex_to_binary(tmp);
+
+    /* Remove trailing zero */
+    wbxml_buffer_remove_trailing_zeros(tmp);
+
+    /* Encode it to Opaque */
+    ret = wbxml_encode_opaque(encoder, tmp);
+
+    wbxml_buffer_destroy(tmp);
+
+    return ret;
+}
+
+#endif /* WBXML_SUPPORT_SI || WBXML_SUPPORT_EMN */
+
+
+#if defined( WBXML_SUPPORT_WV )
+
+/*******************
+ * WV 1.1 / WV 1.2
+ */
+
+/**
+ * @brief Encode a Wireless-Village Content buffer
+ * @param encoder The WBXML Encoder
+ * @param buffer The buffer to encode
+ * @return WBXML_OK if encoded, WBXML_NOT_ENCODED if not encoded, another error code otherwise
+ * @note This function encodes a Specific WV Data Type content, or an exact Extension Token.
+ *       If not found, this is not encoded... and it will be encoded latter as an Inline String
+ *       in wbxml_encode_value_element_buffer(). We don't deal here if this buffer CONTAINS
+ *       Extension Tokens.
+ */
+static WBXMLError wbxml_encode_wv_content(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    const WBXMLExtValueEntry *ext = NULL;
+    WBXMLWVDataType data_type = WBXML_WV_DATA_TYPE_STRING;
+    /* WB_ULONG ucs4_ch = 0; */
+
+    /*
+     *  Specific Data Type Elements:
+     *
+     *        Boolean:
+     *            Acceptance (0x00 / 0x05)
+     *            InUse (0x00 / 0x18)
+     *            Poll (0x00 / 0x21)
+     *            AllFunctionsRequest (0x01 / 0x06)
+     *            CapabilityRequest (0x01 / 0x0B)
+     *            CompletionFlag (0x01 / 0x34)
+     *            ReceiveList (0x01 / 0x36) [WV 1.2]
+     *            AnyContent (0x03 / 0x09)
+     *            DefaultList (0x04 / 0x0B)
+     *            Auto-Subscribe (0x04 / 0x1E) [WV 1.2]
+     *            DeliveryReport (0x06 / 0x08)
+     *            JoinGroup (0x07 / 0x21)
+     *            JoinedRequest (0x07 / 0x10)
+     *            SubscribeNotification (0x07 / 0x22)
+     *            CIR (0x09 / 0x05) [WV 1.2]
+     *
+     *        Integer:
+     *            Code (0x00 / 0x0B)
+     *            ContentSize (0x00 / 0x0F)
+     *            MessageCount (0x00 / 0x1A)
+     *            Validity (0x00 / 0x3C)
+     *            KeepAliveTime (0x01 / 0x1C)
+     *            SearchFindings (0x01 / 0x25)
+     *            SearchID (0x01 / 0x26)
+     *            SearchIndex (0x01 / 0x27)
+     *            SearchLimit (0x01 / 0x28)
+     *            TimeToLive (0x01 / 0x32)
+     *            AcceptedCharSet (0x03 / 0x05)
+     *            AcceptedContentLength (0x03 / 0x06)
+     *            MultiTrans (0x03 / 0x0C)
+     *            ParserSize (0x03 / 0x0D)
+     *            ServerPollMin (0x03 / 0x0E)
+     *            TCPPort (0x03 / 0x12)
+     *            UDPPort (0x03 / 0x13)
+     *            HistoryPeriod (0x09 / 0x08) [WV 1.2]
+     *            MaxWatcherList (0x09 / 0x0A) [WV 1.2]
+     *
+     *        Date and Time:
+     *            DateTime (0x00 / 0x11)
+     *            DeliveryTime (0x06 / 0x1A)
+     *
+     *        Binary:
+     *            ContentData (0x00 / 0x0D) (only if we have a: "<ContentEncoding>BASE64</ContentEncoding>" associated)
+     */
+
+    /****************************************
+     * Get the Data Type of Current Element
+     */
+
+    if (encoder->current_tag != NULL)
+    {
+        switch (encoder->current_tag->wbxmlCodePage) {
+        case 0x00:
+            /* Code Page: 0x00 */
+            switch (encoder->current_tag->wbxmlToken) {
+            case 0x05: /* Acceptance */
+            case 0x18: /* InUse */
+            case 0x21: /* Poll */
+                /* BOOLEAN */
+                data_type = WBXML_WV_DATA_TYPE_BOOLEAN;
+                break;
+            case 0x0B: /* Code */
+            case 0x0F: /* ContentSize */
+            case 0x1A: /* MessageCount */
+            case 0x3C: /* Validity */
+                /* INTEGER */
+                data_type = WBXML_WV_DATA_TYPE_INTEGER;
+                break;
+            case 0x11: /* DateTime */
+                /* DATE_AND_TIME */
+                data_type = WBXML_WV_DATA_TYPE_DATE_AND_TIME;
+                break;
+            case 0x0D: /* ContentData */
+                /* BINARY */
+                /** @todo Check if we have a: "<ContentEncoding>BASE64</ContentEncoding>" associated */
+                /*
+                if (base64_encoded)
+                    data_type = WBXML_WV_DATA_TYPE_BINARY;
+                else
+                */
+                    data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+        case 0x01:
+            /* Code Page: 0x01 */
+            switch (encoder->current_tag->wbxmlToken) {
+            case 0x06: /* AllFunctionsRequest */
+            case 0x0B: /* CapabilityRequest */
+            case 0x34: /* CompletionFlag */
+            case 0x36: /* ReceiveList */
+                /* BOOLEAN */
+                data_type = WBXML_WV_DATA_TYPE_BOOLEAN;
+                break;
+            case 0x1C: /* KeepAliveTime */
+            case 0x25: /* SearchFindings */
+            case 0x26: /* SearchID */
+            case 0x27: /* SearchIndex */
+            case 0x28: /* SearchLimit */
+            case 0x32: /* TimeToLive */
+                /* INTEGER */
+                data_type = WBXML_WV_DATA_TYPE_INTEGER;
+                break;
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+        case 0x03:
+            /* Code Page: 0x03 */
+            switch (encoder->current_tag->wbxmlToken) {
+            case 0x09: /* AnyContent */
+                /* BOOLEAN */
+                data_type = WBXML_WV_DATA_TYPE_BOOLEAN;
+                break;
+            case 0x05: /* AcceptedCharSet */
+            case 0x06: /* AcceptedContentLength */
+            case 0x0C: /* MultiTrans */
+            case 0x0D: /* ParserSize */
+            case 0x0E: /* ServerPollMin */
+            case 0x12: /* TCPPort */
+            case 0x13: /* UDPPort */
+                /* INTEGER */
+                data_type = WBXML_WV_DATA_TYPE_INTEGER;
+                break;
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+        case 0x04:
+            /* Code Page: 0x04 */
+            switch (encoder->current_tag->wbxmlToken) {
+            case 0x0B: /* DefaultList */
+            case 0x1E: /* Auto-Subscribe */
+                /* BOOLEAN */
+                data_type = WBXML_WV_DATA_TYPE_BOOLEAN;
+                break;
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+        case 0x06:
+            /* Code Page: 0x06 */
+            switch (encoder->current_tag->wbxmlToken) {
+            case 0x08: /* DeliveryReport */
+                /* BOOLEAN */
+                data_type = WBXML_WV_DATA_TYPE_BOOLEAN;
+                break;
+            case 0x1A: /* DeliveryTime */
+                /* DATE AND TIME */
+                data_type = WBXML_WV_DATA_TYPE_DATE_AND_TIME;
+                break;
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+        case 0x07:
+            /* Code Page: 0x07 */
+            switch (encoder->current_tag->wbxmlToken) {
+            case 0x21: /* JoinGroup */
+            case 0x10: /* JoinedRequest */
+            case 0x22: /* SubscribeNotification */
+                /* BOOLEAN */
+                data_type = WBXML_WV_DATA_TYPE_BOOLEAN;
+                break;
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+        case 0x09:
+            /* Code Page: 0x09 */
+            switch (encoder->current_tag->wbxmlToken) {
+            case 0x05: /* CIR */
+                /* BOOLEAN */
+                data_type = WBXML_WV_DATA_TYPE_BOOLEAN;
+                break;
+            case 0x08: /* HistoryPeriod */
+            case 0x0A: /* MaxWatcherList */
+                /* INTEGER */
+                data_type = WBXML_WV_DATA_TYPE_INTEGER;
+                break;
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+        default:
+            data_type = WBXML_WV_DATA_TYPE_STRING;
+            break;
+        }
+    }
+
+
+    /****************************************
+     * Encode, given the Data Type
+     */
+
+    switch (data_type) {
+    case WBXML_WV_DATA_TYPE_INTEGER:
+        /* Integer: Encode it */
+        return wbxml_encode_wv_integer(encoder, buffer);
+        break;
+    case WBXML_WV_DATA_TYPE_DATE_AND_TIME:
+        /* Date and time can be encoded as OPAQUE data or as a string as specified in [ISO8601]. */
+        return wbxml_encode_wv_datetime(encoder, buffer);
+        break;
+    case WBXML_WV_DATA_TYPE_BINARY:
+        /** @todo Binary Encoding !! */
+        break;
+    case WBXML_WV_DATA_TYPE_BOOLEAN:
+        /* Booleans are handled by the "T" and "F" extension tokens */
+    case WBXML_WV_DATA_TYPE_STRING:
+        /* Check if this buffer is an EXACT Extension Token */
+        if ((ext = wbxml_tables_get_ext_from_xml(encoder->lang, buffer)) != NULL)
+            return wbxml_encode_inline_integer_extension_token(encoder, WBXML_EXT_T_0, ext->wbxmlToken);
+        else {
+            if (WBXML_STRLEN(buffer) == 1)
+            {
+                /**
+                 * @todo [OMA WV 1.1] - 6.1 : A single character can be encoded as ENTITY (0x02) followed
+                 *                           by a mb_u_int32 containing the entity number.
+                 */
+
+                /*
+                if (convert_char_to_ucs4(*buffer, &ucs4_ch))
+                    return wbxml_encode_entity(encoder, ucs4_ch);
+                */
+            }
+
+            /* Else: noting encoded... this will be latter as an inline string */
+        }
+        break;
+    default:
+        /* Hu ? */
+        break;
+    }
+
+    return WBXML_NOT_ENCODED;
+}
+
+
+/**
+ * @brief Encode a Wireless-Village Integer
+ * @param encoder The WBXML Encoder
+ * @param buffer The buffer that contains the string representation of the integer to encode
+ * @return WBXML_OK if OK, another error code otherwise
+ */
+static WBXMLError wbxml_encode_wv_integer(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    WB_UTINY octets[4];
+    WB_ULONG the_int = 0, start = 0;
+    WB_LONG i = 0;
+
+    if ((encoder == NULL) || (buffer == NULL))
+        return WBXML_ERROR_INTERNAL;
+
+    if (buffer[1] == 'x' || buffer[1] == 'X') {
+        the_int = (WB_ULONG) strtol((const WB_TINY *) buffer , NULL , 16);
+    } else {
+        the_int = (WB_ULONG) atol((const WB_TINY *) buffer);
+    }
+
+
+    for (i = 3; the_int > 0 && i >= 0; i--) {
+        octets[i] = (WB_UTINY)(the_int & 0xff);
+        the_int >>= 8;
+    }
+
+    start = i + 1;
+
+    /* Add WBXML_OPAQUE */
+    if (!wbxml_buffer_append_char(encoder->output, WBXML_OPAQUE))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add Integer Length */
+    if (!wbxml_buffer_append_mb_uint_32(encoder->output, 4 - start))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Add Integer */
+    if (!wbxml_buffer_append_data(encoder->output, octets + start, (WB_UTINY)(4 - start)))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode inline WV Date and Time content value
+ * @param encoder The WBXML Encoder
+ * @param buffer The ISO 8601 Date and Time value to encode
+ * @return WBXML_OK if encoded, another error code otherwise
+ * @note [WV] - 6.6 Date and Time
+ * @note
+ *  Encoded Format: 
+ *      - ISO 8601 string (see expected format)
+ *
+ *  Expected Format (ISO 8601):
+ *      20011019T0950Z
+ *      20011019T095031Z
+ *      2001-10-19T09:50:31Z (with number seperators)
+ *      2001-10-19T09:50:31+01:00 (with explicit positive time zone)
+ *      2001-10-19T09:50:31+05:00 (with explicit negative time zone)
+ */
+static WBXMLError wbxml_encode_wv_datetime_inline(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    WBXMLError result = WBXML_OK;
+    WBXMLBuffer *tmp = NULL;
+
+    /* Create temp Buffer */
+    if ((tmp = wbxml_buffer_create_from_cstr(buffer)) == NULL) {
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Add buffer to encoder */
+    result = wbxml_encode_inline_string(encoder, tmp);
+
+    /* Cleanup buffer */
+    wbxml_buffer_destroy(tmp);
+    
+    return result;
+}
+
+
+/**
+ * @brief Encode opaque WV Date and Time content value
+ * @param encoder The WBXML Encoder
+ * @param buffer The ISO 8601 Date and Time value to encode
+ * @return WBXML_OK if encoded, another error code otherwise
+ * @note [WV] - 6.6 Date and Time
+ * @note
+ *  Encoded Format: (6 octets)
+ *      - The first 2 bits are reserved, and both must be 0.
+ *      - Year is encoded by 12 bits (0 to 4095)
+ *      - Month is encoded by 4 bits (1 to 12)
+ *      - Day is encoded by 5 bits (1 to 31)
+ *      - Hour is encoded by 5 bits (0 to 23)
+ *      - Minute is encoded by 6 bits (0 to 59)
+ *      - Second is encoded by 6 bits (0 to 59)
+ *      - Time zone is encoded in 1 byte [ISO8601].
+ *
+ *      eg:
+ *          Binary:  00 011111010001 1010 10011 01001 110010 011111 01011010
+ *          Octets:  (-------)(-------)(--------)(-------)(-------) (------)
+ *
+ *  Expected Format (ISO 8601):
+ *      20011019T0950 (missing seconds and time zone)
+ *      20011019T0950Z (missing seconds)
+ *      20011019T095031 (missing time zone)
+ *      20011019T095031Z
+ *      20011019T095031A (UTC+1)
+ */
+static WBXMLError wbxml_encode_wv_datetime_opaque(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    WBXMLError error;
+    WBXMLBuffer *tmp = NULL;
+    WB_ULONG i = 0, len = 0;
+    WB_UTINY ch = 0;
+    WBXMLError ret = WBXML_OK;
+    WB_UTINY octets[6];
+    WBXMLBuffer *component = NULL;
+
+    /* definitions first ... or some compilers don't like it */
+    unsigned int year, month, day, hour, minute, second;
+
+    len = WBXML_STRLEN(buffer);
+
+    /* Create temp Buffer */
+    if ((tmp = wbxml_buffer_create_from_cstr(buffer)) == NULL) {
+        error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        goto error;
+    }
+
+    /* Check Length */
+    if ((len == 13) || (len == 14)) {
+        /* This is illegal but we can tolerate datetimes
+         * which forget the seconds.
+         */
+        WBXML_WARNING((WBXML_CONV, "The WV datetime %s is missing the seconds.", buffer));
+        if (len == 13) {
+            wbxml_buffer_append_cstr(tmp, "00");
+        } else {
+            wbxml_buffer_insert_cstr(tmp, (WB_UTINY *) "00", 13);
+        }
+        len = wbxml_buffer_len(tmp);
+    }
+    if ((len != 15) && (len != 16)) {
+        WBXML_ERROR((WBXML_CONV, "The length of a WV datetime must be 15 or 16."));
+        error = WBXML_ERROR_WV_DATETIME_FORMAT;
+        goto error;
+    }
+
+    /* Check position of 'T' */
+    if (*(buffer+8) != 'T') {
+        WBXML_ERROR((WBXML_CONV, "The 9th character of a WV datetime must be 'T'."));
+        error = WBXML_ERROR_WV_DATETIME_FORMAT;
+        goto error;
+    }
+
+    /* Check position of time zone */
+    if (len == 16) {
+        if (!wbxml_buffer_get_char(tmp, 15, &ch)) {
+            error = WBXML_ERROR_INTERNAL;
+            goto error;
+        }
+        if (ch < 'A' || ch == 'J' || ch > 'Z') {
+            WBXML_ERROR((WBXML_CONV, "If the length of a WV datetime is 16 then the last character must be the time zone."));
+            error = WBXML_ERROR_WV_DATETIME_FORMAT;
+            goto error;
+        }
+
+        /* There is a time zone. */
+        octets[5] = ch;
+
+        /* delete time zone */
+        wbxml_buffer_delete(tmp, 15, 1);
+    } else {
+        /* There is no time zone. */
+        octets[5] = 0;
+    }
+
+    /* delete 'T' */
+    wbxml_buffer_delete(tmp, 8, 1);
+
+    /* Check if you have only digits characters */
+    while (i < wbxml_buffer_len(tmp)) {
+        /* Get char */
+        if (!wbxml_buffer_get_char(tmp, i, &ch)) {
+            error = WBXML_ERROR_INTERNAL;
+            goto error;
+        }
+
+        if (!WBXML_ISDIGIT(ch)) {
+            error = WBXML_ERROR_WV_DATETIME_FORMAT;
+            goto error;
+        }
+        else
+            i++;
+    }
+
+    WBXML_DEBUG((WBXML_CONV, "Starting WV datetime conversion ..."));
+
+    /* Set Year */
+    component = wbxml_buffer_duplicate(tmp);
+    if (!component) {
+        error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        goto error;
+    }
+    wbxml_buffer_delete(component, 4, 10);
+    year = strtoul((const char *)wbxml_buffer_get_cstr(component), NULL, 10);
+    wbxml_buffer_destroy(component);
+    octets[0] = (WB_UTINY) ((year & 0xfc0) >> 6); /* 6 bits */
+    octets[1] = (WB_UTINY) (year & 0x3f);  /* 6 bits */
+
+    /* Set Month */
+    component = wbxml_buffer_duplicate(tmp);
+    if (!component) {
+        error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        goto error;
+    }
+    wbxml_buffer_delete(component, 0, 4);
+    wbxml_buffer_delete(component, 2, 8);
+    month = strtoul((const char *)wbxml_buffer_get_cstr(component), NULL, 10);
+    wbxml_buffer_destroy(component);
+    octets[1] <<= 2;
+    octets[1] += (WB_UTINY) ((month & 0xc) >> 2); /* 2 bits */
+    octets[2] = (WB_UTINY) (month & 0x3); /* 2 bits */
+
+    /* Set Day */
+    component = wbxml_buffer_duplicate(tmp);
+    if (!component) {
+        error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        goto error;
+    }
+    wbxml_buffer_delete(component, 0, 6);
+    wbxml_buffer_delete(component, 2, 6);
+    day = strtoul((const char *)wbxml_buffer_get_cstr(component), NULL, 10);
+    wbxml_buffer_destroy(component);
+    octets[2] <<= 5;
+    octets[2] += (WB_UTINY) (day & 0x1f); /* 5 bits */
+
+    /* Set Hour */
+    component = wbxml_buffer_duplicate(tmp);
+    if (!component) {
+        error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        goto error;
+    }
+    wbxml_buffer_delete(component, 0, 8);
+    wbxml_buffer_delete(component, 2, 4);
+    hour = strtoul((const char *)wbxml_buffer_get_cstr(component), NULL, 10);
+    wbxml_buffer_destroy(component);
+    octets[2] <<=1;
+    octets[2] += (WB_UTINY) ((hour & 0x10) >> 4); /* 1 bit */
+    octets[3] = (WB_UTINY) (hour & 0xf); /* 4 bits */
+
+    /* Set Minute */
+    component = wbxml_buffer_duplicate(tmp);
+    if (!component) {
+        error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        goto error;
+    }
+    wbxml_buffer_delete(component, 0, 10);
+    wbxml_buffer_delete(component, 2, 2);
+    minute = strtoul((const char *)wbxml_buffer_get_cstr(component), NULL, 10);
+    wbxml_buffer_destroy(component);
+    octets[3] <<=4;
+    octets[3] += (WB_UTINY) ((minute & 0x3c) >> 2); /* 4 bits */
+    octets[4] = (WB_UTINY) (minute & 0x3); /* 2 bits */
+
+    /* Set Second */
+    component = wbxml_buffer_duplicate(tmp);
+    if (!component) {
+        error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        goto error;
+    }
+    wbxml_buffer_delete(component, 0, 12);
+    second = strtoul((const char *)wbxml_buffer_get_cstr(component), NULL, 10);
+    wbxml_buffer_destroy(component);
+    octets[4] <<=6;
+    octets[4] += (WB_UTINY) (second & 0x3f); /* 6 bits */
+
+    WBXML_DEBUG((WBXML_CONV, "WV datetime: %x %x %x %x %x %x", octets[0], octets[1], octets[2], octets[3], octets[4], octets[5]));
+
+    /* Encode it to Opaque */
+    ret = wbxml_encode_opaque_data(encoder, octets, 6);
+
+    return ret;
+error:
+    if (tmp)
+        wbxml_buffer_destroy(tmp);
+    return error;
+}
+
+
+/**
+ * @brief Encode WV Date and Time content value
+ * @param encoder The WBXML Encoder
+ * @param buffer The ISO 8601 Date and Time value to encode
+ * @return WBXML_OK if encoded, another error code otherwise
+ * @note [WV] - 6.6 Date and Time
+ * @note This function only decides which kind of datetime
+ *       encoding should be used and calls the appropriate
+ *       function. Please see wbxml_encode_wv_datetime_opaque
+ *       and wbxml_encode_wv_datetime_inline for more details.
+ * @note Both encoding mechanisms were implemented to be able
+ *       to test the parsing of both encoding scheme. This is
+ *       necessary because other implementations can decide by
+ *       their own which encoding scheme they use.
+ */
+static WBXMLError wbxml_encode_wv_datetime(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    WB_BOOL use_inline = FALSE;
+    WB_ULONG len = WBXML_STRLEN(buffer);
+
+    /* long version of ISO 8601 should be inline encoded */
+    if (strchr((WB_TINY *) buffer, '-'))
+        use_inline = TRUE;
+    if (strchr((WB_TINY *) buffer, '+'))
+        use_inline = TRUE;
+    if (strchr((WB_TINY *) buffer, ':'))
+        use_inline = TRUE;
+
+    /* timezone Z should be inline encoded */
+    if (buffer[len - 1] == 'Z')
+        use_inline = TRUE;
+
+    if (use_inline) {
+        WBXML_DEBUG((WBXML_CONV, "WV datetime conversion: INLINE"));
+        return wbxml_encode_wv_datetime_inline(encoder, buffer);
+    } else {
+        WBXML_DEBUG((WBXML_CONV, "WV datetime conversion: OPAQUE"));
+        return wbxml_encode_wv_datetime_opaque(encoder, buffer);
+    }
+}
+
+#endif /* WBXML_SUPPORT_WV */
+
+
+#if defined( WBXML_SUPPORT_DRMREL )
+
+/*******************
+ * DRMREL 1.0
+ */
+
+/**
+ * @brief Encode a DRMREL Content buffer
+ * @param encoder The WBXML Encoder
+ * @param buffer The buffer to encode
+ * @return WBXML_OK if encoded, WBXML_NOT_ENCODED if not encoded, another error code otherwise
+ * @note This function encodes a Specific DRMREL content.
+ *       If not found, this is not encoded... and it will be encoded latter as an Inline String
+ *       in wbxml_encode_value_element_buffer().
+ */
+static WBXMLError wbxml_encode_drmrel_content(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    WB_UTINY *data = NULL;
+    WB_LONG data_len = 0;
+    const WBXMLTagEntry *current_tag = NULL;
+
+    if ((encoder->current_text_parent != NULL) && 
+        (encoder->current_text_parent->name != NULL) &&
+        (encoder->current_text_parent->name->type == WBXML_VALUE_TOKEN))
+    {
+        current_tag = encoder->current_text_parent->name->u.token;
+    }
+
+    if (current_tag != NULL) 
+    {
+        if ((current_tag->wbxmlCodePage == 0x00) &&
+            (current_tag->wbxmlToken == 0x0C))
+        {
+            /* <ds:KeyValue> content: "Encoded in binary format, i.e., no base64 encoding" */
+
+            /* Decode Base64 */
+            if ((data_len = wbxml_base64_decode(buffer, -1, &data)) < 0)
+                return WBXML_NOT_ENCODED;
+
+            /* Add WBXML_OPAQUE */
+            if (!wbxml_buffer_append_char(encoder->output, WBXML_OPAQUE))
+            {
+                wbxml_free(data);
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+            }
+
+            /* Add Data Length */
+            if (!wbxml_buffer_append_mb_uint_32(encoder->output, (WB_ULONG) data_len))
+            {
+                wbxml_free(data);
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+            }
+
+            /* Add Data */
+            if (!wbxml_buffer_append_data(encoder->output, data, data_len))
+            {
+                wbxml_free(data);
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+            }
+
+            /* Free Data */
+            wbxml_free(data);
+
+            return WBXML_OK;
+        }
+    }
+
+    return WBXML_NOT_ENCODED;
+}
+
+#endif /* WBXML_SUPPORT_DRMREL */
+
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+
+/*******************
+ * OTA Settings
+ */
+
+/**
+ * @brief Encode a OTA ICON as opaque data 
+ * @param encoder The WBXML Encoder
+ * @param buffer The buffer to encode
+ * @return WBXML_OK if encoded, WBXML_NOT_ENCODED if not encoded, another error code otherwise 
+ * @note Nokia OTA Settings support for the ICON value in bookmarks.
+ *
+ * Nokia introduced a proprietary way of including icons in the old Nokia OTA Settings format when sending bookmarks.
+ * The encoding is done using base64 encoded images in XML, and encoding it as OPAQUE data in the WBXML. 
+ * The icon is embedded using an PARM element with name ICON.
+ *
+ * E.g. the following bookmark (XML) is valid:
+ * 
+ * <?xml version="1.0"?>
+ * <!DOCTYPE CHARACTERISTIC-LIST PUBLIC "-//WAPFORUM//DTD NOKIA-OTA 1.0//EN" "http://localhost:8080/OMABootSendWEB/DTD/characteristic_list.dtd">
+ * 
+ * <CHARACTERISTIC-LIST>
+ *    <CHARACTERISTIC TYPE="BOOKMARK"> 
+ *       <PARM NAME="NAME" VALUE="TV2"/>
+ *       <PARM NAME="URL" VALUE="http://wap.tv2.dk"/>
+ *       <PARM NAME="ICON" VALUE="R0lGODlhIAAgAPMAAP//AP8zAMwAAJkAAGYAAN0AAKoAAIgAAHcAAFUAAEQAACIAABEAALu7u8jIyP8AMyH5BAEAAA4ALAAAAAAgACAAQATh0MlJq704Z8bkucyiJARyHEM6HAjCNJw2hWNpnmdLJMrSyUBMICApAAqbhUiheDVgicQg8dPQSKaBQVAQGFaIXa8KDC2ZaCU5yL4QPe3yoXAIfDacfJVBZV9JNi16fWUiWChbAl5gBAxjMlclKFoGX4w8PkF/BJydO5hrbXp5caUYd6YycwVvqRY4R64goa4dMRKtGBxKaqNShIVMUSUcTwxTtCCGnC04LMWkkMtZlJbPMLdJNVlbXV8sYplW04iKi+Cg0tvUKixh6eqALfM64cnKwlH6PI+mu7y8sskaCMFFADs="/>
+ *    </CHARACTERISTIC>
+ * </CHARACTERISTIC-LIST>
+ *
+ * If not found, this is not encoded... and it will be encoded latter as an Inline String in wbxml_encode_value_element_buffer().
+ */
+static WBXMLError wbxml_encode_ota_nokia_icon(WBXMLEncoder *encoder, WB_UTINY *buffer)
+{
+    WBXMLError ret = WBXML_NOT_ENCODED;
+    
+    /* Is a VALUE attribute ? */
+    if ((encoder->current_tag != NULL) &&
+        (encoder->current_attr->wbxmlCodePage == 0x00) && 
+        (encoder->current_attr->wbxmlToken == 0x11) &&
+        (encoder->current_node && encoder->current_node->attrs)) 
+    {
+        WBXMLList *attrs = encoder->current_node->attrs;
+        WB_ULONG index = 0;
+        WB_ULONG nb_attrs = wbxml_list_len(attrs);
+        WB_BOOL found = FALSE;
+        
+        /* Search for a NAME="ICON" attribute */
+        while (!found && (index < nb_attrs)) {
+            WBXMLAttribute *attr = (WBXMLAttribute*)wbxml_list_get(attrs, index);
+            
+            if ((WBXML_STRCMP("NAME", wbxml_attribute_get_xml_name(attr)) == 0) &&
+                (WBXML_STRCMP("ICON", wbxml_attribute_get_xml_value(attr)) == 0))
+            {
+                WB_UTINY *data = NULL;
+                WB_LONG data_len = 0;
+                
+                /* Decode Base64 */
+                if ((data_len = wbxml_base64_decode(buffer, -1, &data)) < 0)
+                    return WBXML_NOT_ENCODED;
+            
+                /* Encode opaque */
+                if ((ret = wbxml_encode_opaque_data(encoder, data, data_len)) != WBXML_OK)
+                    return ret;
+                
+                /* Free Data */
+                wbxml_free(data);
+                
+                found = TRUE;
+            }
+            
+            index++;
+        }
+    }
+    
+    return ret;
+}
+
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+
+#if defined( WBXML_ENCODER_USE_STRTBL )
+
+/****************************
+ * String Table Functions
+ */
+
+/**
+ * @brief Create a String Table element
+ * @param string The WBXMLBuffer containing the String
+ * @param is_stat If set to TRUE, this Buffer won't be destroyed in wbxml_strtbl_element_destroy() function
+ * @return The newly created String Table Element, or NULL if not enought memory
+ */
+static WBXMLStringTableElement *wbxml_strtbl_element_create(WBXMLBuffer *string, WB_BOOL is_stat)
+{
+    WBXMLStringTableElement *elt = NULL;
+
+    if ((elt = wbxml_malloc(sizeof(WBXMLStringTableElement))) == NULL)
+        return NULL;
+
+    elt->string = string;
+    elt->offset = 0;
+    elt->count = 0;
+    elt->stat = is_stat;
+
+    return elt;
+}
+
+
+/**
+ * @brief Destroy a String Table element
+ * @param element The element to destroy
+ */
+static void wbxml_strtbl_element_destroy(WBXMLStringTableElement *element)
+{
+    if (element == NULL)
+        return;
+
+    if (!element->stat)
+        wbxml_buffer_destroy(element->string);
+
+    wbxml_free(element);
+}
+
+
+/**
+ * @brief Destroy a String Table element (for wbxml_list_destroy())
+ * @param element The element to destroy
+ */
+static void wbxml_strtbl_element_destroy_item(void *element)
+{
+    wbxml_strtbl_element_destroy((WBXMLStringTableElement *) element);
+}
+
+
+/**
+ * @brief Initialize the String Table
+ * @param encoder The WBXML Encoder
+ * @param root The root element of LibXML Tree
+ */
+static WBXMLError wbxml_strtbl_initialize(WBXMLEncoder *encoder, WBXMLTreeNode *root)
+{
+    WBXMLList *strings = NULL, *one_ref = NULL;
+    WBXMLError ret;
+
+    if ((strings = wbxml_list_create()) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Collect all Strings:
+     * [out] 'strings' is the list of pointers to WBXMLBuffer. This Buffers must not be freed.
+     */
+    wbxml_strtbl_collect_strings(encoder, root, strings);
+
+    /* Insert, in String Table, Strings that are referenced more than one time
+     * [out] 'strings' is NULL
+     *       'one_ref' is the list of strings referenced only ONE time (list of WBXMLStringTableElement*)
+     *       Strings referenced more than one time are added to String Table
+     */
+    if ((ret = wbxml_strtbl_check_references(encoder, &strings, &one_ref, TRUE)) != WBXML_OK) {
+        wbxml_list_destroy(strings, NULL);
+        return ret;
+    }
+
+    /* 'strings' is destroyed after call of wbxml_strtbl_check_references() */
+
+    /* Split Strings refered only one time in Words
+     * [out] 'strings' is the list of words. This words (WBXMLBuffer) must be freed
+     */
+    if ((ret = wbxml_strtbl_collect_words(one_ref, &strings)) != WBXML_OK) {
+        wbxml_list_destroy(one_ref, wbxml_strtbl_element_destroy_item);
+        return ret;
+    }
+
+    /* Destroy References List */
+    wbxml_list_destroy(one_ref, wbxml_strtbl_element_destroy_item);
+    one_ref = NULL;
+
+    /* Keep Strings referenced more than one time */
+    if (strings != NULL)
+        wbxml_strtbl_check_references(encoder, &strings, &one_ref, FALSE);
+
+    /* 'strings' is destroyed after call of wbxml_strtbl_check_references() */
+
+    /* Cleanup */
+    wbxml_list_destroy(one_ref, wbxml_strtbl_element_destroy_item);
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Collect Strings in XML Document (in Text Content and Attribute Values)
+ * @param encoder [in] The WBXML Encoder
+ * @param node [in] The current element node of LibXML Tree
+ * @param strings [out] List of WBXMLBuffer buffers corresponding to Collected Strings
+ */
+static void wbxml_strtbl_collect_strings(WBXMLEncoder *encoder, WBXMLTreeNode *node, WBXMLList *strings)
+{
+    const WBXMLAttrEntry *attr_entry = NULL;
+    WBXMLAttribute *attr = NULL;
+    WB_ULONG i = 0;
+    WB_UTINY *value_left = NULL;
+
+    switch (node->type)
+    {
+        case WBXML_TREE_TEXT_NODE:
+            /* Ignore blank nodes */
+            if (wbxml_buffer_contains_only_whitespaces(node->content))
+                break;
+
+            /** @todo Shrink / Strip Blanks */
+
+            /* Only add this string if it is big enought */
+            if (wbxml_buffer_len(node->content) > WBXML_ENCODER_STRING_TABLE_MIN) {
+                wbxml_list_append(strings, node->content);
+                WBXML_DEBUG((WBXML_ENCODER, "Strtbl - Collecting String: %s", wbxml_buffer_get_cstr(node->content)));
+            }
+            break;
+
+        case WBXML_TREE_ELEMENT_NODE:
+            /* Collect strings in Attributes Values too */
+            if (node->attrs != NULL) {
+                for (i = 0; i < wbxml_list_len(node->attrs); i++) {
+                    /* Get attribute */
+                    attr = wbxml_list_get(node->attrs, i);
+
+                    /* Only add this string if it is big enought */
+                    if (attr && wbxml_buffer_len(attr->value) > WBXML_ENCODER_STRING_TABLE_MIN) {
+                        /* This mustn't be a tokenisable Attribute Start */
+                        attr_entry = wbxml_tables_get_attr_from_xml(encoder->lang,
+                                                                   (WB_UTINY *) wbxml_attribute_get_xml_name(attr),
+                                                                   (WB_UTINY *) wbxml_attribute_get_xml_value(attr),
+                                                                   &value_left);
+
+                        /* - If attr_entry is NULL: no Attribute Start found
+                         * - If attr_entry is not NULL: and Attribute Start is found, but it can be the one with
+                         *   no Attribute Value associated. So just check that the 'value_left' is the same than
+                         *   the attribute value we where searching for
+                         */
+                        if ((attr_entry == NULL) || ((attr_entry != NULL) && (value_left == (WB_UTINY *) wbxml_attribute_get_xml_value(attr))))
+                        {
+                            /* It mustn't contain a tokenisable Attribute Value */
+                            if (!wbxml_tables_contains_attr_value_from_xml(encoder->lang,
+                                                                           (WB_UTINY *) wbxml_attribute_get_xml_value(attr)))
+                            {
+                                wbxml_list_append(strings, attr->value);
+                                WBXML_DEBUG((WBXML_ENCODER, "Strtbl - Collecting String: %s", wbxml_buffer_get_cstr(attr->value)));
+                            }
+                        }
+                    }
+                }
+            }
+            break;
+
+        default:
+            /* NOOP */
+            break;
+    }
+
+    if (node->children != NULL)
+        wbxml_strtbl_collect_strings(encoder, node->children, strings);
+
+    if (node->next != NULL)
+        wbxml_strtbl_collect_strings(encoder, node->next, strings);
+}
+
+
+/**
+ * @brief Split Strings into Words
+ * @param elements [in] List of String Table Elements to split
+ * @param result [out] Resulting list of Words
+ * @return WBXML_OK is no error, another error code otherwise
+ */
+static WBXMLError wbxml_strtbl_collect_words(WBXMLList *elements, WBXMLList **result)
+{
+    WBXMLStringTableElement *elt = NULL;
+    WBXMLList *list = NULL, *temp_list = NULL;
+    WBXMLBuffer *word = NULL;
+    WB_ULONG i = 0;
+
+    *result = NULL;
+
+    for (i = 0; i < wbxml_list_len(elements); i++)
+    {
+        elt = (WBXMLStringTableElement *) wbxml_list_get(elements, i);
+        if (elt == NULL) {
+            /* There is a bug inside the wbxml strtbl implementation.
+               wbxml_list must be used in a wrong way.
+             */
+            wbxml_list_destroy(list, wbxml_buffer_destroy_item);
+            return WBXML_ERROR_INTERNAL;
+        }
+
+        if (list == NULL) {
+            if ((list = wbxml_buffer_split_words(elt->string)) == NULL) {
+                wbxml_list_destroy(list, wbxml_buffer_destroy_item);
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+        } else {
+            if ((temp_list = wbxml_buffer_split_words(elt->string)) == NULL) {
+                wbxml_list_destroy(list, wbxml_buffer_destroy_item);
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+
+            while ((word = wbxml_list_extract_first(temp_list)) != NULL) {
+                if (!wbxml_list_append(list, word)) {
+                    wbxml_buffer_destroy(word);
+                    wbxml_list_destroy(temp_list, wbxml_buffer_destroy_item);
+                    wbxml_list_destroy(list, wbxml_buffer_destroy_item);
+                    return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                }
+            }
+
+            wbxml_list_destroy(temp_list, NULL);
+        }
+    }
+
+    *result = list;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Append the String Table to result Buffer
+ * @param buff The Buffer to append the String Table to
+ * @param strstbl The String Table to append
+ */
+static WBXMLError wbxml_strtbl_construct(WBXMLBuffer *buff, WBXMLList *strstbl)
+{
+    WBXMLStringTableElement *elt = NULL;
+    WB_ULONG i = 0;
+
+    if ((buff == NULL) || (strstbl == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    for (i = 0; i < wbxml_list_len(strstbl); i++)
+    {
+        if ((elt = wbxml_list_get(strstbl, i)) == NULL)
+            continue;
+        
+        if (!wbxml_buffer_append(buff, elt->string))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+            
+        if (!wbxml_buffer_append_char(buff, WBXML_STR_END))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+    
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Check strings that have multiple references, add them to string table
+ *        and return strings that have only one reference
+ * @param encoder The WBXML Encoder
+ * @param strings The List of Strings to check (List of WBXMLBuffer) : This list is freed by this function
+ * @param one_ref List of strings that have only one reference (List of WBXMLStringTableElement)
+ * @param stat_buff If set to TRUE, Buffers referenced by 'strings' must NOT be destroyed.
+ * @return WBXML_OK if no error, another error code otherwise
+ * @warning All elements of 'strings' list are removed from this list
+ */
+static WBXMLError wbxml_strtbl_check_references(WBXMLEncoder *encoder, WBXMLList **strings, WBXMLList **one_ref, WB_BOOL stat_buff)
+{
+    WBXMLList *referenced = NULL, *result = NULL;
+    WBXMLBuffer *string = NULL;
+    WBXMLStringTableElement *ref = NULL;
+    WB_ULONG j = 0;
+    WB_BOOL added = FALSE;
+
+    if ((strings == NULL) || (one_ref == NULL))
+        return WBXML_ERROR_INTERNAL;
+
+    *one_ref = NULL;
+
+    /* Create list of String References */
+    if ((referenced = wbxml_list_create()) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+
+    /*********************
+     * Count References
+     */
+
+    while (wbxml_list_len(*strings) > 0)
+    {
+        string = (WBXMLBuffer *) wbxml_list_extract_first(*strings);
+
+        /* Check if we have already found this String */
+        for (j = 0; j < wbxml_list_len(referenced); j++)
+        {
+            ref = (WBXMLStringTableElement *) wbxml_list_get(referenced, j);
+            if (ref == NULL) 
+            {
+                /* There is a bug inside wbxml_strtbl_check_references.
+                   wbxml_list must be used in a wrong way.
+                 */
+            	if (!stat_buff)
+                    wbxml_buffer_destroy(string);
+                string = NULL;
+                wbxml_list_destroy(referenced, wbxml_strtbl_element_destroy_item);
+                return WBXML_ERROR_INTERNAL;
+            }
+
+            if (wbxml_buffer_compare(ref->string, string) == 0)
+            {
+                if (!stat_buff)
+                    wbxml_buffer_destroy(string);
+
+                string = NULL;
+                ref->count++;
+                break;
+            }
+        }
+
+        if (string != NULL)
+        {
+            /* New Reference Element */
+            if ((ref = wbxml_strtbl_element_create(string, stat_buff)) == NULL)
+            {
+                wbxml_list_destroy(referenced, wbxml_strtbl_element_destroy_item);
+
+                if (!stat_buff)
+                    wbxml_list_destroy(*strings, wbxml_buffer_destroy_item);
+                else
+                    wbxml_list_destroy(*strings, NULL);
+
+                *strings = NULL;
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+
+            ref->count++;
+
+            if (!wbxml_list_append(referenced, (void *) ref))
+            {
+                wbxml_list_destroy(referenced, wbxml_strtbl_element_destroy_item);
+
+                if (!stat_buff)
+                    wbxml_list_destroy(*strings, wbxml_buffer_destroy_item);
+                else
+                    wbxml_list_destroy(*strings, NULL);
+
+                *strings = NULL;
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+        }
+    }
+
+
+    wbxml_list_destroy(*strings, NULL);
+    *strings = NULL;
+
+
+    /***********************************************
+     * Remove Strings that have only One reference
+     */
+
+    if ((result = wbxml_list_create()) == NULL) {
+        wbxml_list_destroy(referenced, wbxml_strtbl_element_destroy_item);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    while (wbxml_list_len(referenced) > 0)
+    {
+        ref = (WBXMLStringTableElement *) wbxml_list_extract_first(referenced);
+        if ((ref->count > 1) && (wbxml_buffer_len(ref->string) > WBXML_ENCODER_STRING_TABLE_MIN)) {
+            /* Add Element to String Table */
+            if (!wbxml_strtbl_add_element(encoder, ref, NULL, &added)) {
+                wbxml_strtbl_element_destroy(ref);
+                wbxml_list_destroy(referenced, wbxml_strtbl_element_destroy_item);
+                wbxml_list_destroy(result, wbxml_strtbl_element_destroy_item);
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+
+            if (!added) {
+                wbxml_strtbl_element_destroy(ref);
+            }
+        }
+        else {
+            /* Add Element in resulting 'not added in String Table' list */
+            if (!wbxml_list_append(result, (void *) ref)) {
+                wbxml_strtbl_element_destroy(ref);
+                wbxml_list_destroy(referenced, wbxml_strtbl_element_destroy_item);
+                wbxml_list_destroy(result, wbxml_strtbl_element_destroy_item);
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+        }
+    }
+
+    wbxml_list_destroy(referenced, wbxml_strtbl_element_destroy_item);
+
+    *one_ref = result;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Add a String in String table
+ * @param encoder [in] The WBXML Encoder
+ * @param elt [in] The Element to add
+ * @param index [out] The index in String Table
+ * @param added [out] TRUE if really added, or FALSe if already in String Table
+ * @return TRUE if no error, FALSE is Memory Error
+ */
+static WB_BOOL wbxml_strtbl_add_element(WBXMLEncoder *encoder, WBXMLStringTableElement *elt, WB_ULONG *index, WB_BOOL *added)
+{
+    WBXMLStringTableElement *elt_tmp = NULL;
+    WB_ULONG i = 0;
+
+    if ((encoder == NULL) || (encoder->strstbl == NULL) || (elt == NULL) || (elt->string == NULL))
+        return FALSE;
+
+    *added = FALSE;
+
+    /* Check if this element already exists in String Table */
+    for (i = 0; i < wbxml_list_len(encoder->strstbl); i++)
+    {
+        if ((elt_tmp = wbxml_list_get(encoder->strstbl, i)) == NULL)
+            continue;
+
+        if ((wbxml_buffer_len(elt_tmp->string) == wbxml_buffer_len(elt->string)) &&
+            (wbxml_buffer_compare(elt_tmp->string, elt->string) == 0))
+        {
+            /* The String already exists in the String Table */
+            if (index != NULL)
+                *index = elt_tmp->offset;
+            return TRUE;
+        }
+    }
+
+    /* Add this string to String Table */
+    elt->offset = encoder->strstbl_len;
+
+    if (!wbxml_list_append(encoder->strstbl, (void *) elt))
+        return FALSE;
+
+    /* Index in String Table */
+    if (index != NULL)
+        *index = encoder->strstbl_len;
+
+    /* New String Table length */
+    encoder->strstbl_len += wbxml_buffer_len(elt->string) + 1;
+
+    *added = TRUE;
+
+    return TRUE;
+}
+
+#endif /* WBXML_ENCODER_USE_STRTBL */
+
+
+/*****************************************
+ *  XML Output Functions
+ */
+
+/****************************
+ * Build XML Result
+ */
+
+/**
+ * @brief Build XML Result
+ * @param encoder [in] The WBXML Encoder
+ * @param xml     [out] Resulting XML document
+ * @param xml_len [out] XML document length
+ * @return WBXML_OK if built is OK, an error code otherwise
+ */
+static WBXMLError xml_build_result(WBXMLEncoder *encoder, WB_UTINY **xml, WB_ULONG *xml_len)
+{
+    WBXMLBuffer *header = NULL;
+    WB_ULONG     len    = 0;
+    WBXMLError   ret    = WBXML_OK;
+
+    if (xml == NULL)
+        return WBXML_ERROR_BAD_PARAMETER;
+    
+    /* Init */
+    if (xml_len != NULL)
+        *xml_len = 0;
+    
+    if (encoder->flow_mode == TRUE) {
+        /* Header already built */
+        header = encoder->output_header;
+    }
+    else {
+        /* Create Header Buffer */
+        if ((header = wbxml_buffer_create("", 0, WBXML_ENCODER_XML_HEADER_MALLOC_BLOCK)) == NULL)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+        /* Fill Header Buffer */
+        if (encoder->xml_encode_header) {
+            if ((ret = xml_fill_header(encoder, header)) != WBXML_OK) {
+                wbxml_buffer_destroy(header);
+                return ret;
+            }
+        }
+    }
+
+    /* Result Buffer Length */
+    len = wbxml_buffer_len(header) + wbxml_buffer_len(encoder->output);
+
+    /* Create Result Buffer */
+    *xml = wbxml_malloc((len + 1) * sizeof(WB_UTINY));
+    if (*xml == NULL) {
+        if (encoder->flow_mode == FALSE)
+            wbxml_buffer_destroy(header);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /** @todo Use the 'output_charset' field */
+
+    /* Copy Header to Result */
+    memcpy(*xml, wbxml_buffer_get_cstr(header), wbxml_buffer_len(header));
+
+    /* Copy XML Document to Result */
+    memcpy(*xml + wbxml_buffer_len(header), wbxml_buffer_get_cstr(encoder->output), wbxml_buffer_len(encoder->output));
+
+    /** @todo Remove this NULL char if not needed by charset */
+
+    /* NULL Terminated Buffer */
+    (*xml)[len] = '\0';
+
+    /* Set length */
+    if (xml_len != NULL)
+        *xml_len = len;
+
+    /* Clean-up */
+    if (encoder->flow_mode == FALSE)
+        wbxml_buffer_destroy(header);
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Fill the XML Header
+ * @param encoder The WBXML Encoder
+ * @param header The Buffer to Fill
+ * @return WBXML_OK if built is OK, an error code otherwise
+ */
+static WBXMLError xml_fill_header(WBXMLEncoder *encoder, WBXMLBuffer *header)
+{
+    if ((encoder == NULL) || (header == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    /** @todo Add 'encoding' info */
+
+    /* <?xml version=\"1.0\"?> */
+    if (!wbxml_buffer_append_cstr(header, WBXML_ENCODER_XML_HEADER))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* New Line */
+    if (encoder->xml_gen_type == WBXML_GEN_XML_INDENT) {
+        if (!xml_encode_new_line(header))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+
+    /* <!DOCTYPE */
+    if (!wbxml_buffer_append_cstr(header, WBXML_ENCODER_XML_DOCTYPE))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Check that the language is set */
+    if (encoder->lang == NULL)
+        return WBXML_ERROR_LANG_TABLE_UNDEFINED;
+
+    /* Root Element */
+    if (!wbxml_buffer_append_cstr(header, encoder->lang->publicID->xmlRootElt))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    if (encoder->lang->publicID->xmlPublicID &&
+        WBXML_STRLEN(encoder->lang->publicID->xmlPublicID)) {
+
+        /*  PUBLIC " */
+        if (!wbxml_buffer_append_cstr(header, WBXML_ENCODER_XML_PUBLIC_START))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+        /* Public ID */
+        if (!wbxml_buffer_append_cstr(header, encoder->lang->publicID->xmlPublicID))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+        /* " */
+        if (!wbxml_buffer_append_cstr(header, WBXML_ENCODER_XML_PUBLIC_END))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+    } else {
+	/*  SYSTEM */
+        if (!wbxml_buffer_append_cstr(header, WBXML_ENCODER_XML_SYSTEM))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+
+    /* DTD */
+    if (!wbxml_buffer_append_cstr(header, WBXML_ENCODER_XML_DTD))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* DTD */
+    if (!wbxml_buffer_append_cstr(header, encoder->lang->publicID->xmlDTD))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* "> */
+    if (!wbxml_buffer_append_cstr(header, WBXML_ENCODER_XML_END_DTD))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* New Line */
+    if (encoder->xml_gen_type == WBXML_GEN_XML_INDENT) {
+        if (!xml_encode_new_line(header))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+
+    return WBXML_OK;
+}
+
+
+/****************************
+ * XML Encoding Functions
+ */
+
+/**
+ * @brief Encode an XML Tag
+ * @param encoder The WBXML Encoder
+ * @param node The element to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_tag(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+    const WB_TINY *ns = NULL;
+    WB_UTINY i;
+
+    /* Set as current Tag */
+    if (node->name->type == WBXML_VALUE_TOKEN)
+        encoder->current_tag = node->name->u.token;
+    else
+        encoder->current_tag = NULL;
+
+    /* Indent */
+    if (encoder->xml_gen_type == WBXML_GEN_XML_INDENT) {
+        for (i=0; i<(encoder->indent * encoder->indent_delta); i++) {
+            if (!wbxml_buffer_append_char(encoder->output, ' '))
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+    }
+
+    /* Append < */
+    if (!wbxml_buffer_append_char(encoder->output, '<'))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Append Element Name */
+    if (!wbxml_buffer_append_cstr(encoder->output, wbxml_tag_get_xml_name(node->name)))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* NameSpace handling: Check if Current Node Code Page is different than Parent Node Code Page */
+    if ((encoder->lang->nsTable != NULL) &&
+        ((node->parent == NULL) ||
+         ((node->parent->type == WBXML_TREE_ELEMENT_NODE) &&
+          (node->parent->name->type == WBXML_VALUE_TOKEN) &&
+          (node->type == WBXML_TREE_ELEMENT_NODE) &&
+          (node->name->type == WBXML_VALUE_TOKEN) &&
+          (node->parent->name->u.token->wbxmlCodePage != node->name->u.token->wbxmlCodePage))))
+    {
+        if ((ns = wbxml_tables_get_xmlns(encoder->lang->nsTable, node->name->u.token->wbxmlCodePage)) != NULL)
+        {
+            /* Append xmlns=" */
+            if (!wbxml_buffer_append_cstr(encoder->output, " xmlns=\""))
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+            /* Append NameSpace */
+            if (!wbxml_buffer_append_cstr(encoder->output, ns))
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+            /* Append " */
+            if (!wbxml_buffer_append_char(encoder->output, '"'))
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+    }
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode an XML End Tag
+ * @param encoder The WBXML Encoder
+ * @param node Tag
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_end_tag(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+    WB_UTINY i;
+
+    if (encoder->xml_gen_type == WBXML_GEN_XML_INDENT) {
+
+#if defined( WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT )
+        if (wbxml_tree_node_have_child_elt(node)) {
+#endif /* WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT */
+
+            /* Add a New Line if there were content in this element */
+            if (encoder->in_content) {
+                if (!xml_encode_new_line(encoder->output))
+                    return WBXML_ERROR_ENCODER_APPEND_DATA;
+            }
+
+            encoder->indent--;
+
+            /* Indent End Element */
+            for (i=0; i<(encoder->indent * encoder->indent_delta); i++) {
+                if (!wbxml_buffer_append_char(encoder->output, ' '))
+                    return WBXML_ERROR_ENCODER_APPEND_DATA;
+            }
+
+#if defined( WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT )
+        }
+#endif /* WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT */
+
+    }
+
+    /* Append </ */
+    if (!wbxml_buffer_append_cstr(encoder->output, "</"))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Append Element Name */
+    if (!wbxml_buffer_append_cstr(encoder->output, wbxml_tag_get_xml_name(node->name)))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Append > */
+    if (!wbxml_buffer_append_char(encoder->output, '>'))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* New Line */
+    if (encoder->xml_gen_type == WBXML_GEN_XML_INDENT) {
+        if (!xml_encode_new_line(encoder->output))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+
+    /* No more in content */
+    encoder->in_content = FALSE;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a XML Attribute
+ * @param encoder [in] The WBXML Encoder
+ * @param attribute [in] The Attribute to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_attr(WBXMLEncoder *encoder, WBXMLAttribute *attribute)
+{
+    /* Append a space */
+    if (!wbxml_buffer_append_char(encoder->output, ' '))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Append Attribute Name */
+    if (!wbxml_buffer_append_cstr(encoder->output, wbxml_attribute_get_xml_name(attribute)))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    /* Append =" */
+    if (!wbxml_buffer_append_cstr(encoder->output, "=\""))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    if (wbxml_attribute_get_xml_value(attribute) != NULL) {
+        /* Fix Attribute Value text */
+        WBXMLBuffer *tmp = NULL;
+
+        /* Work with a temporary copy */
+        if ((tmp = wbxml_buffer_create_from_cstr(wbxml_attribute_get_xml_value(attribute))) == NULL)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+        /* Fix text */
+        if (xml_encode_text_entities(encoder, tmp)) {
+            wbxml_buffer_destroy(tmp);
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+
+        wbxml_buffer_destroy(tmp);
+    }
+
+    /* Append " */
+    if (!wbxml_buffer_append_char(encoder->output, '"'))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a End of XML Attributes List
+ * @param encoder [in] The WBXML Encoder
+ * @param node    [in] Current node
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_end_attrs(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+#if defined( WBXML_ENCODER_XML_GEN_EMPTY_ELT )
+
+    if (node->children == NULL) {
+        /* Append " />" */
+        if (!wbxml_buffer_append_cstr(encoder->output, "/>"))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+        /* New Line */
+        if (encoder->xml_gen_type == WBXML_GEN_XML_INDENT) {
+            if (!xml_encode_new_line(encoder->output))
+                return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+    }
+    else {
+
+#endif /* WBXML_ENCODER_XML_GEN_EMPTY_ELT */
+            
+        /* Append > */
+        if (!wbxml_buffer_append_char(encoder->output, '>'))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+        /* New Line */
+        if (encoder->xml_gen_type == WBXML_GEN_XML_INDENT) {
+
+#if defined( WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT )
+            if (wbxml_tree_node_have_child_elt(node)) {
+#endif /* WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT */
+
+                if (!xml_encode_new_line(encoder->output))
+                    return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+                /* Increment indentation */
+                encoder->indent++;
+
+#if defined( WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT )
+            }
+#endif /* WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT */
+
+        }
+
+#if defined( WBXML_ENCODER_XML_GEN_EMPTY_ELT )
+
+    }
+
+#endif /* WBXML_ENCODER_XML_GEN_EMPTY_ELT */
+
+    return WBXML_OK;
+}
+
+/**
+ * @brief Encode an XML Text
+ * @param encoder The WBXML Encoder
+ * @param node    The node containing XML Text to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_text(WBXMLEncoder *encoder, WBXMLTreeNode *node)
+{
+    WBXMLBuffer *str = node->content;
+    WBXMLBuffer *tmp = NULL;
+    WB_UTINY i = 0;
+
+    if (encoder->in_cdata) {
+        /* If we are in a CDATA section, do not modify the text to encode */
+        if (!wbxml_buffer_append(encoder->output, str))
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+    }
+    else {
+        /* Work with a temporary copy */
+        if ((tmp = wbxml_buffer_duplicate(str)) == NULL)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+        /* Indent */
+        if ((encoder->xml_gen_type == WBXML_GEN_XML_INDENT) &&
+            (!encoder->in_content))
+        {
+#if defined( WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT )
+            if (wbxml_tree_node_have_child_elt(node)) {
+#endif /* WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT */
+
+                /* Indent Content (only indent in first call to xml_encode_text()) */
+                for (i=0; i<(encoder->indent * encoder->indent_delta); i++) {
+                    if (!wbxml_buffer_append_char(encoder->output, ' ')) {
+                        wbxml_buffer_destroy(tmp);
+                        return WBXML_ERROR_ENCODER_APPEND_DATA;
+                    }
+                }
+
+#if defined( WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT )
+            }
+#endif /* WBXML_ENCODER_XML_NO_EMPTY_ELT_INDENT */
+        }
+
+#if defined( WBXML_SUPPORT_SYNCML )
+        /* Change text in <Type> from "application/vnd.syncml-devinf+wbxml" to "application/vnd.syncml-devinf+xml" */
+        if (((encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML10) ||
+             (encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML11) ||
+             (encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML12)) &&
+            (encoder->current_tag != NULL) &&
+            (encoder->current_tag->wbxmlCodePage == 0x01 ) &&
+            (encoder->current_tag->wbxmlToken == 0x13 ) &&
+            (wbxml_buffer_compare_cstr(tmp, "application/vnd.syncml-devinf+wbxml") == 0))
+        {
+            wbxml_buffer_destroy(tmp);
+
+            /* Change Content */
+            if ((tmp = wbxml_buffer_create_from_cstr("application/vnd.syncml-devinf+xml")) == NULL)
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+        /* Change text in <Type> from "application/vnd.syncml.dmtnds+wbxml" to "application/vnd.syncml.dmtnds+xml" */
+        if ((encoder->lang->langID == WBXML_LANG_SYNCML_SYNCML12) &&
+            (encoder->current_tag != NULL) &&
+            (encoder->current_tag->wbxmlCodePage == 0x01 ) &&
+            (encoder->current_tag->wbxmlToken == 0x13 ) &&
+            (wbxml_buffer_compare_cstr(tmp, "application/vnd.syncml.dmtnds+wbxml") == 0))
+        {
+            wbxml_buffer_destroy(tmp);
+
+            /* Change Content */
+            if ((tmp = wbxml_buffer_create_from_cstr("application/vnd.syncml.dmtnds+xml")) == NULL)
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+#endif /* WBXML_SUPPORT_SYNCML */
+
+        /* Some elements are transferred as WBXML opaque data. They contain
+         * binary data that isn't necessary valid in XML, so return them in Base
+         * 64.
+         */
+        if (encoder->current_tag != NULL &&
+            encoder->current_tag->options & WBXML_TAG_OPTION_BINARY)
+        {
+            WBXMLError ret;
+            if ((ret = wbxml_buffer_encode_base64(tmp)) != WBXML_OK) {
+                wbxml_buffer_destroy(tmp);
+                return ret;
+            }
+        }
+
+        /* Fix text */
+        if (xml_encode_text_entities(encoder, tmp)) {
+            wbxml_buffer_destroy(tmp);
+            return WBXML_ERROR_ENCODER_APPEND_DATA;
+        }
+
+        /* Clean-up */
+        wbxml_buffer_destroy(tmp);
+    }
+
+    encoder->in_content = TRUE;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Append a New Line to a Buffer
+ * @param buff The Buffer
+ * @return TRUE if added, FALSE otherwise
+ */
+static WB_BOOL xml_encode_new_line(WBXMLBuffer *buff)
+{
+    if (buff == NULL)
+        return FALSE;
+
+    return wbxml_buffer_append_data(buff, WBXML_ENCODER_XML_NEW_LINE, WBXML_STRLEN(WBXML_ENCODER_XML_NEW_LINE));
+}
+
+
+/**
+ * @brief Fix an XML text buffer (content text or attribute value)
+ * @param buff The Buffer to fix
+ * @param normalize Normalize text ?
+ * @return WBXML_OK if ok, an Error Code otherwise
+ * @note Reference: http://www.w3.org/TR/2004/REC-xml-20040204/#syntax
+ */
+static WBXMLError xml_encode_text_entities(WBXMLEncoder *encoder, WBXMLBuffer *buff)
+{
+    WB_ULONG i = 0;
+    WB_UTINY ch;
+    WB_BOOL normalize = (WB_BOOL) (encoder->xml_gen_type == WBXML_GEN_XML_CANONICAL);
+
+    for (i = 0; i < wbxml_buffer_len(buff); i++) {
+        if (!wbxml_buffer_get_char(buff, i, &ch))
+            continue;
+
+        switch (ch) {
+        case '<':
+            /* Write "&lt;" */
+            if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_lt))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+            break;
+
+        case '>':
+            /* Write "&gt;" */
+            if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_gt))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+            break;
+
+        case '&':
+            /* Write "&amp;" */
+            if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_amp))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+            break;
+
+        case '"':
+            /* Write "&quot;" */
+            if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_quot))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+            break;
+
+        case '\'':
+            /* Write "&apos;" */
+            if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_apos))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+            break;
+
+        case '\r':
+            if (normalize) {
+                /* Write "&#13;" */
+                if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_slashr))
+                    return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+                break;
+            }
+
+        case '\n':
+            if (normalize) {
+                /* Write "&#10;" */
+                if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_slashn))
+                    return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                break;
+            }
+
+        case '\t':
+            if (normalize) {
+                /* Write "&#9;" */
+                if (!wbxml_buffer_append_cstr(encoder->output, (WB_UTINY *) xml_tab))
+                    return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                break;
+            }
+
+        default:
+            if (!wbxml_buffer_append_char(encoder->output, ch))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+            break;
+        }
+    }
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode a begin of CDATA section
+ * @param encoder The WBXML Encoder
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_cdata(WBXMLEncoder *encoder)
+{
+    /* Append <![CDATA[ */
+    if (!wbxml_buffer_append_cstr(encoder->output, "<![CDATA["))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode an end of CDATA section
+ * @param encoder The WBXML Encoder
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_end_cdata(WBXMLEncoder *encoder)
+{
+    /* Append ]]> */
+    if (!wbxml_buffer_append_cstr(encoder->output, "]]>"))
+        return WBXML_ERROR_ENCODER_APPEND_DATA;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Encode an encapsulated WBXML Tree to XML
+ * @param encoder [in] The WBXML Encoder
+ * @param tree    [in] The WBXML Tree to encode
+ * @return WBXML_OK if encoding is OK, an error code otherwise
+ */
+static WBXMLError xml_encode_tree(WBXMLEncoder *encoder, WBXMLTree *tree)
+{
+    WBXMLEncoder *new_encoder = NULL;
+    WB_UTINY     *xml         = NULL;
+    WB_ULONG      xml_len     = 0;
+    WBXMLError    ret         = WBXML_OK;
+
+    if ((new_encoder = encoder_duplicate(encoder)) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Set Tree */
+    new_encoder->tree = tree;
+
+    /* Encode to XML */
+    if ((ret = wbxml_encoder_encode_tree_to_xml(new_encoder, &xml, &xml_len)) != WBXML_OK) {
+        wbxml_encoder_destroy(new_encoder);
+        return ret;
+    }
+
+    /* Clean-up */
+    wbxml_encoder_destroy(new_encoder);
+
+    /** @bug Handle output_charset ! */
+
+    /* Append xml to output */
+    if (!wbxml_buffer_append_cstr(encoder->output, xml)) {
+        wbxml_free(xml);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Clean-up */
+    wbxml_free(xml);
+
+    return WBXML_OK;
+}

--- a/src/libwbxml/wbxml_encoder.h
+++ b/src/libwbxml/wbxml_encoder.h
@@ -1,0 +1,319 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_encoder.h
+ * @ingroup wbxml_encoder
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 11/11/02
+ *
+ * @brief WBXML Encoder - Encodes a WBXML Tree to WBXML or to XML
+ */
+
+#ifndef WBXML_ENCODER_H
+#define WBXML_ENCODER_H
+
+#include "wbxml.h"
+#include "wbxml_tree.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_encoder
+ *  @{ 
+ */
+
+/**
+ * @brief WBXML Encoder
+ */
+typedef struct WBXMLEncoder_s WBXMLEncoder;
+
+/**
+ * @brief WBXML Encoder Output Type
+ */
+typedef enum WBXMLEncoderOutputType_e {
+    WBXML_ENCODER_OUTPUT_WBXML = 0,
+    WBXML_ENCODER_OUTPUT_XML
+} WBXMLEncoderOutputType;
+
+
+/**
+ * @brief Create a WBXML Encoder
+ * @result Return the newly created WBXMLEncoder, or NULL if not enough memory
+ * @warning Do NOT use this function directly, use wbxml_encoder_create() macro instead
+ */
+WBXML_DECLARE(WBXMLEncoder *) wbxml_encoder_create_real(void);
+#define wbxml_encoder_create() wbxml_mem_cleam(wbxml_encoder_create_real())
+
+/**
+ * @brief Destroy a WBXML Encoder
+ * @param encoder The WBXMLEncoder to free
+ */
+WBXML_DECLARE(void) wbxml_encoder_destroy(WBXMLEncoder *encoder);
+
+/**
+ * @brief Reset a WBXML Encoder
+ * @param encoder The WBXMLEncoder to reset
+ */
+WBXML_DECLARE(void) wbxml_encoder_reset(WBXMLEncoder *encoder);
+
+
+/**
+ * @brief Set the WBXML Encoder to ignore empty texts (ie: ignorable Whitespaces) [Default: FALSE]
+ * @param encoder [in] The WBXML Encoder
+ * @param set_ignore [in] TRUE if ignore, FALSE otherwise
+ * @warning This behaviour can me overriden by the WBXML_GEN_XML_CANONICAL mode (set by wbxml_encoder_set_xml_gen_type())
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_ignore_empty_text(WBXMLEncoder *encoder, WB_BOOL set_ignore);
+
+/**
+ * @brief Set the WBXML Encoder to remove leading and trailing blanks in texts [Default: FALSE]
+ * @param encoder [in] The WBXML Encoder
+ * @param set_remove [in] TRUE if remove, FALSE otherwise
+ * @warning This behaviour can me overriden by the WBXML_GEN_XML_CANONICAL mode (set by wbxml_encoder_set_xml_gen_type())
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_remove_text_blanks(WBXMLEncoder *encoder, WB_BOOL set_remove);
+
+/**
+ * @brief Set output document Charset Encoding
+ * @param encoder [in] The WBXML Encoder
+ * @param charset [in] The Charset to set
+ * @note - This overrides the Charset Encoding found in WBXML Tree.
+ *       - If not set with this function, the 'orig_charset' field of the WBXML Tree is used
+ *         (ie the Charset Encoding of the original document).
+ *       - If no 'orig_charset' is set in WBXML Tree, the default charset is used : 
+ *          - 'WBXML_ENCODER_WBXML_DEFAULT_CHARSET' when encoding to XML
+ *          - 'WBXML_ENCODER_XML_DEFAULT_CHARSET' when encoding to WBXML
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_output_charset(WBXMLEncoder *encoder, WBXMLCharsetMIBEnum charset);
+
+
+/**
+ * @brief Set if we use String Table when Encoding into WBXML [Default: TRUE]
+ * @param encoder [in] The WBXML Encoder
+ * @param use_strtbl [in] TRUE if we use String Table, FALSE otherwise
+ * @note This function has no effect if WBXML_ENCODER_USE_STRTBL compilation flag is not set
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_use_strtbl(WBXMLEncoder *encoder, WB_BOOL use_strtbl);
+
+/**
+ * @brief Set if we want to produce anonymous WBXML documents [Default: FALSE]
+ * @param encoder [in] The WBXML encoder
+ * @param set_anonymous [in] TRUE to produce anonymous documents, FALSE otherwise
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_produce_anonymous(WBXMLEncoder *encoder, WB_BOOL set_anonymous);
+
+/**
+ * @brief Set the WBXML Version of the output document, when generating WBXML [Default: 'WBXML_VERSION_TOKEN_13' (1.3)]
+ * @param encoder [in] The WBXML Encoder
+ * @param version [in] The WBXML Version
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_wbxml_version(WBXMLEncoder *encoder, WBXMLVersion version);
+
+
+/**
+ * @brief Set the WBXML Encoder XML Generation Type, when generating XML [Default: WBXML_GEN_XML_COMPACT]
+ * @param encoder [in] The WBXML Encoder
+ * @param gen_type [in] Generation Type (cf. WBXMLEncoderXMLGen enum)
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_xml_gen_type(WBXMLEncoder *encoder, WBXMLGenXMLType gen_type);
+
+/**
+ * @brief Set the WBXML Encoder indent, when generating XML in WBXML_GEN_XML_INDENT mode [Default: 0]
+ * @param encoder [in] The WBXML Encoder
+ * @param indent [in] If 'WBXML_GEN_XML_INDENT' type is used, this is the number of spaces for indent
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_indent(WBXMLEncoder *encoder, WB_UTINY indent);
+
+
+/**
+ * @brief Set the WBXML Tree to encode
+ *
+ * Use this method before calling wbxml_encoder_encode_tree_to_wbxml() or wbxml_encoder_encode_tree_to_xml().
+ *
+ * @param encoder [in] The WBXML Encoder to use
+ * @param tree [in] The WBXML Tree to encode
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_tree(WBXMLEncoder *encoder, WBXMLTree *tree);
+
+/**
+ * @brief Encode the WBXML Tree attached to this encoder into WBXML
+ *
+ * Call wbxml_encoder_set_tree() before using this method.
+ *
+ * @param encoder [in] The WBXML Encoder to use
+ * @param wbxml [out] Resulting WBXML document
+ * @param wbxml_len [out] The resulting WBXML document length
+ * @return Return WBXML_OK if no error, an error code otherwise
+ * @warning The 'encoder->tree' WBXMLLib Tree MUST be already set with a call to wbxml_encoder_set_tree() function
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_tree_to_wbxml(WBXMLEncoder *encoder, WB_UTINY **wbxml, WB_ULONG *wbxml_len);
+
+/* BC */
+#define wbxml_encoder_encode_to_wbxml(a,b,c) wbxml_encoder_encode_tree_to_wbxml(a,b,c)
+
+/**
+ * @brief Encode the WBXML Tree attached to this encoder into XML
+ *
+ * Call wbxml_encoder_set_tree() before using this method.
+ *
+ * @param encoder [in] The WBXML Encoder to use
+ * @param xml     [out] Resulting XML document
+ * @param xml_len [out] XML document length
+ * @return Return WBXML_OK if no error, an error code otherwise
+ * @warning The 'encoder->tree' WBXMLLib Tree MUST be already set with a call to wbxml_encoder_set_tree() function
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_tree_to_xml(WBXMLEncoder *encoder, WB_UTINY **xml, WB_ULONG *xml_len);
+
+/* BC */
+#define wbxml_encoder_encode_to_xml(a,b,c) wbxml_encoder_encode_tree_to_xml(a,b,c)
+
+
+/**
+ * @brief Set the encoder into 'Flow Mode' (to encode nodes directly)
+ *
+ * Use this method to the set the encoder in 'Flow Mode'. This permits to encode WBXML Nodes 'on the fly', without
+ * having to encode a whole WBXML Tree.
+ *
+ * You should use this function (with TRUE parameter) before calling wbxml_encoder_encode_node().
+ *
+ * @param encoder   [in] The WBXML Encoder to use
+ * @param flow_mode [in] Set Flow Mode ?
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_set_flow_mode(WBXMLEncoder *encoder, WB_BOOL flow_mode);
+
+/**
+ * @brief Set the output type (WBXML_ENCODER_OUTPUT_XML | WBXML_ENCODER_OUTPUT_WBXML)
+ * @param encoder [in] The WBXML Encoder
+ * @param output_type [in] The output type
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_output_type(WBXMLEncoder *encoder, WBXMLEncoderOutputType output_type);
+
+/**
+ * @brief Set the language to use
+ * @param encoder [in] The WBXML Encoder
+ * @param lang    [in] The language to use
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_lang(WBXMLEncoder *encoder, WBXMLLanguage lang);
+
+/**
+ * @brief Generate textual Public ID instead of token
+ * @param encoder  [in] The WBXML Encoder
+ * @param gen_text [in] Set or unset
+ */
+WBXML_DECLARE(void) wbxml_encoder_set_text_public_id(WBXMLEncoder *encoder, WB_BOOL gen_text); 
+
+/**
+ * @brief Encode a WBXML Tree Node
+ *
+ * This function directly encode a WBXMLTreeNode. So you can use if you don't want to encode a whole WBXML Tree.
+ *
+ * You should call wbxml_encoder_set_flow_mode(TRUE), wbxml_encoder_set_output_type() before using this function.
+ * You must call wbxml_encoder_set_lang() before using this function.
+ *
+ * @param encoder [in] The WBXML Encoder to use
+ * @param node    [in] The WBXML Tree Node to encode
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_node(WBXMLEncoder *encoder, WBXMLTreeNode *node);
+
+/**
+ * @brief Encode node, but if node is an Element, choose the encode 'end' tag or not
+ *
+ * @param encoder [in] The WBXML Encoder to use
+ * @param node    [in] The WBXML Tree Node to encode
+ * @param enc_end [in] Encoded element 'end' ?
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_node_with_elt_end(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL enc_end);
+
+/**
+ * @brief Encode a WBXML Tree
+ *
+ * You should call wbxml_encoder_set_flow_mode(TRUE), wbxml_encoder_set_output_type() before using this function.
+ *
+ * @param encoder [in] The WBXML Encoder to use
+ * @param tree    [in] The WBXML Tree to encode
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_tree(WBXMLEncoder *encoder, WBXMLTree *tree);
+
+/**
+ * @brief Encode a raw element start
+ * @param encoder     [in] The WBXML Encoder to use
+ * @param node        [in] The WBXML Tree Node representing the element start to encode
+ * @param has_content [in] Does the element has content ?
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_raw_elt_start(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content);
+
+/**
+ * @brief Encode a raw element end
+ * @param encoder     [in] The WBXML Encoder to use
+ * @param node        [in] The WBXML Tree Node representing the element end to encode
+ * @param has_content [in] Does the element has content ?
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_encode_raw_elt_end(WBXMLEncoder *encoder, WBXMLTreeNode *node, WB_BOOL has_content);
+
+/**
+ * @brief Get currently encoded buffer
+ * @param encoder    [in] The WBXML Encoder to use
+ * @param result     [out] Resulting buffer
+ * @param result_len [out] Resulting buffer length
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_encoder_get_output(WBXMLEncoder *encoder, WB_UTINY **result, WB_ULONG *result_len);
+
+/**
+ * @brief Get currently encoded buffer length
+ * @param encoder [in] The WBXML Encoder to use
+ * @return Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WB_ULONG) wbxml_encoder_get_output_len(WBXMLEncoder *encoder);
+
+/**
+ * @brief Delete bytes from output buffer (from end of buffer)
+ * @param encoder [in] The WBXML Encoder to use
+ * @param nb      [in] Number of bytes to delete
+ */
+WBXML_DECLARE(void) wbxml_encoder_delete_output_bytes(WBXMLEncoder *encoder, WB_ULONG nb);
+
+/**
+ * @brief Delete last encoded node
+ * @param encoder [in] The WBXML Encoder to use
+ */
+WBXML_DECLARE(void) wbxml_encoder_delete_last_node(WBXMLEncoder *encoder);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_ENCODER_H */

--- a/src/libwbxml/wbxml_errors.c
+++ b/src/libwbxml/wbxml_errors.c
@@ -1,0 +1,136 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_errors.c
+ * @ingroup wbxml_errors
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/11/18
+ *
+ * @brief WBXML Error Codes Handling
+ */
+
+#include "wbxml_errors.h"
+#include <stdio.h>
+
+
+/**
+ * @brief Error Code item
+ */
+typedef struct WBXMLErrorCodeItem_s {
+    WBXMLError     code;    /**< Error Code */
+    const WB_TINY *string;  /**< Error Description */
+} WBXMLErrorCodeItem;
+
+
+/**
+ * @brief Error Code table
+ */
+static const WBXMLErrorCodeItem error_table [] = {
+    /* Generic Errors */
+    { WBXML_OK,                                 "No Error" },
+    { WBXML_NOT_ENCODED,                        "Not Encoded" },
+    { WBXML_ERROR_ATTR_TABLE_UNDEFINED,         "Attribute Table Undefined" },
+    { WBXML_ERROR_BAD_DATETIME,                 "Bad Datetime Format" },
+    { WBXML_ERROR_BAD_PARAMETER,                "Bad Parameter" },
+    { WBXML_ERROR_INTERNAL,                     "Internal Error" },
+    { WBXML_ERROR_LANG_TABLE_UNDEFINED,         "Languages Table Undefined" },
+    { WBXML_ERROR_NOT_ENOUGH_MEMORY,            "Not Enough Memory" },
+    { WBXML_ERROR_NOT_IMPLEMENTED,              "Not Implemented" },
+    { WBXML_ERROR_TAG_TABLE_UNDEFINED,          "Tag Table Undefined" },
+    { WBXML_ERROR_B64_ENC,                      "Failed to encode Base64" },
+    { WBXML_ERROR_B64_DEC,                      "Failed to decode Base64" },
+#if defined( WBXML_SUPPORT_WV )
+    { WBXML_ERROR_WV_DATETIME_FORMAT,           "Bad Wireless-Village Date and Time Format" },
+#endif /* WBXML_SUPPORT_WV */
+    { WBXML_ERROR_NO_CHARSET_CONV,              "No built-in charset convertor (Compiled without libiconv)" },
+    { WBXML_ERROR_CHARSET_STR_LEN,              "Bad string length, can't convert" },
+    /* WBXML Parser Errors */
+    { WBXML_ERROR_ATTR_VALUE_TABLE_UNDEFINED,   "Attribute Value Table Undefined" },
+    { WBXML_ERROR_BAD_LITERAL_INDEX,            "Bad Literal Index" },
+    { WBXML_ERROR_BAD_NULL_TERMINATED_STRING_IN_STRING_TABLE,    "Not NULL Terminated String in String Table" },
+    { WBXML_ERROR_BAD_OPAQUE_LENGTH,            "Bad Opaque Length" },
+    { WBXML_ERROR_EMPTY_WBXML,                  "Empty WBXML" },    
+    { WBXML_ERROR_END_OF_BUFFER,                "Unexpected End Of WBXML Buffer" },
+    { WBXML_ERROR_ENTITY_CODE_OVERFLOW,         "Entity Code Overflow" },
+    { WBXML_ERROR_EXT_VALUE_TABLE_UNDEFINED,    "Extension Value Table Undefined" },
+    { WBXML_ERROR_INVALID_STRTBL_INDEX,         "Invalid String Table Index" },
+    { WBXML_ERROR_LITERAL_NOT_NULL_TERMINATED_IN_STRING_TABLE,    "Literal Not NULL Terminated in String Table" },
+    { WBXML_ERROR_NOT_NULL_TERMINATED_INLINE_STRING,             "Not NULL Terminated Inline String" },
+    { WBXML_ERROR_NULL_PARSER,                  "Null Parser" },
+    { WBXML_ERROR_NULL_STRING_TABLE,            "No String Table In Document" },
+    { WBXML_ERROR_STRING_EXPECTED,              "String Expected" },
+    { WBXML_ERROR_STRTBL_LENGTH,                "Bad String Table Length" },
+    { WBXML_ERROR_UNKNOWN_ATTR,                 "Unknown Attribute" },
+    { WBXML_ERROR_UNKNOWN_ATTR_VALUE,           "Unknown Attribute Value" },
+    { WBXML_ERROR_UNKNOWN_EXTENSION_TOKEN,      "Unknown Extension Token" },
+    { WBXML_ERROR_UNKNOWN_EXTENSION_VALUE,      "Unknown Extension Value token" },
+    { WBXML_ERROR_UNKNOWN_PUBLIC_ID,            "Unknown Public ID" },    
+    { WBXML_ERROR_UNKNOWN_TAG,                  "Unknown Tag" },
+    { WBXML_ERROR_UNVALID_MBUINT32,             "Unvalid MultiByte UINT32" },
+#if defined( WBXML_SUPPORT_WV )
+    { WBXML_ERROR_WV_INTEGER_OVERFLOW,          "Wireless-Village Integer Overflow" },
+#endif /* WBXML_SUPPORT_WV */
+    /* WBXML Encoder Errors */
+    { WBXML_ERROR_ENCODER_APPEND_DATA,          "Can't append data to output buffer" },
+    { WBXML_ERROR_STRTBL_DISABLED,              "String Table generation disabled: can't encode Literal" },
+    { WBXML_ERROR_UNKNOWN_XML_LANGUAGE,		"The XML language is unknown." },
+    { WBXML_ERROR_XML_NODE_NOT_ALLOWED,         "XML Node Type not allowed" },
+    { WBXML_ERROR_XML_NULL_ATTR_NAME,           "NULL XML Attribute Name" },
+    { WBXML_ERROR_XML_PARSING_FAILED,           "Parsing of XML Document Failed" },
+#if defined( WBXML_SUPPORT_SYNCML )
+    { WBXML_ERROR_XML_DEVINF_CONV_FAILED,       "The conversion of a XML DevInf document failed" },
+#endif /* WBXML_SUPPORT_WV */
+    { WBXML_ERROR_NO_XMLPARSER,                 "Can't parse XML (Compiled without Expat): XML to WBXML conversion not possible" },
+    { WBXML_ERROR_XMLPARSER_OUTPUT_UTF16,       "XML Parser (Expat) is outputting UTF-16, so you have two choices :\n"
+                                              "  - Get the iconv library (http://www.gnu.org/software/libiconv/)\n"
+                                              "  - Use a version of Expat that output UTF-8" },
+    { WBXML_ERROR_CHARSET_UNKNOWN,              "The character set is unknown."},
+    { WBXML_ERROR_CHARSET_CONV_INIT,            "The converter for the character set cannot be initialized."},
+    { WBXML_ERROR_CHARSET_CONV,                 "The character conversion failed."},
+    { WBXML_ERROR_CHARSET_NOT_FOUND,            "The character set cannot be found."}
+};
+
+#define ERROR_TABLE_SIZE ((WB_ULONG) (sizeof(error_table) / sizeof(error_table[0])))
+
+
+/***************************************************
+ *    Public Functions
+ */
+
+WBXML_DECLARE(const WB_UTINY *) wbxml_errors_string(WBXMLError error_code)
+{
+    WB_ULONG i;
+
+    for (i=0; i < ERROR_TABLE_SIZE; i++) {
+        if (error_table[i].code == error_code)
+            return (const WB_UTINY *)error_table[i].string;
+    }
+
+    fprintf(stderr, "PACKAGE_NAME: Unknown error code %d.\n", error_code);
+
+    return (const WB_UTINY *)"Unknown Error Code";
+}

--- a/src/libwbxml/wbxml_errors.h
+++ b/src/libwbxml/wbxml_errors.h
@@ -1,0 +1,130 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_errors.h
+ * @ingroup wbxml_errors
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/11/18
+ *
+ * @brief WBXML Error Codes Handling
+ */
+
+#ifndef WBXML_ERRORS_H
+#define WBXML_ERRORS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include "wbxml_config.h"
+#include "wbxml_defines.h"
+
+/** @addtogroup wbxml_errors
+ *  @{ 
+ */
+
+/**
+ * @brief The WBXML Parser Errors enumeration
+ */
+typedef enum WBXMLError_e {
+    /* Generic Errors */
+    WBXML_OK = 0,       /**< No Error */
+    WBXML_NOT_ENCODED = 1,  /**< Not an error; just a special internal return code */
+    WBXML_ERROR_ATTR_TABLE_UNDEFINED = 10,
+    WBXML_ERROR_BAD_DATETIME =         11,
+    WBXML_ERROR_BAD_PARAMETER =        12,    
+    WBXML_ERROR_INTERNAL =             13,
+    WBXML_ERROR_LANG_TABLE_UNDEFINED = 14,
+    WBXML_ERROR_NOT_ENOUGH_MEMORY =    15,
+    WBXML_ERROR_NOT_IMPLEMENTED =      16,
+    WBXML_ERROR_TAG_TABLE_UNDEFINED =  17,
+    WBXML_ERROR_B64_ENC =              18,
+    WBXML_ERROR_B64_DEC =              19,
+#if defined( WBXML_SUPPORT_WV )
+    WBXML_ERROR_WV_DATETIME_FORMAT = 20,
+#endif /* WBXML_SUPPORT_WV */
+    WBXML_ERROR_NO_CHARSET_CONV =   30,
+    WBXML_ERROR_CHARSET_STR_LEN =   31,
+    WBXML_ERROR_CHARSET_UNKNOWN =   32,
+    WBXML_ERROR_CHARSET_CONV_INIT = 33,
+    WBXML_ERROR_CHARSET_CONV =      34,
+    WBXML_ERROR_CHARSET_NOT_FOUND = 35,
+    /* WBXML Parser Errors */    
+    WBXML_ERROR_ATTR_VALUE_TABLE_UNDEFINED =                  40,
+    WBXML_ERROR_BAD_LITERAL_INDEX =                           41,
+    WBXML_ERROR_BAD_NULL_TERMINATED_STRING_IN_STRING_TABLE =  42,
+    WBXML_ERROR_BAD_OPAQUE_LENGTH =                           43,
+    WBXML_ERROR_EMPTY_WBXML =                                 44,
+    WBXML_ERROR_END_OF_BUFFER =                               45,
+    WBXML_ERROR_ENTITY_CODE_OVERFLOW =                        46,
+    WBXML_ERROR_EXT_VALUE_TABLE_UNDEFINED =                   47,
+    WBXML_ERROR_INVALID_STRTBL_INDEX =                        48,
+    WBXML_ERROR_LITERAL_NOT_NULL_TERMINATED_IN_STRING_TABLE = 49,
+    WBXML_ERROR_NOT_NULL_TERMINATED_INLINE_STRING =           50,
+    WBXML_ERROR_NULL_PARSER =                                 51,
+    WBXML_ERROR_NULL_STRING_TABLE =                           52,
+    WBXML_ERROR_STRING_EXPECTED =                             53,
+    WBXML_ERROR_STRTBL_LENGTH =                               54,   
+    WBXML_ERROR_UNKNOWN_ATTR =            60,
+    WBXML_ERROR_UNKNOWN_ATTR_VALUE =      61,
+    WBXML_ERROR_UNKNOWN_EXTENSION_TOKEN = 62,
+    WBXML_ERROR_UNKNOWN_EXTENSION_VALUE = 63,
+    WBXML_ERROR_UNKNOWN_PUBLIC_ID =       64,
+    WBXML_ERROR_UNKNOWN_TAG =             65,
+    WBXML_ERROR_UNVALID_MBUINT32 = 70,
+#if defined( WBXML_SUPPORT_WV )
+    WBXML_ERROR_WV_INTEGER_OVERFLOW = 80,
+#endif /* WBXML_SUPPORT_WV */
+    /* WBXML Encoder Errors */
+    WBXML_ERROR_ENCODER_APPEND_DATA = 90,
+    WBXML_ERROR_STRTBL_DISABLED =      100,
+    WBXML_ERROR_UNKNOWN_XML_LANGUAGE = 101,
+    WBXML_ERROR_XML_NODE_NOT_ALLOWED = 102,
+    WBXML_ERROR_XML_NULL_ATTR_NAME =   103,
+    WBXML_ERROR_XML_PARSING_FAILED =   104,
+#if defined( WBXML_SUPPORT_SYNCML )
+    WBXML_ERROR_XML_DEVINF_CONV_FAILED = 110,
+#endif /* WBXML_SUPPORT_WV */
+    WBXML_ERROR_NO_XMLPARSER =           120,
+    WBXML_ERROR_XMLPARSER_OUTPUT_UTF16 = 121,
+} WBXMLError;
+
+
+/**
+ * @brief Return a String describing an Error Code
+ * @param error_code WBXML error code
+ * @return The error description
+ */
+WBXML_DECLARE(const WB_UTINY *) wbxml_errors_string(WBXMLError error_code);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_ERRORS_H */

--- a/src/libwbxml/wbxml_handlers.h
+++ b/src/libwbxml/wbxml_handlers.h
@@ -1,0 +1,118 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_handlers.h
+ * @ingroup wbxml_parser
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/06/09
+ *
+ * @brief WBXML Parser Handlers
+ */
+
+#ifndef WBXML_HANDLERS_H
+#define WBXML_HANDLERS_H
+
+#include "wbxml.h"
+#include "wbxml_tables.h"
+#include "wbxml_elt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_parser 
+ *  @{ 
+ */
+
+/**
+ * @brief Start Document Handler
+ * @param ctx User data
+ * @param charset Charset (The MIBenum from IANA character-sets assignements. See "http://www.iana.org/assignments/character-sets")
+ * @param lang Language Table for this Document (cf: wbxml_table.[h|c])
+ */
+typedef void (*WBXMLStartDocumentHandler)(void *ctx, WBXMLCharsetMIBEnum charset, const WBXMLLangEntry *lang);
+
+/**
+ * @brief End Document handler
+ * @param ctx User data
+ */
+typedef void (*WBXMLEndDocumentHandler)(void *ctx);
+
+/**
+ * @brief Start Element handler
+ * @param ctx User data
+ * @param localName The local tag name
+ * @param atts The attributes attached to the element
+ * @param empty Set to TRUE if this is an empty element
+ */
+typedef void (*WBXMLStartElementHandler)(void *ctx, WBXMLTag *localName, WBXMLAttribute **atts);
+
+/**
+ * @brief End Element handler
+ * @param ctx User data
+ * @param localName The local tag name
+ * @param empty Set to TRUE if this is an empty element
+ */
+typedef void (*WBXMLEndElementHandler)(void *ctx, WBXMLTag *localName);
+
+/**
+ * @brief Characters handler
+ * @param ctx User data
+ * @param ch The characters
+ * @param start The start position in the array
+ * @param length The number of characters to read from the array
+ */
+typedef void (*WBXMLCharactersHandler)(void *ctx, WB_UTINY *ch, WB_ULONG start, WB_ULONG length);
+
+/**
+ * @brief Processing Instruction Handler
+ * @param ctx User data
+ * @param target The processing instruction target.
+ * @param data The processing instruction data, or null if  none was supplied. The data does
+ *            not include any whitespace separating it from the target
+ */
+typedef void (*WBXMLProcessingInstructionHandler)(void *ctx, const WB_UTINY *target, WB_UTINY *data);
+
+/**
+ * @brief WBXMLContentHandler structure
+ */
+typedef struct WBXMLContentHandler_s {
+    WBXMLStartDocumentHandler start_document_clb;       /**< Start Document Handler */
+    WBXMLEndDocumentHandler end_document_clb;           /**< End Document handler */
+    WBXMLStartElementHandler start_element_clb;         /**< Start Element handler */
+    WBXMLEndElementHandler end_element_clb;             /**< End Element handler */
+    WBXMLCharactersHandler characters_clb;              /**< Characters handler */
+    WBXMLProcessingInstructionHandler pi_clb;           /**< Processing Instruction Handler */
+} WBXMLContentHandler;
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_HANDLERS_H */

--- a/src/libwbxml/wbxml_internals.h
+++ b/src/libwbxml/wbxml_internals.h
@@ -1,0 +1,163 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml.h
+ * @ingroup wbxml
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/11/11
+ *
+ * @brief WBXML Library Main Header
+ */
+
+#ifndef WBXML_INTERNALS_H
+#define WBXML_INTERNALS_H
+
+#include "wbxml.h"
+
+/** @addtogroup wbxml
+ *  @{ 
+ */
+
+/* WBXML Global Tokens */
+#define WBXML_SWITCH_PAGE 0x00
+#define WBXML_END         0x01
+#define WBXML_ENTITY      0x02
+#define WBXML_STR_I       0x03
+#define WBXML_LITERAL     0x04
+#define WBXML_EXT_I_0     0x40
+#define WBXML_EXT_I_1     0x41
+#define WBXML_EXT_I_2     0x42
+#define WBXML_PI          0x43
+#define WBXML_LITERAL_C   0x44
+#define WBXML_EXT_T_0     0x80
+#define WBXML_EXT_T_1     0x81
+#define WBXML_EXT_T_2     0x82
+#define WBXML_STR_T       0x83
+#define WBXML_LITERAL_A   0x84
+#define WBXML_EXT_0       0xC0
+#define WBXML_EXT_1       0xC1
+#define WBXML_EXT_2       0xC2
+#define WBXML_OPAQUE      0xC3
+#define WBXML_LITERAL_AC  0xC4
+
+/* WBXML Tokens Masks */
+#define WBXML_TOKEN_MASK              0x3F
+#define WBXML_TOKEN_WITH_ATTRS        0x80
+#define WBXML_TOKEN_WITH_CONTENT      0x40
+
+/* WBXML Versions (XML text) */
+#define WBXML_VERSION_TEXT_10   "1.0"   /**< WBXML 1.0 */
+#define WBXML_VERSION_TEXT_11   "1.1"   /**< WBXML 1.1 */
+#define WBXML_VERSION_TEXT_12   "1.2"   /**< WBXML 1.2 */
+#define WBXML_VERSION_TEXT_13   "1.3"   /**< WBXML 1.3 */
+
+
+#if defined( WBXML_SUPPORT_WV )
+/** Wireless-Village Specific Data Types */
+typedef enum WBXMLWVDataType_e {
+    WBXML_WV_DATA_TYPE_BOOLEAN = 0,     /**< Boolean */
+    WBXML_WV_DATA_TYPE_INTEGER,         /**< Integer */
+    WBXML_WV_DATA_TYPE_DATE_AND_TIME,   /**< Date and Time */
+    WBXML_WV_DATA_TYPE_STRING,          /**< String */
+    WBXML_WV_DATA_TYPE_BINARY           /**< Binary */
+} WBXMLWVDataType;
+#endif /* WBXML_SUPPORT_WV */
+
+/** Generic macro to get number of elements in a table */
+#define WBXML_TABLE_SIZE(table) ((WB_LONG)(sizeof(table) / sizeof(table[0])))
+
+/* We are good coders and we don't want to ignore Warnings :) */
+#ifdef WIN32
+#pragma warning(error: 4001) /**< nonstandard extension 'single line comment' was used (disallow "//" C++ comments) */
+#pragma warning(error: 4002) /**< too many actual parameters for macro 'identifier' */
+#pragma warning(error: 4003) /**< not enough actual parameters for macro 'identifier' */
+#pragma warning(error: 4004) /**< incorrect construction after 'defined' */
+#pragma warning(error: 4005) /**< 'identifier' : macro redefinition */
+#pragma warning(error: 4006) /**< #undef expected an identifier */
+#pragma warning(error: 4009) /**< string too big; trailing characters truncated */
+#pragma warning(error: 4013) /**< 'function' undefined; assuming extern returning int */
+#pragma warning(error: 4015) /**< 'identifier' : type of bit field must be integral */
+#pragma warning(error: 4016) /**< 'function' : no function return type; using int as default */
+#pragma warning(error: 4018) /**< 'expression' : signed/unsigned mismatch */
+#pragma warning(error: 4020) /**< 'function' : too many actual parameters */
+#pragma warning(error: 4021) /**< 'function' : too few actual parameters */
+#pragma warning(error: 4022) /**< 'function' : pointer mismatch for actual parameter 'number' */
+#pragma warning(error: 4023) /**< 'symbol' : based pointer passed to unprototyped function : parameter number */
+#pragma warning(error: 4024) /**< 'function' : different types for formal and actual parameter 'number' */
+#pragma warning(error: 4025) /**< 'number' : based pointer passed to function with variable arguments: parameter number */
+#pragma warning(error: 4026) /**< function declared with formal parameter list */
+#pragma warning(error: 4027) /**< function declared without formal parameter list */
+#pragma warning(error: 4028) /**< formal parameter 'number' different from declaration */
+#pragma warning(error: 4029) /**< declared formal parameter list different from definition */
+#pragma warning(error: 4030) /**< first formal parameter list longer than the second list */
+#pragma warning(error: 4031) /**< second formal parameter list longer than the first list */
+#pragma warning(error: 4033) /**< 'function' must return a value */
+#pragma warning(error: 4035) /**< 'function' : no return value */
+#pragma warning(error: 4036) /**< unnamed 'type' as actual parameter */
+#pragma warning(error: 4045) /**< 'identifier' : array bounds overflow */
+#pragma warning(error: 4047) /**< 'identifier1' : 'operator' : different levels of indirection from 'identifier2' */
+#pragma warning(error: 4049) /**< compiler limit : terminating line number emission */
+#pragma warning(error: 4051) /**< type conversion; possible loss of data */
+#pragma warning(error: 4053) /**< one void operand for '?:' */
+#pragma warning(error: 4054) /**< 'conversion' : from function pointer 'type1' to data pointer 'type2' */
+#pragma warning(error: 4057) /**< 'operator' : 'identifier1' indirection to slightly different base types from 'identifier2' */
+#pragma warning(error: 4059) /**< pascal string too big, length byte is length % 256 */
+#pragma warning(error: 4061) /**< enumerate 'identifier' in switch of enum 'identifier' is not explicitly handled by a case label */
+#pragma warning(error: 4063) /**< case 'identifier' is not a valid value for switch of enum 'identifier' */
+#pragma warning(error: 4064) /**< switch of incomplete enum 'identifier' */
+#pragma warning(error: 4071) /**< 'function' : no function prototype given */
+#pragma warning(error: 4072) /**< 'function' : no function prototype on 'convention' function */
+#pragma warning(error: 4078) /**< case constant 'value' too big for the type of the switch expression */
+#pragma warning(error: 4081) /**< expected 'token1'; found 'token2' */
+#pragma warning(error: 4087) /**< 'function' : declared with 'void' parameter list */
+#pragma warning(error: 4088) /**< 'function' : pointer mismatch in actual parameter 'number', formal parameter 'number' */
+#pragma warning(error: 4089) /**< 'function' : different types in actual parameter 'number', formal parameter 'number' */
+#pragma warning(error: 4098) /**< 'function' : void function returning a value */
+#pragma warning(error: 4113) /**< 'identifier1' differs in parameter lists from 'identifier2' */
+#pragma warning(error: 4129) /**< 'character' : unrecognized character escape sequence */
+#pragma warning(error: 4133) /**< 'type' : incompatible types - from 'type1' to 'type2' */
+#pragma warning(error: 4150) /**< deletion of pointer to incomplete type 'type'; no destructor called */
+#pragma warning(error: 4172) /**< returning address of local variable or temporary */
+#pragma warning(error: 4221) /**< nonstandard extension used : 'identifier' : cannot be initialized using address of automatic variable */
+#pragma warning(error: 4223) /**< nonstandard extension used : non-lvalue array converted to pointer */
+#pragma warning(error: 4224) /**< nonstandard extension used : formal parameter 'identifier' was previously defined as a type */
+#pragma warning(error: 4390) /**< ';' : empty controlled statement found; is this what was intended?" */
+#pragma warning(error: 4508) /**< 'function' : function should return a value; void return type assumed */
+#pragma warning(error: 4541) /**< 'identifier' used on polymorphic type 'type' with /GR-; unpredictable behavior may result */
+#pragma warning(error: 4551) /**< function call missing argument list */
+#pragma warning(error: 4553) /**< 'operator' : operator has no effect; did you intend 'operator'? */
+#pragma warning(error: 4700) /**< local variable 'name' used without having been initialized */
+#pragma warning(error: 4706) /**< assignment within conditional expression */
+#pragma warning(error: 4715) /**< 'function' : not all control paths return a value */
+#pragma warning(error: 4761) /**< integral size mismatch in argument : conversion supplied */
+#endif /* WIN32 */
+
+#define WBXML_NAMESPACE_SEPARATOR ':'
+
+/** @} */
+
+#endif /* WBXML_INTERNALS_H */

--- a/src/libwbxml/wbxml_lists.c
+++ b/src/libwbxml/wbxml_lists.c
@@ -1,0 +1,271 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011,2014 Michael Bell <michael.bell@web.de>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_lists.c
+ * @ingroup wbxml_lists
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/12/06
+ *
+ * @brief Generic Lists Functions
+ */
+
+#include "wbxml.h"
+#include "wbxml_lists.h"
+
+/** Element of this list */
+typedef struct WBXMLListElt_s
+{
+    void *item;                     /**< Element item */
+    struct WBXMLListElt_s *next;    /**< Next Element */  
+} WBXMLListElt;
+
+/** The Generic List type */
+struct WBXMLList_s
+{
+    WBXMLListElt *head;         /**< Head of the list */
+    WBXMLListElt *tail;         /**< Tail of the list */
+    WB_ULONG len;               /**< Number of elements in List */
+};
+
+/* Private functions prototypes */
+static WBXMLListElt *wbxml_elt_create_real(void *item);
+#define wbxml_elt_create(a) wbxml_mem_cleam(wbxml_elt_create_real(a))
+
+static void wbxml_elt_destroy(WBXMLListElt *elt, WBXMLListEltCleaner *destructor);
+
+
+/**********************************
+ *    Public functions
+ */
+
+WBXML_DECLARE(WBXMLList *) wbxml_list_create_real(void)
+{
+    WBXMLList *list = NULL;
+    
+    if ((list = wbxml_malloc(sizeof(WBXMLList))) == NULL)
+        return NULL;
+
+    list->head = NULL;
+    list->tail = NULL;
+    list->len = 0;
+    
+    return list;    
+}
+
+
+WBXML_DECLARE(void) wbxml_list_destroy(WBXMLList *list, WBXMLListEltCleaner *destructor)
+{
+    WBXMLListElt *elt = NULL, *next = NULL;
+
+    if (list == NULL)
+        return;
+
+    elt = list->head;
+
+    while (elt != NULL) {
+        next = elt->next;
+        wbxml_elt_destroy(elt, destructor);
+        elt = next;
+    }
+
+    wbxml_free(list);
+}
+
+
+WBXML_DECLARE(WB_ULONG) wbxml_list_len(WBXMLList *list)
+{
+    if (list == NULL)
+        return 0;
+    else
+        return list->len;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_list_append(WBXMLList *list, void *item)
+{
+    if (list == NULL)
+        return FALSE;
+
+    if (item == NULL)
+        return FALSE;
+
+    if (list->head == NULL) {
+        /* Empty list */
+        if ((list->head = wbxml_elt_create(item)) == NULL)
+            return FALSE;
+
+        list->tail = list->head;
+    }
+    else {
+        /* Element is the new Tail */
+        if ((list->tail->next = wbxml_elt_create(item)) == NULL)
+            return FALSE;
+
+        list->tail = list->tail->next;
+    }
+
+    list->len++;
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_list_insert(WBXMLList *list, void *item, WB_ULONG pos)
+{
+    WBXMLListElt *elt = NULL, *prev = NULL, *new_elt = NULL;
+    WB_ULONG i = 0;
+
+    if (list == NULL)
+        return FALSE;
+
+    if (item == NULL)
+        return FALSE;
+
+    if ((new_elt = wbxml_elt_create(item)) == NULL)
+        return FALSE;
+
+    /* Empty List */
+    if (list->len == 0) {
+        list->head = new_elt;
+        list->tail = list->head;
+    }
+    else {
+        /* Insert at Head */
+        if (pos == 0) {
+            /* New Head */
+            new_elt->next = list->head;
+            list->head = new_elt;
+        }
+        else {
+            /* If position is greater than list length, just append it at tail */
+            if (pos >= list->len) {
+                list->tail->next = new_elt;
+                list->tail = list->tail->next;
+            }
+            else {
+                /* Insert Element */
+                elt = list->head;
+
+                for (i=0; i<pos; i++) {
+                    prev = elt;
+                    elt = elt->next;
+                }
+
+                prev->next = new_elt;
+                new_elt->next = elt;
+            }
+        }
+    }
+
+    list->len++;
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(void *) wbxml_list_get(WBXMLList *list, WB_ULONG index)
+{
+    WBXMLListElt *elt = NULL;
+    WB_ULONG i = 0;
+
+    if ((list == NULL) || (index >= wbxml_list_len(list)))
+        return NULL;    
+
+    /* We start to search from head */
+    elt = list->head;
+
+    for (i=0; i<index; i++)
+        elt = elt->next;
+
+    return elt->item;
+}
+
+
+WBXML_DECLARE(void *) wbxml_list_extract_first(WBXMLList *list)
+{
+    WBXMLListElt *elt = NULL;
+    void *result = NULL;
+
+    if ((list == NULL) || (wbxml_list_len(list) == 0))
+        return NULL;
+
+    elt = list->head;
+    result = elt->item;
+
+    if ((list->head = list->head->next) == NULL)
+        list->tail = NULL;
+
+    wbxml_elt_destroy(elt, NULL);
+
+    list->len--;
+
+    return result;
+}
+
+
+/**********************************
+ *    Private functions
+ */
+
+/**
+ * @brief Create a List Element
+ * @param item Item of Element to create
+ * @return The newly created Element, or NULL if not enough memory
+ * @warning Do NOT use this function directly, use wbxml_list_create() macro instead
+ */
+static WBXMLListElt *wbxml_elt_create_real(void *item)
+{
+    WBXMLListElt *elt = NULL;
+
+    if (item == NULL)
+        return NULL;
+
+    if ((elt = wbxml_malloc(sizeof(WBXMLListElt))) == NULL)
+        return NULL;
+
+    elt->item = item;
+    elt->next = NULL;
+
+    return elt;
+}
+
+
+/**
+ * @brief Destroy a List Element
+ * @param elt The element to destroy
+ * @param destructor The Destructor Function to clean Element Item (can be NULL)
+ */
+static void wbxml_elt_destroy(WBXMLListElt *elt, WBXMLListEltCleaner *destructor)
+{
+    if (elt == NULL)
+        return;
+
+    if (destructor != NULL)
+        destructor(elt->item);
+
+    wbxml_free(elt);
+}

--- a/src/libwbxml/wbxml_lists.h
+++ b/src/libwbxml/wbxml_lists.h
@@ -1,0 +1,122 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011,2014 Michael Bell <michael.bell@web.de>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_lists.h 
+ * @ingroup wbxml_lists
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/12/06
+ *
+ * @brief Generic Lists Functions
+ */
+
+#ifndef WBXML_LISTS_H
+#define WBXML_LISTS_H
+
+#include "wbxml_mem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+
+/**
+ * @brief WBXML Generic List
+ */
+typedef struct WBXMLList_s WBXMLList;
+
+
+/** @addtogroup wbxml_lists  
+ *  @{ 
+ */
+
+/**
+ * @brief A List Element Cleaner Function prototype
+ */
+typedef void WBXMLListEltCleaner(void *item);
+
+/**
+ * @brief Create a List
+ * @return The newly created List, or NULL if not enough memory
+ * @warning Do NOT use this function directly, use wbxml_list_create() macro instead
+ */
+WBXML_DECLARE(WBXMLList *) wbxml_list_create_real(void);
+#define wbxml_list_create() wbxml_mem_cleam(wbxml_list_create_real())
+
+/**
+ * @brief Destroy a List
+ * @param list The List to destroy
+ * @param destructor The function to destroy an element from list (if NULL, items are not destroyed from list)
+ */
+WBXML_DECLARE(void) wbxml_list_destroy(WBXMLList *list, WBXMLListEltCleaner *destructor);
+
+/**
+ * @brief Get list length
+ * @param list The List
+ * @return The List length
+ */
+WBXML_DECLARE(WB_ULONG) wbxml_list_len(WBXMLList *list);
+
+/**
+ * @brief Append an element at end of list
+ * @param list The List
+ * @param elt The element to append which must be not null.
+ * @return TRUE if element appended, FALSE if not enough memory
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_list_append(WBXMLList *list, void *elt);
+
+/**
+ * @brief Append an element to a list
+ * @param list The List
+ * @param elt The element to insert which must be not null.
+ * @param pos The index where to insert this element
+ * @return TRUE if element appended, FALSE if not enough memory
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_list_insert(WBXMLList *list, void *elt, WB_ULONG pos);
+
+/**
+ * @brief Get an Element from list
+ * @param list The List
+ * @param index Index of element to get (index in start starts at '0')
+ * @return The element, or NULL if not found
+ */
+WBXML_DECLARE(void *) wbxml_list_get(WBXMLList *list, WB_ULONG index);
+
+/**
+ * @brief Extract first element of a List
+ * @param list The List
+ * @return The element extracted, or NULL if not found
+ * @note The element is removed from this list
+ */
+WBXML_DECLARE(void *) wbxml_list_extract_first(WBXMLList *list);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_LISTS_H */

--- a/src/libwbxml/wbxml_log.c
+++ b/src/libwbxml/wbxml_log.c
@@ -1,0 +1,145 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_log.c
+ * @ingroup wbxml_log
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/12/04
+ *
+ * @brief Log Functions
+ */
+
+#include "wbxml_log.h"
+
+
+#if defined( WBXML_LIB_VERBOSE ) && !defined( WBXML_USE_LEAKTRACKER )
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+
+/** Length of Log Buffer */
+#define WBXML_LOG_FORMAT_SIZE 1024
+
+
+/* Private Functions Prototypes */
+static void format_log_message(WB_TINY *buf, WB_UTINY type, const WB_TINY *fmt);
+static const WB_TINY *get_type(WB_UTINY type);
+
+
+/***************************************************
+ *    Public Functions
+ */
+
+WBXML_DECLARE(void) wbxml_log_debug(WB_UTINY type, const WB_TINY *fmt, ...)
+{
+    char buf[WBXML_LOG_FORMAT_SIZE];
+    va_list args;
+    
+    format_log_message(buf, type, fmt);
+    
+    va_start(args, fmt);
+    vfprintf(stderr, buf, args);   
+    va_end(args);
+}
+
+WBXML_DECLARE(void) wbxml_log_warning(WB_UTINY type, const WB_TINY *fmt, ...)
+{
+    char buf[WBXML_LOG_FORMAT_SIZE];
+    va_list args;
+    
+    format_log_message(buf, type, fmt);
+    
+    va_start(args, fmt);
+    vfprintf(stderr, buf, args);   
+    va_end(args);
+}
+
+WBXML_DECLARE(void) wbxml_log_error(WB_UTINY type, const WB_TINY *fmt, ...)
+{
+    char buf[WBXML_LOG_FORMAT_SIZE];
+    va_list args;
+    
+    format_log_message(buf, type, fmt);
+    
+    va_start(args, fmt);
+    vfprintf(stderr, buf, args);   
+    va_end(args);
+}
+
+
+/***************************************************
+ *    Private Functions
+ */
+
+/**
+ * @brief Format a Log Message
+ * @param buf [out] Resulting formated buffer
+ * @param type [in] Type of Message
+ * @param fmt [int] Message to format
+ */
+static void format_log_message(WB_TINY *buf, WB_UTINY type, const WB_TINY *fmt)
+{
+    WB_TINY *p, prefix[WBXML_LOG_FORMAT_SIZE];
+    
+    p = prefix;
+    
+    sprintf(p, "%s> ", get_type(type));
+    
+    if (WBXML_STRLEN(prefix) + WBXML_STRLEN(fmt) > WBXML_LOG_FORMAT_SIZE / 2) {
+        sprintf(buf, "(LOG MESSAGE TOO LONG !)\n");
+        return;
+    }
+    
+    sprintf(buf, "%s%s\n", prefix, fmt);    
+}
+
+/**
+ * @brief Get a Message Type string
+ * @param type [in] Type of Message
+ * @return The string representation of the Message Type
+ */
+static const WB_TINY *get_type(WB_UTINY type) 
+{
+    switch (type)
+    {
+        case WBXML_PARSER:
+            return "WBXML Parser";
+        
+        case WBXML_ENCODER:
+            return "WBXML Encoder";
+
+        case WBXML_CONV:
+            return "WBXML Converter";
+        
+        default:
+            return "WBXML Unknown";
+    }
+}
+
+#endif /* WBXML_LIB_VERBOSE */

--- a/src/libwbxml/wbxml_log.h
+++ b/src/libwbxml/wbxml_log.h
@@ -1,0 +1,110 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_log.h
+ * @ingroup wbxml_log
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/12/04
+ *
+ * @brief Log Functions
+ */
+
+#ifndef WBXML_LOG_H
+#define WBXML_LOG_H
+
+#include "wbxml.h"
+
+#ifdef WBXML_USE_LEAKTRACKER
+#include "leaktrack.h"
+#include "lt_log.h"
+#endif /* WBXML_USE_LEAKTRACKER */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_log  
+ *  @{ 
+ */
+ 
+/* Compilation Flags: WBXML_LIB_VERBOSE / WBXML_USE_LEAKTRACKER */
+
+/* Log Macros */
+#if defined( WBXML_LIB_VERBOSE )
+#if defined( WBXML_USE_LEAKTRACKER )
+#define WBXML_DEBUG(msg)   lt_log msg
+#define WBXML_WARNING(msg) lt_log msg
+#define WBXML_ERROR(msg)   lt_log msg
+#define WBXML_PARSER 0x00
+#define WBXML_ENCODER 0x00
+#define WBXML_CONV 0x00
+#else  /* !WBXML_USE_LEAKTRACKER */
+#define WBXML_DEBUG(msg)   wbxml_log_debug msg
+#define WBXML_WARNING(msg) wbxml_log_warning msg
+#define WBXML_ERROR(msg)   wbxml_log_error msg
+#define WBXML_PARSER 0x01
+#define WBXML_ENCODER 0x02
+#define WBXML_CONV 0x03
+#endif /* WBXML_USE_LEAKTRACKER */
+#else  /* !WBXML_LIB_VERBOSE */
+#define WBXML_DEBUG(msg)
+#define WBXML_WARNING(msg)
+#define WBXML_ERROR(msg)
+#endif /* WBXML_LIB_VERBOSE */
+
+
+/**
+ * @brief Log a DEBUG message
+ * @param type Type of Message
+ * @param fmt Message to log
+ * @note Do NOT use this function directly, use WBXML_DEBUG() macro instead
+ */
+WBXML_DECLARE(void) wbxml_log_debug(WB_UTINY type, const WB_TINY *fmt, ...);
+
+/**
+ * @brief Log a WARNING message
+ * @param type Type of Message
+ * @param fmt Message to log
+ * @note Do NOT use this function directly, use WBXML_WARNING() macro instead
+ */
+WBXML_DECLARE(void) wbxml_log_warning(WB_UTINY type, const WB_TINY *fmt, ...);
+
+/**
+ * @brief Log an ERROR message
+ * @param type Type of Message
+ * @param fmt Message to log
+ * @note Do NOT use this function directly, use WBXML_ERROR() macro instead
+ */
+WBXML_DECLARE(void) wbxml_log_error(WB_UTINY type, const WB_TINY *fmt, ...);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_LOG_H */

--- a/src/libwbxml/wbxml_mem.c
+++ b/src/libwbxml/wbxml_mem.c
@@ -1,0 +1,80 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_mem.c
+ * @ingroup wbxml_mem
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/11/24
+ *
+ * @brief Memory Functions
+ */
+
+#include "wbxml_mem.h"
+
+
+/***************************************************
+ *    Public Functions
+ */
+
+WBXML_DECLARE(void *) wbxml_malloc(size_t size)
+{
+#ifdef WBXML_USE_LEAKTRACKER
+    return lt_malloc(size);
+#else
+    return malloc(size);
+#endif
+}
+
+
+WBXML_DECLARE(void) wbxml_free(void *memblock)
+{
+#ifdef WBXML_USE_LEAKTRACKER
+    lt_free(memblock);
+#else
+    free(memblock);
+#endif
+}
+
+
+WBXML_DECLARE(void *) wbxml_realloc(void *memblock, size_t size)
+{
+#ifdef WBXML_USE_LEAKTRACKER
+    return lt_realloc(memblock, size);
+#else
+    return realloc(memblock, size);
+#endif
+}
+
+
+WBXML_DECLARE(char *) wbxml_strdup(const char *str)
+{
+#ifdef WBXML_USE_LEAKTRACKER
+    return lt_strdup(str);
+#else
+    return strdup(str);
+#endif
+}

--- a/src/libwbxml/wbxml_mem.h
+++ b/src/libwbxml/wbxml_mem.h
@@ -1,0 +1,91 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_mem.h
+ * @ingroup wbxml_mem
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/07/01
+ *
+ * @brief Memory Functions
+ */
+
+#ifndef WBXML_MEM_H
+#define WBXML_MEM_H
+
+#include "wbxml.h"
+
+#ifdef WBXML_USE_LEAKTRACKER
+#include "leaktrack.h"
+#include "lt_log.h"
+#define wbxml_mem_cleam(ptr) (lt_claim_area(ptr))
+#else  /* WBXML_USE_LEAKTRACKER */
+#define wbxml_mem_cleam(ptr) (ptr)
+#endif /* WBXML_USE_LEAKTRACKER */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_mem  
+ *  @{ 
+ */
+
+/**
+ * @brief Alloc a Memory Block
+ * @param size Size of Memory to alloc
+ * @return The newly mlloced Memory Block, or NULL if not enough memory
+ */
+WBXML_DECLARE(void *) wbxml_malloc(size_t size);
+
+/**
+ * @brief Free a Memory Block
+ * @param memblock The Memory Block to free
+ */
+WBXML_DECLARE(void) wbxml_free(void *memblock);
+
+/**
+ * @brief Realloc a Memory Block
+ * @param memblock The Memory Block to realloc
+ * @param size Size of Memory to realloc
+ * @return The newly realloced Memory Block, or NULL if not enough memory
+ */
+WBXML_DECLARE(void *) wbxml_realloc(void *memblock, size_t size);
+
+/**
+ * @brief Duplicate a C String
+ * @param str The C String to duplicate
+ * @return The newly duplicated C String, or NULL if not enough memory
+ */
+WBXML_DECLARE(char *) wbxml_strdup(const char *str);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_MEM_H */

--- a/src/libwbxml/wbxml_parser.c
+++ b/src/libwbxml/wbxml_parser.c
@@ -1,0 +1,2912 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2009-2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_parser.c
+ * @ingroup wbxml_parser
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/03/12
+ *
+ * @brief WBXML Parser - Parse a WBXML document and call user defined Callbacks
+ *
+ * @todo Handle correctly charset
+ *
+ * @note WBXML Versions Differences:
+ *            - WBXML 1.2: - No differences with WBXML 1.3, except a clarification in BNF for 'LITERAL' handling
+ *            - WBXML 1.1: - No Switch Page mecanism
+ *                         - An Attribute value can't be "opaque"
+ *            - WBXML 1.0: - No 'charset' handling
+ *                         - No 'opaque' support
+ *                         - A strange 'body' rule description in BNF (just forget it).
+ */
+
+#include "wbxml_parser.h"
+#include "wbxml_log.h"
+#include "wbxml_internals.h"
+#include "wbxml_base64.h"
+#include "wbxml_charset.h"
+#include <assert.h>
+
+
+/* Memory management related defines */
+#define WBXML_PARSER_MALLOC_BLOCK 5000
+#define WBXML_PARSER_STRING_TABLE_MALLOC_BLOCK 200
+#define WBXML_PARSER_ATTR_VALUE_MALLOC_BLOCK 100
+
+/** Set it to '1' for Best Effort mode */
+#define WBXML_PARSER_BEST_EFFORT 1
+
+/** For unknown Tag Name or Attribute Name (in Best Effort Mode) */
+#define WBXML_PARSER_UNKNOWN_STRING ((WB_UTINY *)"unknown")
+
+/**
+ * @brief The WBXML Application Token types
+ */
+typedef enum WBXMLTokenType_e {
+    WBXML_TAG_TOKEN,        /**< Tag token */
+    WBXML_ATTR_TOKEN        /**< Attribute token */
+} WBXMLTokenType;
+
+
+/**
+ * @brief The WBXML Parser
+ * @warning For now 'current_tag' field is only used for WV Content Parsing. And for this use, it works.
+ *          But this field is reset after End Tag, and as there is no Linked List mecanism, this is bad for
+ *          cascading elements: we don't fill this field with parent Tag when parsing End Tag.
+ */
+struct WBXMLParser_s {
+    void                 *user_data;       /**< User Data */
+    WBXMLContentHandler  *content_hdl;     /**< Content Handlers Callbacks */
+    WBXMLBuffer          *wbxml;           /**< The wbxml we are parsing */    
+    WBXMLBuffer          *strstbl;         /**< String Table specified in WBXML document */
+    const WBXMLLangEntry *langTable;       /**< Current document Language Table */
+    const WBXMLLangEntry *mainTable;       /**< Main WBXML Languages Table */
+    const WBXMLTagEntry  *current_tag;     /**< Current Tag */
+  
+    WBXMLLanguage         lang_forced;     /**< Language forced by User */
+    WB_ULONG              public_id;       /**< Public ID specified in WBXML document */    
+    WB_LONG               public_id_index; /**< If Public ID is a String Table reference,
+                                                this is the index defined in the strtbl */
+    WBXMLCharsetMIBEnum   charset;         /**< Charset of WBXML document */
+    WBXMLCharsetMIBEnum   meta_charset;    /**< Meta-info provided by user: only used if
+                                                Charset is not specified in WBXML document */
+    WB_ULONG              pos;             /**< Position of parsing curser in wbxml */    
+    WBXMLVersion          version;         /**< WBXML Version field specified in WBXML document */
+    WB_UTINY              tagCodePage;     /**< Current Tag Code Page */
+    WB_UTINY              attrCodePage;    /**< Current Attribute Code Page */
+};
+
+
+
+/***************************************************
+ *    Private Functions prototypes
+ */
+
+/* WBXML Parser functions */
+static void wbxml_parser_reinit(WBXMLParser *parser);
+
+/* Check functions */
+static WB_BOOL is_token(WBXMLParser *parser, WB_UTINY token);
+static WB_BOOL is_literal(WBXMLParser *parser);
+static WB_BOOL is_attr_value(WBXMLParser *parser);
+static WB_BOOL is_string(WBXMLParser *parser);
+static WB_BOOL is_extension(WBXMLParser *parser);
+static WB_BOOL check_public_id(WBXMLParser *parser);
+
+/* Parse functions */
+static WBXMLError parse_version(WBXMLParser *parser);
+static WBXMLError parse_publicid(WBXMLParser *parser);
+static WBXMLError parse_charset(WBXMLParser *parser);
+static WBXMLError parse_strtbl(WBXMLParser *parser);
+static WBXMLError parse_body(WBXMLParser *parser);
+
+static WBXMLError parse_pi(WBXMLParser *parser);
+static WBXMLError parse_element(WBXMLParser *parser);
+static void free_attrs_table(WBXMLAttribute **attrs);
+
+static WBXMLError parse_switch_page(WBXMLParser *parser, WBXMLTokenType  code_space);
+static WBXMLError parse_stag(WBXMLParser *parser, WB_UTINY *tag, WBXMLTag **element);
+static WBXMLError parse_tag(WBXMLParser *parser, WB_UTINY *tag, WBXMLTag **element);
+static WBXMLError parse_attribute(WBXMLParser *parser, WBXMLAttribute **attr);
+static WBXMLError parse_content(WBXMLParser *parser, WBXMLBuffer **result);
+
+static WBXMLError parse_string(WBXMLParser *parser, WBXMLBuffer **result);
+static WBXMLError parse_extension(WBXMLParser *parser, WBXMLTokenType code_space, WBXMLBuffer **result);
+static WBXMLError parse_entity(WBXMLParser *parser, WBXMLBuffer **result);
+static WBXMLError parse_opaque(WBXMLParser *parser, WBXMLBuffer **result);
+
+static WBXMLError parse_literal(WBXMLParser *parser, WB_UTINY *tag, WBXMLBuffer **result);
+
+static WBXMLError parse_attr_start(WBXMLParser *parser, WBXMLAttributeName **name, const WB_UTINY **value);
+static WBXMLError parse_attr_value(WBXMLParser *parser, WBXMLBuffer **result);
+
+static WBXMLError parse_termstr(WBXMLParser *parser, WBXMLBuffer **result);
+static WBXMLError parse_inline(WBXMLParser *parser, WBXMLBuffer **result);
+static WBXMLError parse_tableref(WBXMLParser *parser, WBXMLBuffer **result);
+static WBXMLError parse_entcode(WBXMLParser *parser, WB_ULONG *result);
+
+static WBXMLError get_strtbl_reference(WBXMLParser *parser, WB_ULONG index, WBXMLBuffer **result);
+
+/* Basic Types Parse functions */
+static WBXMLError parse_uint8(WBXMLParser *parser, WB_UTINY *result);
+static WBXMLError parse_mb_uint32(WBXMLParser *parser, WB_ULONG *result);
+
+/* Language Specific Decoding Functions */
+static WBXMLError decode_base64_value(WBXMLBuffer **data);
+
+#if defined( WBXML_SUPPORT_SI ) || defined( WBXML_SUPPORT_EMN )
+static WBXMLError decode_datetime(WBXMLBuffer *buff);
+#endif /* WBXML_SUPPORT_SI || WBXML_SUPPORT_EMN */
+
+static WBXMLError decode_opaque_content(WBXMLParser *parser, WBXMLBuffer **data);
+static WBXMLError decode_opaque_attr_value(WBXMLParser *parser, WBXMLBuffer **data);
+
+#if defined( WBXML_SUPPORT_WV )
+static WBXMLError decode_wv_content(WBXMLParser *parser, WBXMLBuffer **data);
+static WBXMLError decode_wv_integer(WBXMLBuffer **data);
+static WBXMLError decode_wv_datetime(WBXMLBuffer **data);
+#endif /* WBXML_SUPPORT_WV */
+
+/* Macro for error handling */
+#define CHECK_ERROR if (ret != WBXML_OK) return ret;
+
+
+/***************************************************
+ *    Public Functions
+ */
+
+WBXML_DECLARE(WBXMLParser *) wbxml_parser_create(void)
+{
+    WBXMLParser *parser = NULL;
+
+    parser = wbxml_malloc(sizeof(WBXMLParser));
+    if (parser == NULL) {
+        return NULL;
+    }
+    
+    parser->wbxml = NULL;
+    parser->user_data = NULL;
+    parser->content_hdl = NULL;
+    parser->strstbl = NULL;
+    parser->langTable = NULL;
+
+    /* Default Main WBXML Languages Table */
+    parser->mainTable = wbxml_tables_get_main();
+
+    parser->current_tag = NULL;
+
+    parser->lang_forced = WBXML_LANG_UNKNOWN;
+    parser->public_id = WBXML_PUBLIC_ID_UNKNOWN;    
+    parser->public_id_index = -1;
+    parser->charset = WBXML_CHARSET_UNKNOWN;
+    parser->meta_charset = WBXML_CHARSET_UNKNOWN;
+    parser->version = WBXML_VERSION_UNKNOWN;    
+    
+    parser->pos = 0;
+    parser->tagCodePage = 0;
+    parser->attrCodePage = 0;
+
+    return parser;
+}
+
+
+WBXML_DECLARE(void) wbxml_parser_destroy(WBXMLParser *parser)
+{
+    if (parser == NULL)
+        return;
+    
+    wbxml_buffer_destroy(parser->wbxml);
+    wbxml_buffer_destroy(parser->strstbl);
+
+    wbxml_free(parser);
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_parser_parse(WBXMLParser *parser, WB_UTINY *wbxml, WB_ULONG wbxml_len)
+{
+    WBXMLError ret = WBXML_OK;
+
+    if (parser == NULL)
+        return WBXML_ERROR_NULL_PARSER;
+
+    if ((wbxml == NULL) || (wbxml_len <= 0))
+        return WBXML_ERROR_EMPTY_WBXML;
+
+    /* Reinitialize WBXML Parser */
+    wbxml_parser_reinit(parser);
+
+    parser->wbxml = wbxml_buffer_create(wbxml, wbxml_len, WBXML_PARSER_MALLOC_BLOCK);
+    if (parser->wbxml == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* WBXML Version */
+    ret = parse_version(parser);
+    CHECK_ERROR
+
+    if ((WB_UTINY)parser->version > WBXML_VERSION_13) {
+        WBXML_WARNING((WBXML_PARSER, "This library only supports WBXML %s.", WBXML_VERSION_TEXT_13));
+    }
+
+    /* WBXML Public ID */
+    ret = parse_publicid(parser);
+    CHECK_ERROR
+
+    /* Ignore Document Public ID if user has forced use of another Public ID */
+    if (parser->lang_forced != WBXML_LANG_UNKNOWN)
+        parser->public_id = wbxml_tables_get_wbxml_publicid(wbxml_tables_get_main(), parser->lang_forced);
+
+    /* No charset in WBXML 1.0 */
+    if (parser->version != WBXML_VERSION_10) {
+        ret = parse_charset(parser);
+        CHECK_ERROR
+    }
+
+    /* Check charset */
+    if (parser->charset == WBXML_CHARSET_UNKNOWN) {
+        if (parser->meta_charset != WBXML_CHARSET_UNKNOWN) {
+            /* Use meta-information provided by user */
+            parser->charset = parser->meta_charset;
+      
+            WBXML_DEBUG((WBXML_PARSER,
+                        "Using provided meta charset: %ld",
+                        parser->meta_charset));
+        }
+        else {
+            /* Default Charset Encoding: UTF-8 */
+            parser->charset = WBXML_PARSER_DEFAULT_CHARSET;
+      
+            WBXML_WARNING((WBXML_PARSER,
+                           "No charset information found, using default : %x",
+                           WBXML_PARSER_DEFAULT_CHARSET));
+        }
+    }
+
+    /* WBXML String Table */
+    ret = parse_strtbl(parser);
+    CHECK_ERROR
+
+    /* Now that we have parsed String Table, we can check Public ID */
+    if (!check_public_id(parser)) {
+        WBXML_ERROR((WBXML_PARSER, "PublicID not found"));
+        return WBXML_ERROR_UNKNOWN_PUBLIC_ID;
+    }
+
+    /* Call to WBXMLStartDocumentHandler */
+    if ((parser->content_hdl != NULL) && (parser->content_hdl->start_document_clb != NULL))
+        parser->content_hdl->start_document_clb(parser->user_data, parser->charset, parser->langTable);
+
+    /* WBXML Body */
+    ret = parse_body(parser);
+    CHECK_ERROR
+
+    /* Call to WBXMLEndDocumentHandler */
+    if ((parser->content_hdl != NULL) && (parser->content_hdl->end_document_clb != NULL))
+        parser->content_hdl->end_document_clb(parser->user_data);
+
+    return ret;
+}
+
+
+WBXML_DECLARE(void) wbxml_parser_set_user_data(WBXMLParser *parser, void *user_data)
+{
+    if (parser != NULL)
+        parser->user_data = user_data;
+}
+
+
+WBXML_DECLARE(void) wbxml_parser_set_content_handler(WBXMLParser *parser, WBXMLContentHandler *content_handler)
+{
+    if (parser != NULL)
+        parser->content_hdl = content_handler;
+}
+
+
+WBXML_DECLARE(void) wbxml_parser_set_main_table(WBXMLParser *parser, const WBXMLLangEntry *main_table)
+{
+    if (parser != NULL)
+        parser->mainTable = main_table;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_parser_set_language(WBXMLParser *parser, WBXMLLanguage lang)
+{
+    if (parser != NULL) {
+        parser->lang_forced = lang;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_parser_set_meta_charset(WBXMLParser *parser,
+                                                     WBXMLCharsetMIBEnum charset)
+{
+    if ( parser != NULL ) {
+        parser->meta_charset = charset;
+        return TRUE;
+    }
+  
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WB_ULONG) wbxml_parser_get_wbxml_public_id(WBXMLParser *parser)
+{
+    if ((parser != NULL) && (parser->langTable != NULL) && (parser->langTable->publicID != NULL))
+        return parser->langTable->publicID->wbxmlPublicID;
+    else
+        return WBXML_PUBLIC_ID_UNKNOWN;
+}
+
+
+WBXML_DECLARE(const WB_UTINY *) wbxml_parser_get_xml_public_id(WBXMLParser *parser)
+{
+    if ((parser != NULL) && (parser->langTable != NULL) && (parser->langTable->publicID != NULL))
+        return (const WB_UTINY *) parser->langTable->publicID->xmlPublicID;
+    else
+        return NULL;
+}
+
+
+WBXML_DECLARE(WBXMLVersion) wbxml_parser_get_wbxml_version(WBXMLParser *parser)
+{
+    if (parser != NULL)
+        return parser->version;
+    else
+        return WBXML_VERSION_UNKNOWN;
+}
+
+
+WBXML_DECLARE(WB_LONG) wbxml_parser_get_current_byte_index(WBXMLParser *parser)
+{
+    if (parser != NULL)
+        return parser->pos - 1;
+    else
+        return 0;
+}
+
+
+/***************************************************
+ *    Private Functions
+ */
+
+/**************************
+ * WBXML Parser functions
+ */
+
+/**
+ * @brief Reinitialize a WBXML Parser
+ * @param parser The WBXMLParser to reinitialize
+ * @note Only reinitialize internal fields of parser, and so keep User Data
+ *         and Content Handler pointers.
+ */
+static void wbxml_parser_reinit(WBXMLParser *parser)
+{
+    if (parser == NULL)
+        return;
+
+    wbxml_buffer_destroy(parser->wbxml);
+    parser->wbxml           = NULL;
+  
+    wbxml_buffer_destroy(parser->strstbl);
+    parser->strstbl         = NULL;
+  
+    parser->langTable       = NULL;
+    parser->current_tag     = NULL;
+  
+    parser->public_id       = WBXML_PUBLIC_ID_UNKNOWN;    
+    parser->public_id_index = -1;
+    parser->charset         = WBXML_CHARSET_UNKNOWN;
+    parser->version         = WBXML_VERSION_UNKNOWN;    
+  
+    parser->pos             = 0;
+    parser->tagCodePage     = 0;
+    parser->attrCodePage    = 0;    
+}
+
+
+/******************
+ * Check functions
+ */
+
+/**
+ * @brief Check if current byte a specified WBXML token
+ * @param parser The WBXML Parser
+ * @param token The WBXML token
+ * @return TRUE is current byte is the specified token, FALSE otherwise
+ */
+static WB_BOOL is_token(WBXMLParser *parser, WB_UTINY token)
+{
+    WB_UTINY result;
+
+    if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, &result))
+        return FALSE;
+
+    return (WB_BOOL) (result == token);
+}
+
+
+/**
+ * @brief Check if current byte is a WBXML literalTag token
+ * @param parser The WBXML Parser
+ * @return TRUE is current byte is a literalTag token, FALSE otherwise
+ */
+static WB_BOOL is_literal(WBXMLParser *parser)
+{
+    WB_UTINY result;
+
+    if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, &result))
+        return FALSE;
+
+    return (WB_BOOL) ((result == WBXML_LITERAL) || (result == WBXML_LITERAL_A) || (result == WBXML_LITERAL_C) || (result == WBXML_LITERAL_AC));
+}
+
+
+/**
+ * @brief Check if next token to parse is an Attribute Value
+ * @param parser The WBXML Parser
+ * @return TRUE if next token to parse is an Attribute Value, FALSE otherwise
+ * @note attrValue    = ([switchPage] ATTRVALUE | string | extension | entity | opaque)
+ */
+static WB_BOOL is_attr_value(WBXMLParser *parser)
+{
+    WB_UTINY cur_byte, next_byte;
+
+    /* Get current byte */
+    if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, &cur_byte))
+        return FALSE;
+
+    /* If current byte is a switch page, check that following token is an Attribute Value token */
+    if (is_token(parser, WBXML_SWITCH_PAGE)) {
+        if (!wbxml_buffer_get_char(parser->wbxml, parser->pos + 2, &next_byte))
+            return FALSE;
+
+        /* Attribute Value is greater than or equal to 128 */
+        if ((next_byte & 0x80) == 0x80)
+            return TRUE;
+    }
+
+    /* Else, check current byte is an Attribute Value, a string, an extension, an entity or an opaque */
+    if (((cur_byte & 0x80) == 0x80) ||
+        (is_string(parser)) ||
+        (is_extension(parser)) ||
+        (is_token(parser, WBXML_ENTITY)) ||
+        (is_token(parser, WBXML_OPAQUE)))
+        return TRUE;
+
+    return FALSE;
+}
+
+
+/**
+ * @brief Check if current byte is a string
+ * @param parser The WBXML Parser
+ * @return TRUE if current byte is a string, FALSE otherwise
+ */
+static WB_BOOL is_string(WBXMLParser *parser)
+{
+    return (WB_BOOL) (is_token(parser, WBXML_STR_I) || is_token(parser, WBXML_STR_T));
+}
+
+
+/**
+ * @brief Check if current byte is an extension
+ * @param parser The WBXML Parser
+ * @return TRUE if current byte is an extension, FALSE otherwise
+ */
+static WB_BOOL is_extension(WBXMLParser *parser)
+{
+    WB_UTINY cur_byte;
+
+    /* If current byte is a switch page, check the following token */
+    if (is_token(parser, WBXML_SWITCH_PAGE)) {
+        if (!wbxml_buffer_get_char(parser->wbxml, parser->pos + 2, &cur_byte))
+            return FALSE;
+    }
+    else {
+        if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, &cur_byte))
+            return FALSE;
+    }
+
+    return (WB_BOOL) ((cur_byte == WBXML_EXT_I_0) || (cur_byte == WBXML_EXT_I_1) || (cur_byte == WBXML_EXT_I_2) ||
+            (cur_byte == WBXML_EXT_T_0) || (cur_byte == WBXML_EXT_T_1) || (cur_byte == WBXML_EXT_T_2) ||
+            (cur_byte == WBXML_EXT_0)   || (cur_byte == WBXML_EXT_1)   || (cur_byte == WBXML_EXT_2));
+}
+
+
+/**
+ * @brief Check the Public ID
+ * @param parser The WBXML Parser
+ * @return TRUE if Public ID is found, FALSE otherwise
+ */
+static WB_BOOL check_public_id(WBXMLParser *parser)
+{
+    WBXMLBuffer *public_id = NULL;
+    WB_LONG          index = 0;
+    WBXMLError         ret;
+
+    WBXML_DEBUG((WBXML_PARSER, "\t  Checking PublicID"));
+
+    /* First check if we can figure out the Public ID */
+    if ((parser->lang_forced == WBXML_LANG_UNKNOWN) && 
+        (parser->public_id == WBXML_PUBLIC_ID_UNKNOWN) && 
+        (parser->public_id_index == -1))
+    {
+        return FALSE;
+    }
+
+
+    /********************************************************
+     * Case 1: Language is forced by user
+     */
+
+    if (parser->lang_forced != WBXML_LANG_UNKNOWN) {
+        /* Search Language Entry */
+        while (parser->mainTable[index].langID != WBXML_LANG_UNKNOWN) {
+            if (parser->mainTable[index].langID == parser->lang_forced) {
+                parser->langTable = &(parser->mainTable[index]);
+
+                WBXML_DEBUG((WBXML_PARSER, "\t  Language Forced - PublicID : '%s'", parser->mainTable[index].publicID->xmlPublicID));
+
+                return TRUE;
+            }
+
+            index++;
+        }
+    }
+
+
+    /********************************************************
+     * Case 2: Public ID is a normal token 
+     *         (found in WBXML Document, or forced by user)
+     */
+
+    if (parser->public_id != WBXML_PUBLIC_ID_UNKNOWN) {
+        WBXML_DEBUG((WBXML_PARSER, "\t  PublicID token: 0x%X", parser->public_id));
+
+        /* Search Public ID Table */
+        while (parser->mainTable[index].publicID != NULL) {
+            if (parser->mainTable[index].publicID->wbxmlPublicID == parser->public_id) {
+                parser->langTable = &(parser->mainTable[index]);
+
+                WBXML_DEBUG((WBXML_PARSER, "\t  PublicID : '%s'", parser->mainTable[index].publicID->xmlPublicID));
+
+                return TRUE;
+            }
+
+            index++;
+        }
+    }
+
+
+    /********************************************************
+     * Case 3: Public ID referenced in String Table 
+     */
+    if (parser->public_id_index != -1) {
+        WBXML_DEBUG((WBXML_PARSER, "\t  PublicID is in String Table (index: 0x%X)", parser->public_id_index));
+
+        ret = get_strtbl_reference(parser, (WB_ULONG) parser->public_id_index, &public_id);
+        if (ret != WBXML_OK) {
+            WBXML_ERROR((WBXML_PARSER, "Bad publicID reference in string table. %s", wbxml_errors_string(ret)));
+            return FALSE;
+        }
+
+        WBXML_DEBUG((WBXML_PARSER, "\t  PublicID : '%s'", wbxml_buffer_get_cstr(public_id)));
+
+        /* Search Public ID Table */
+        while (parser->mainTable[index].publicID != NULL)
+        {
+            if ((parser->mainTable[index].publicID->xmlPublicID != NULL) && 
+                (WBXML_STRCASECMP(parser->mainTable[index].publicID->xmlPublicID, wbxml_buffer_get_cstr(public_id)) == 0))
+            {
+                parser->langTable = &(parser->mainTable[index]);
+                /* parser->public_id = parser->mainTable[index].publicID->wbxmlPublicID; */
+
+                wbxml_buffer_destroy(public_id);
+                return TRUE;
+            }
+
+            index++;
+        }
+
+        /* Clean up */
+        wbxml_buffer_destroy(public_id);
+    }
+
+    /* Public ID not found in Tables */
+    return FALSE;
+}
+
+
+
+/***************************
+ *    WBXML Parse functions
+ */
+
+/**
+ * @brief Parse WBXML version
+ * @param parser The WBXML Parser
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note version = u_int8
+ */
+static WBXMLError parse_version(WBXMLParser *parser)
+{   
+    WBXMLError ret = WBXML_OK;
+    
+    /* Initialize version: 1.0 
+     *
+     * Do NOT keep 'WBXML_VERSION_UNKNOWN' (0xffffffff) because only one byte will change.
+     * (for example, if the version is 0x02, then parser->version will be 0xffffff02)
+     */
+    WB_UTINY version = WBXML_VERSION_10;
+    
+    if ((ret = parse_uint8(parser, &version)) != WBXML_OK)
+        return ret;
+    
+    parser->version = version;
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsed version: 1.%d", parser->pos - 1, parser->version));
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML public id
+ * @param parser The WBXML Parser
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note publicid = mb_u_int32 | ( zero index )
+ * @note index = mb_u_int32
+ */
+static WBXMLError parse_publicid(WBXMLParser *parser)
+{
+    WB_UTINY public_id;
+    WBXMLError ret;
+
+    if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, &public_id))
+        return WBXML_ERROR_END_OF_BUFFER;
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsed public id value: '0x%X'", parser->pos, public_id));
+
+    if (public_id == 0x00) {
+        parser->pos++;
+
+        /* Get index (we will retrieve the Public ID later from string table) */
+        ret = parse_mb_uint32(parser, (WB_ULONG *)&parser->public_id_index);
+        WBXML_DEBUG((WBXML_PARSER, "(%d) Parsed public id index: '0x%x'", parser->pos-1, parser->public_id_index));
+        return ret;
+    }
+    else {
+        /* Get Public ID */
+        ret = parse_mb_uint32(parser, &parser->public_id);        
+        WBXML_DEBUG((WBXML_PARSER, "(%d) Parsed public id: '0x%x'", parser->pos-1, parser->public_id));
+        return ret;
+    }
+}
+
+
+/**
+ * @brief Parse WBXML charset
+ * @param parser The WBXML Parser
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note charset = mb_u_int32
+ * @note "The binary XML format contains a representation of the XML document character encoding.
+ *        This is the WBXML equivalent of the XML document format encoding attribute,
+ *        which is specified in the ?xml processing instruction. The character set is encoded as
+ *        a multi-byte positive integer value, representing the IANA-assigned MIB number for
+ *        a character set. A value of zero indicates an unknown document encoding. In the case of
+ *        an unknown encoding, transport meta-information should be used to determine the character
+ *        encoding. If transport meta-information is unavailable, the default encoding of UTF-8
+ *        should be assumed."
+ */
+static WBXMLError parse_charset(WBXMLParser *parser)
+{
+    /* definitions first ... or some compilers don't like it */
+    const char *charset_name = NULL;
+
+#if defined( WBXML_LIB_VERBOSE )
+    WB_ULONG startpos = parser->pos;
+#endif /* WBXML_LIB_VERBOSE */
+
+    unsigned int charset = 0;
+    WBXMLError ret = parse_mb_uint32(parser, &charset);
+
+    if (ret != WBXML_OK) {
+        WBXML_DEBUG((WBXML_PARSER, "(%d) failed to parse character set", startpos));
+        return ret;
+    }
+
+    if (charset == 0) {
+        WBXML_DEBUG((WBXML_PARSER, "(%d) The character set is zero.", startpos));
+        if (parser->meta_charset != WBXML_CHARSET_UNKNOWN) {
+            /* use character set from transport meta-information */
+            WBXML_DEBUG((WBXML_PARSER, "(%d) Using charset from meta-info ...%d.", startpos, parser->meta_charset));
+            charset = parser->meta_charset;
+        } else {
+            /* default encoding is UTF-8 */
+            WBXML_DEBUG((WBXML_PARSER, "(%d) Enabling the default character set ... UTF-8.", startpos));
+            charset = WBXML_CHARSET_UTF_8;
+        }
+    }
+
+    if (!wbxml_charset_get_name(charset, &charset_name)) {
+        WBXML_DEBUG((WBXML_PARSER, "(%d) failed to get character set name", charset));
+        return WBXML_ERROR_CHARSET_NOT_FOUND;
+    }
+    parser->charset = (WBXMLCharsetMIBEnum) charset;
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsed charset: '0x%X'", startpos, parser->charset));
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML string table
+ * @param parser The WBXML Parser
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note strtbl = length *byte
+ * @note length = mb_u_int32
+ */
+static WBXMLError parse_strtbl(WBXMLParser *parser)
+{
+    WB_UTINY  *data       = NULL;
+    WB_ULONG   strtbl_len = 0;
+    WB_UTINY   end_char   = 0;
+    WBXMLError ret        = WBXML_OK;
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing strtbl", parser->pos));
+
+    /* Get String Table Length */
+    ret = parse_mb_uint32(parser, &strtbl_len);
+    if (ret != WBXML_OK)
+        return WBXML_ERROR_END_OF_BUFFER;
+
+    if (strtbl_len > 0) {
+        /* Check this string table length */
+        if (strtbl_len > wbxml_buffer_len(parser->wbxml) - parser->pos)
+            return WBXML_ERROR_STRTBL_LENGTH;
+
+        /* Get String Table */
+        data = wbxml_buffer_get_cstr(parser->wbxml);
+        parser->strstbl = wbxml_buffer_create(data + parser->pos, strtbl_len, WBXML_PARSER_STRING_TABLE_MALLOC_BLOCK);
+        if (parser->strstbl == NULL)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+        /** @todo Damned ! Check the charset ! This may not be a simple NULL terminated string ! */
+
+        /* Some phones doesn't terminate the String Table with a null char... let's correct this */
+        if (!wbxml_buffer_get_char(parser->strstbl,
+                                   wbxml_buffer_len(parser->strstbl) - 1,
+                                   &end_char))
+        {
+            return WBXML_ERROR_INTERNAL;
+        }
+
+        /* If there is a correctly terminated string
+         * then there is no reason to do anything.
+         */
+        if (end_char != '\0') {
+            WBXML_DEBUG((WBXML_PARSER, "    Adding NULL bytes to strtbl."));
+            /* A terminating NULL byte is not enough today.
+             * There exists character sets with a fixed length of bytes.
+             * Such strings must be terminated with a complete NULL character.
+             * ASCII  => 1 byte
+             * UTF-8  => 1 byte
+             * UTF-16 => 2 bytes
+             * UTF-32 => 4 bytes (I hope so)
+             * UCS-2  => 2 bytes
+             * I hope four NULL bytes are enough for all cases.
+             */
+            if (!wbxml_buffer_append_char(parser->strstbl, '\0'))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            if (!wbxml_buffer_append_char(parser->strstbl, '\0'))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            if (!wbxml_buffer_append_char(parser->strstbl, '\0'))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            if (!wbxml_buffer_append_char(parser->strstbl, '\0'))
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        parser->pos = parser->pos + strtbl_len;
+    }
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML body
+ * @param parser The WBXML Parser
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note body = *pi element *pi
+ */
+static WBXMLError parse_body(WBXMLParser *parser)
+{
+    WBXMLError ret = WBXML_OK;
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing body", parser->pos));
+
+    while (is_token(parser, WBXML_PI)) {
+        if ((ret = parse_pi(parser)) != WBXML_OK)
+            return ret;
+    }
+
+    if ((ret = parse_element(parser)) != WBXML_OK)
+        return ret;
+
+    while (is_token(parser, WBXML_PI)) {
+        if ((ret = parse_pi(parser)) != WBXML_OK)
+            return ret;
+    }
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML pi
+ * @param parser The WBXML Parser
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note pi = PI attrStart *attrValue END
+ */
+static WBXMLError parse_pi(WBXMLParser *parser)
+{
+    WBXMLAttributeName *attr_name    = NULL;
+    const WB_UTINY     *start_value  = NULL;
+    WBXMLBuffer        *attr_value   = NULL;
+    WBXMLBuffer        *tmp_value    = NULL;
+    WBXMLError          ret          = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing PI", parser->pos));
+  
+    /* Skip PI */
+    parser->pos++;    
+      
+    /* Parse attrStart */
+    if ((ret = parse_attr_start(parser,
+                                &attr_name,
+                                &start_value)) != WBXML_OK)
+    {
+        return ret;
+    }
+      
+    if (start_value != NULL ) {
+        /* Create a buffer from attribute start value */
+        attr_value = wbxml_buffer_create(start_value,
+                                         WBXML_STRLEN(start_value),
+                                         WBXML_PARSER_ATTR_VALUE_MALLOC_BLOCK);
+    }
+    else {
+        /* Create an empty buffer */
+        attr_value = wbxml_buffer_create(NULL,
+                                         0,
+                                         WBXML_PARSER_ATTR_VALUE_MALLOC_BLOCK);
+    }
+      
+    if (attr_value == NULL) {
+        /* Memory error */
+        wbxml_attribute_name_destroy(attr_name);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    } 
+    
+    
+    /* Parse *attrValue */
+    while (!is_token(parser, WBXML_END)) {
+        /* Parse attrValue */
+        if ((ret = parse_attr_value(parser, &tmp_value)) != WBXML_OK) {
+            wbxml_attribute_name_destroy(attr_name);
+            wbxml_buffer_destroy(attr_value);
+            return ret;
+        }
+    
+        /* Append to main attribute value buffer */
+        if (!wbxml_buffer_append(attr_value, tmp_value)) {
+            wbxml_attribute_name_destroy(attr_name);
+            wbxml_buffer_destroy(attr_value);
+            wbxml_buffer_destroy(tmp_value);
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+        
+        wbxml_buffer_destroy(tmp_value);
+        tmp_value = NULL;
+    }
+      
+    /* Skip END */
+    parser->pos++;
+      
+    /* Append NULL char to attr value */
+    if (wbxml_buffer_len(attr_value) > 0) {
+        if (!wbxml_buffer_append_char(attr_value, '\0')) {
+            wbxml_attribute_name_destroy(attr_name);
+            wbxml_buffer_destroy(attr_value);
+
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    }
+      
+    /* Callback WBXMLProcessingInstructionHandler */
+    if ((parser->content_hdl != NULL) &&
+        (parser->content_hdl->pi_clb != NULL))
+    {
+        parser->content_hdl->pi_clb(parser->user_data,
+                                    wbxml_attribute_name_get_xml_name(attr_name),
+                                    wbxml_buffer_get_cstr(attr_value));
+    }
+        
+    wbxml_attribute_name_destroy(attr_name);
+    wbxml_buffer_destroy(attr_value);
+      
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML element
+ * @param parser The WBXML Parser
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note element = ([switchPage] stag) [ 1*attribute END ] [ *content END ]
+ */
+static WBXMLError parse_element(WBXMLParser *parser)
+{
+    WBXMLTag        *element        = NULL;
+    WBXMLAttribute  *attr           = NULL;
+    WBXMLAttribute **attrs          = NULL;
+    WBXMLBuffer     *content        = NULL;
+  
+    WB_ULONG         attrs_nb       = 0;
+    WBXMLError       ret            = WBXML_OK;
+    WB_UTINY         tag            = 0;
+    WB_BOOL          is_empty       = FALSE;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing element", parser->pos));
+  
+    if (is_token(parser, WBXML_SWITCH_PAGE)) {
+        if ((ret = parse_switch_page(parser, WBXML_TAG_TOKEN)) != WBXML_OK) {
+            return ret;
+        }
+    }
+  
+    /* Parse Tag */
+    if ((ret = parse_stag(parser, &tag, &element)) != WBXML_OK ) {
+        return ret;
+    }
+
+    WBXML_DEBUG((WBXML_PARSER, "<%s>", wbxml_tag_get_xml_name(element)));
+  
+    /* Set Current Tag */
+    if (element->type == WBXML_VALUE_TOKEN) {
+        parser->current_tag = element->u.token;
+    }
+  
+    /* Parse Attributes */
+    if (tag & WBXML_TOKEN_WITH_ATTRS) {
+        WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing attributes", parser->pos));
+    
+        /* There must be at least one attribute */
+        do {
+            /* Parse attribute */
+            if ((ret = parse_attribute(parser, &attr)) != WBXML_OK) {
+                wbxml_tag_destroy(element);
+                free_attrs_table(attrs);
+                return ret;
+            }
+          
+            /* Append this attribute in WBXMLAttribute **attrs table */
+            attrs_nb++;
+    
+            if ((attrs = wbxml_realloc(attrs,
+                                        (attrs_nb + 1) * sizeof(*attrs))) == NULL)
+            {
+                /* Clean-up */
+                wbxml_tag_destroy(element);
+                wbxml_attribute_destroy(attr);
+                free_attrs_table(attrs);
+                return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+            }
+    
+            attrs[(attrs_nb - 1)] = attr;
+            attrs[attrs_nb] = NULL;
+        } while ( !is_token(parser, WBXML_END) );
+        
+        /* Skip END */
+        parser->pos++;
+    }
+    
+    /* Is it an empty element ? */
+    is_empty = (WB_BOOL) !(tag & WBXML_TOKEN_WITH_CONTENT);
+      
+    /* Callback WBXMLStartElementHandler */
+    if ((parser->content_hdl != NULL) &&
+        (parser->content_hdl->start_element_clb != NULL))
+    {
+        parser->content_hdl->start_element_clb(parser->user_data,
+                                               element,
+                                               attrs);
+    }
+    
+    /* Free Attributes */
+    free_attrs_table(attrs);
+    
+    
+    /* Parse *content */
+    if (!is_empty) {
+        /* There can be NO content */
+        while (!is_token(parser, WBXML_END)) {
+            /* Parse content */
+            if ((ret = parse_content(parser, &content)) != WBXML_OK)
+            {
+                wbxml_tag_destroy(element);
+                return ret;
+            }
+    
+            /* Callback WBXMLCharactersHandler if content is not NULL */
+            if ((content != NULL) &&
+                (wbxml_buffer_len(content) != 0) &&
+                (parser->content_hdl != NULL) &&
+                (parser->content_hdl->characters_clb != NULL))
+            {
+                parser->content_hdl->characters_clb(parser->user_data,
+                                                    wbxml_buffer_get_cstr(content),
+                                                    0,
+                                                    wbxml_buffer_len(content));
+            }
+          
+            /* Free content */
+            wbxml_buffer_destroy(content);
+            content = NULL;
+        }
+        
+        WBXML_DEBUG((WBXML_PARSER, "(%d) End of Element", parser->pos - 1));
+        
+        /* Skip END */
+        parser->pos++;
+    }
+      
+    /* Callback WBXMLEndElementHandler */
+    if ((parser->content_hdl != NULL) &&
+        (parser->content_hdl->end_element_clb != NULL))
+    {
+        parser->content_hdl->end_element_clb(parser->user_data,
+                                             element);
+    }
+    
+    WBXML_DEBUG((WBXML_PARSER, "</%s>", wbxml_tag_get_xml_name(element)));
+    
+    /* Free Tag */
+    wbxml_tag_destroy(element);
+      
+    /* Reset Current Tag */
+    parser->current_tag = NULL;
+      
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Free a (WBXMLAttribute *) table
+ * @param attrs The table to ree
+ */
+static void free_attrs_table(WBXMLAttribute **attrs)
+{
+    WB_LONG i = 0;
+
+    if (attrs != NULL) {
+        while (attrs[i] != NULL) {
+            /* Free attribute */
+            wbxml_attribute_destroy(attrs[i++]);
+        }
+        wbxml_free(attrs);
+    }
+}
+
+
+/**
+ * @brief Parse WBXML switchPage
+ * @param parser The WBXML Parser
+ * @param code_space The token code space
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note switchPage = SWITCH_PAGE pageindex
+ */
+static WBXMLError parse_switch_page(WBXMLParser *parser, WBXMLTokenType code_space)
+{
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing switchPage", parser->pos));
+
+    if ((WB_UTINY) parser->version < (WB_UTINY) WBXML_VERSION_12) {
+        WBXML_WARNING((WBXML_PARSER, "No Switch Page mecanism possible in WBXML < %s (current: %d)", WBXML_VERSION_TEXT_12, (WB_UTINY) parser->version));
+    }
+
+    /* Skip SWITCH_PAGE token */
+    parser->pos++;
+
+    /* Change Code Page in correct Code Space */
+    if (code_space == WBXML_TAG_TOKEN)
+        return parse_uint8(parser, &parser->tagCodePage);
+    else
+        if (code_space == WBXML_ATTR_TOKEN)
+            return parse_uint8(parser, &parser->attrCodePage);
+        else
+            return WBXML_ERROR_INTERNAL;
+}
+
+
+/**
+ * @brief Parse WBXML stag
+ * @param parser The WBXML Parser
+ * @param tag The parsed tag token
+ * @param element The parsed element corresponding to token
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note stag = TAG | (literalTag index)
+ */
+static WBXMLError parse_stag(WBXMLParser *parser, WB_UTINY *tag, WBXMLTag **element)
+{
+    WBXMLBuffer *name = NULL;
+    WBXMLError   ret  = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing stag", parser->pos));
+  
+    if (is_literal(parser)) {
+        /* Parse '(literalTag index)' */
+        if ((ret = parse_literal(parser, tag, &name)) != WBXML_OK) {
+            return ret;
+        }
+    
+        /* Create Element Tag */
+        if ((*element = wbxml_tag_create_literal(wbxml_buffer_get_cstr(name))) == NULL) {
+            ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        wbxml_buffer_destroy(name);
+        return ret;
+    }
+
+    /* Parse 'TAG' */
+    return parse_tag(parser, tag, element);
+}
+
+
+/**
+ * @brief Parse WBXML Application Token (tag)
+ * @param parser The WBXML Parser
+ * @param tag The parsed token tag
+ * @param element The parsed element (the text element corresponding to token)
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ */
+static WBXMLError parse_tag(WBXMLParser *parser, WB_UTINY *tag, WBXMLTag **element)
+{
+    WB_ULONG index = 0;
+    WB_UTINY token;
+    WBXMLError ret = WBXML_OK;
+
+    /* Parse UINT8 */
+    ret = parse_uint8(parser, tag);
+    if (ret != WBXML_OK)
+        return ret;
+
+    /* Remove ATTR and CONTENT bits */
+    token = (WB_UTINY) (*tag & WBXML_TOKEN_MASK);
+
+    /* Search tag in Tags Table */
+    if (parser->langTable == NULL)
+        return WBXML_ERROR_LANG_TABLE_UNDEFINED;
+
+    if (parser->langTable->tagTable == NULL)
+        return WBXML_ERROR_TAG_TABLE_UNDEFINED;
+
+    
+    while ((parser->langTable->tagTable[index].xmlName != NULL) &&
+           ((parser->langTable->tagTable[index].wbxmlToken != token) ||
+            (parser->langTable->tagTable[index].wbxmlCodePage != parser->tagCodePage))) {
+        index++;
+    }
+
+
+    if (parser->langTable->tagTable[index].xmlName == NULL) {
+#if WBXML_PARSER_BEST_EFFORT
+        /* Create "unknown" Tag Element */
+        if ((*element = wbxml_tag_create_literal(WBXML_PARSER_UNKNOWN_STRING)) == NULL)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+        return WBXML_OK;
+#else
+        return WBXML_ERROR_UNKNOWN_TAG;
+#endif /* WBXML_PARSER_BEST_EFFORT */
+    }
+
+    if ((*element = wbxml_tag_create(WBXML_VALUE_TOKEN)) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    (*element)->u.token = &(parser->langTable->tagTable[index]);
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Token: 0x%X", parser->pos - 1, token));
+    
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML attribute
+ * @param parser The WBXML Parser
+ * @param attr The resulting attribute parsed
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note attribute = attrStart *attrValue
+ * @warning The attr_value parameter MUST be freed by caller
+ */
+static WBXMLError parse_attribute(WBXMLParser *parser, WBXMLAttribute **attr)
+{
+    WBXMLAttributeName *attr_name    = NULL;
+    const WB_UTINY     *start_value  = NULL;
+    WBXMLBuffer        *attr_value   = NULL;
+    WBXMLBuffer        *tmp_value    = NULL;
+    WBXMLError          ret          = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing attribute", parser->pos));
+  
+    /* Parse attrStart */
+    if ((ret = parse_attr_start(parser,
+                                &attr_name,
+                                &start_value)) != WBXML_OK)
+    {
+        return ret;
+    }
+  
+    if ( start_value != NULL ) {
+        /* Create a buffer from attribute start value */
+        attr_value = wbxml_buffer_create(start_value,
+                                         WBXML_STRLEN(start_value),
+                                         WBXML_PARSER_ATTR_VALUE_MALLOC_BLOCK);
+    }
+    else {
+        /* Create an empty buffer */
+        attr_value = wbxml_buffer_create(NULL,
+                                         0,
+                                         WBXML_PARSER_ATTR_VALUE_MALLOC_BLOCK);
+    }
+  
+    if (attr_value == NULL) {
+        /* Memory error */
+        wbxml_attribute_name_destroy(attr_name);        
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+  
+    /* Construct Attribute Value */
+    while (is_attr_value(parser)) {
+        /* Parse attrValue */
+        if ((ret = parse_attr_value(parser, &tmp_value)) != WBXML_OK) {
+            wbxml_attribute_name_destroy(attr_name);
+            wbxml_buffer_destroy(attr_value);
+            return ret;
+        }
+    
+        if (!wbxml_buffer_append(attr_value, tmp_value)) {
+            wbxml_attribute_name_destroy(attr_name);
+            wbxml_buffer_destroy(attr_value);
+            wbxml_buffer_destroy(tmp_value);
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    
+        wbxml_buffer_destroy(tmp_value);
+        tmp_value = NULL;
+    }
+  
+    if ((wbxml_buffer_len(attr_value) > 0) &&
+        (attr_name->type == WBXML_VALUE_TOKEN)) 
+    {
+        /* Handle Language Specific Attribute Values */
+        switch (parser->langTable->langID) {
+    #if defined( WBXML_SUPPORT_SI )
+        case WBXML_LANG_SI10:
+          /* SI 1.0: Decode date for 'created' and 'si-expires' attributes */
+          if ((attr_name->u.token->wbxmlCodePage == 0x00) && 
+              ((attr_name->u.token->wbxmlToken == 0x0a) ||
+               (attr_name->u.token->wbxmlToken == 0x10)))
+          {
+            if ((ret = decode_datetime(attr_value)) != WBXML_OK) {
+              wbxml_attribute_name_destroy(attr_name);
+              wbxml_buffer_destroy(attr_value);
+              return ret;
+            }
+          }
+          break;
+    #endif /* WBXML_SUPPORT_SI */
+      
+    #if defined( WBXML_SUPPORT_EMN )
+        case WBXML_LANG_EMN10:
+          /* EMN 1.0: Decode date for 'timestamp' attribute */
+          if ((attr_name->u.token->wbxmlCodePage == 0x00) &&
+              (attr_name->u.token->wbxmlToken == 0x05))
+          {
+            if ((ret = decode_datetime(attr_value)) != WBXML_OK) {
+              wbxml_attribute_name_destroy(attr_name);
+              wbxml_buffer_destroy(attr_value);
+              return ret;
+            }
+          }
+          break;
+    #endif /* WBXML_SUPPORT_EMN */
+      
+        default:
+          break;
+        }
+    }
+  
+    /* Append NULL char to attr value */
+    if (wbxml_buffer_len(attr_value) > 0) {
+        if (!wbxml_buffer_append_char(attr_value, '\0')) {
+            wbxml_attribute_name_destroy(attr_name);
+            wbxml_buffer_destroy(attr_value);
+
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    }
+  
+    if ((*attr = wbxml_attribute_create()) == NULL) {
+        wbxml_attribute_name_destroy(attr_name);
+        wbxml_buffer_destroy(attr_value);
+
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+  
+    (*attr)->name = attr_name;
+    (*attr)->value = attr_value;
+  
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML content
+ * @param parser The WBXML Parser
+ * @param result Resulting parsed content, if content is not an Element
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note content = element | string | extension | entity | pi | opaque
+ */
+static WBXMLError parse_content(WBXMLParser *parser, WBXMLBuffer **result)
+{
+    WB_UTINY cur_byte;
+    WBXMLError ret = WBXML_OK;
+
+    /* Debug */
+    if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, &cur_byte))
+        return WBXML_ERROR_END_OF_BUFFER;
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing content: '0x%X'", parser->pos, cur_byte));
+
+    /* extension */
+    if (is_extension(parser))
+        return parse_extension(parser, WBXML_TAG_TOKEN, result);
+
+    /* entity */
+    if (is_token(parser, WBXML_ENTITY))
+        return parse_entity(parser, result);
+
+    /* string */
+    if (is_string(parser))
+        return parse_string(parser, result);
+
+    /* opaque */
+    if (is_token(parser, WBXML_OPAQUE)) {
+        if ((ret = parse_opaque(parser, result)) != WBXML_OK)
+            return ret;
+
+        return decode_opaque_content(parser, result);
+    }
+
+    /* pi */
+    if (is_token(parser, WBXML_PI))
+        return parse_pi(parser);
+        
+    /** 
+     * @note Non standard behaviour because of a Nokia 6600 bug
+     *       that generate switch pages in wrong places.
+     *
+     * Thanks to Balaji Alasyam for finding this bug.
+     *
+     * Example : 02 9F 53 6A 00 6D 6C 71 C3 03 31 2E 31 01 72 C3 0A 53 79 6E
+     *           63 4D 4C 2F 31 2E 31 01 65 C3 01 34 01 5B C3 01 31 01 6E 57
+     *           C3 31 68 74 74 70 3A 2F 2F 32 31 30 2E 32 31 34 2E 31 36 31
+     *           2E 31 37 32 3A 38 30 38 30 2F 74 65 73 74 2F 53 79 6E 63 4D
+     *           4C 3F 75 73 65 72 3D 62 61 6C 75 01 01 67 57 C3 14 49 4D 45
+     *           49 3A 33 35 31 35 34 36 30 30 35 33 39 34 31 39 39 01 01 5A
+     *           00 01 4C C3 05 31 30 30 30 30 01 00 00 01 01 6B 46 4B C3 ...
+     *                                            ^^^^^
+     */
+   
+    /* switchPage */
+    if ( is_token(parser, WBXML_SWITCH_PAGE) )
+      return parse_switch_page(parser, WBXML_TAG_TOKEN);
+
+    /** @note We have recurrency here ! */
+    return parse_element(parser);
+}
+
+
+/**
+ * @brief Parse WBXML string
+ * @param parser [in]  The WBXML Parsertatic
+ * @param result [out] The resulting parsed string
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note string = inline | tableref
+ */
+static WBXMLError parse_string(WBXMLParser *parser, WBXMLBuffer **result)
+{
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing string", parser->pos));
+
+    if (is_token(parser, WBXML_STR_I))
+        return parse_inline(parser, result);
+
+    if (is_token(parser, WBXML_STR_T))
+        return parse_tableref(parser, result);
+
+    return WBXML_ERROR_STRING_EXPECTED;
+}
+
+
+/**
+ * @brief Parse WBXML extension
+ * @param parser     The WBXML Parser
+ * @param code_space The token code space
+ * @param result     Resulting parsed extension
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note extension = [switchPage] (( EXT_I termstr ) | ( EXT_T index ) | EXT)
+ * @note 5.8.4.2 - The effect of a switchPage preceding an extension will depend upon where the extension appears.
+ *                   If switchPage appears in content, it will change the tag code page. Is switchPage appears in
+ *                   an attribute list, it will change the attribute code page.
+ * @note Extensions tokens are explained in WML Specifications (WAP-191-WML-20000219-a.pdf - 14.1.1 & 14.3)
+ * @warning The resulting ext paramater MUST be freed by caller !
+ */
+static WBXMLError parse_extension(WBXMLParser *parser, WBXMLTokenType code_space, WBXMLBuffer **result)
+{
+    WB_UTINY   *ext   = NULL;
+    WB_ULONG    len   = 0;
+    WBXMLError  ret   = WBXML_OK;
+    WB_UTINY    token = 0;
+
+#if ( defined ( WBXML_SUPPORT_WML ) || defined ( WBXML_SUPPORT_WTA ) )
+    WB_UTINY var_begin[3] = "$(",
+             var_end[2]   = ")",
+             escape[8]    = ":escape",
+             unesc[7]     = ":unesc",
+             noesc[7]     = ":noesc";
+
+    WBXMLBuffer *var_value = NULL;
+    WB_ULONG     index     = 0;
+#endif /* WBXML_SUPPORT_WML || WBXML_SUPPORT_WTA */
+  
+#if defined ( WBXML_SUPPORT_WV )
+    WB_ULONG ext_value = 0;
+    WB_UTINY tab_index = 0;
+#endif /* WBXML_SUPPORT_WV */
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing extension", parser->pos));
+  
+    /* Parse switchPage */
+    if (is_token(parser, WBXML_SWITCH_PAGE)) {
+        if ((ret = parse_switch_page(parser, code_space)) != WBXML_OK) {
+          return ret;
+        }
+    }
+  
+    /* Get Extension Token */
+    if ((ret = parse_uint8(parser, &token)) != WBXML_OK) {
+        return ret;
+    }
+
+    if (parser->langTable == NULL) {
+            return WBXML_ERROR_LANG_TABLE_UNDEFINED;
+        }
+    /* Language specific treatment */
+    switch (parser->langTable->langID) {
+
+#if defined( WBXML_SUPPORT_WML )
+
+    case WBXML_LANG_WML10:
+    case WBXML_LANG_WML11:
+    case WBXML_LANG_WML12:
+    case WBXML_LANG_WML13:
+
+#endif /* WBXML_SUPPORT_WML */
+    
+#if defined( WBXML_SUPPORT_WTA )
+
+    case WBXML_LANG_WTAWML12:
+
+#endif /* WBXML_SUPPORT_WTA */
+    
+#if ( defined( WBXML_SUPPORT_WML ) || defined( WBXML_SUPPORT_WTA ) )
+    
+        /*****************************
+         * WML Variable Substitution 
+         */
+    
+        switch (token) {
+        case WBXML_EXT_0:
+        case WBXML_EXT_1:
+        case WBXML_EXT_2:
+            WBXML_WARNING((WBXML_PARSER, "This extension token is reserved for futur use (ignoring)"));
+            return WBXML_OK;
+
+        case WBXML_EXT_I_0:
+        case WBXML_EXT_I_1:
+        case WBXML_EXT_I_2:
+            /* Inline variable */
+            if ((ret = parse_termstr(parser, &var_value)) != WBXML_OK) {
+                WBXML_ERROR((WBXML_PARSER, "Bad Inline Extension"));
+                return ret;
+            }
+            break;
+
+        case WBXML_EXT_T_0:
+        case WBXML_EXT_T_1:
+        case WBXML_EXT_T_2:
+            /* Index in String Table */
+            if ((ret = parse_mb_uint32(parser, &index)) != WBXML_OK) {
+                return ret;
+            }
+
+            if ((ret = get_strtbl_reference(parser,
+                                            index,
+                                            &var_value)) != WBXML_OK)
+            {
+                WBXML_ERROR((WBXML_PARSER, "Bad Extension reference in string table"));
+                return ret;
+            }
+            break;
+
+        default:
+            return WBXML_ERROR_UNKNOWN_EXTENSION_TOKEN;
+        }
+
+        /* Build Variable */
+        ext = wbxml_malloc(WBXML_STRLEN(var_begin) +
+                                       wbxml_buffer_len(var_value) +
+                                       WBXML_STRLEN(escape) +
+                                       WBXML_STRLEN(var_end) + 1);
+        if (ext == NULL) {
+            wbxml_buffer_destroy(var_value);
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    
+        /* Generate "$(" */
+        memcpy(ext + len, var_begin, WBXML_STRLEN(var_begin));
+        len += WBXML_STRLEN(var_begin);
+    
+        /* Generate 'variable' */
+        memcpy(ext + len, wbxml_buffer_get_cstr(var_value), wbxml_buffer_len(var_value));
+        len += wbxml_buffer_len(var_value);
+
+        /* Destroy 'variable' */
+        wbxml_buffer_destroy(var_value);
+    
+        switch (token) {
+        case WBXML_EXT_I_0:
+        case WBXML_EXT_T_0:
+            /* Generate ":escape" */
+            memcpy(ext + len, escape, WBXML_STRLEN(escape));
+            len += WBXML_STRLEN(escape);
+            break;
+
+        case WBXML_EXT_I_1:
+        case WBXML_EXT_T_1:
+            /* Generate ":unesc" */
+            memcpy(ext + len, unesc, WBXML_STRLEN(unesc));
+            len += WBXML_STRLEN(unesc);
+            break;
+
+        case WBXML_EXT_I_2:
+        case WBXML_EXT_T_2:
+            /* Generate ":noesc" */
+            memcpy(ext + len, noesc, WBXML_STRLEN(noesc));
+            len += WBXML_STRLEN(noesc);
+            break;
+
+        default:
+            wbxml_free(ext);
+            return WBXML_ERROR_UNKNOWN_EXTENSION_TOKEN;
+        }
+    
+        /* Generate ")" */
+        memcpy(ext + len, var_end, WBXML_STRLEN(var_end));
+        len += WBXML_STRLEN(var_end);
+
+        break;
+
+#endif /* WBXML_SUPPORT_WML || WBXML_SUPPORT_WTA */
+
+#if defined( WBXML_SUPPORT_WV )
+
+    case WBXML_LANG_WV_CSP11:
+    case WBXML_LANG_WV_CSP12:
+    
+        /**********************************
+         * Wireless Village extension
+         */
+    
+        if (token != WBXML_EXT_T_0) {
+            WBXML_ERROR((WBXML_PARSER, "Only EXT_T_0 extensions authorized with Wireless Village CSP"));
+            return WBXML_OK;
+        }
+    
+        /* Get Extension Value Token */
+        if ((ret = parse_mb_uint32(parser, &ext_value)) != WBXML_OK) {
+            return ret;
+        }
+
+        /* Search Token in Extension Value Table */
+        if (parser->langTable->extValueTable == NULL) {
+            return WBXML_ERROR_EXT_VALUE_TABLE_UNDEFINED;
+        }
+    
+        tab_index = 0;
+    
+        while ((parser->langTable->extValueTable[tab_index].xmlName != NULL) &&
+               (parser->langTable->extValueTable[tab_index].wbxmlToken != ext_value) )
+        {
+            tab_index++;
+        }
+    
+        if (parser->langTable->extValueTable[tab_index].xmlName == NULL) {
+#if WBXML_PARSER_BEST_EFFORT
+            ext = (WB_UTINY *) wbxml_strdup((const WB_TINY*) WBXML_PARSER_UNKNOWN_STRING);
+            len = WBXML_STRLEN(WBXML_PARSER_UNKNOWN_STRING);
+            wbxml_free(ext);
+            return WBXML_OK;
+#else
+            return WBXML_ERROR_UNKNOWN_EXTENSION_VALUE;
+#endif /* WBXML_PARSER_BEST_EFFORT */
+        }
+    
+        ext = (WB_UTINY *) wbxml_strdup((const WB_TINY*) parser->langTable->extValueTable[tab_index].xmlName);
+        len = WBXML_STRLEN(parser->langTable->extValueTable[tab_index].xmlName);
+        break;
+
+#endif /* WBXML_SUPPORT_WV */
+    
+    default:
+        WBXML_ERROR((WBXML_PARSER, "Extension tokens not allowed with this Document !"));
+    }
+
+    /* Set result */
+    if (ext == NULL) {
+        *result = NULL;
+    }
+    else {
+        if ((*result = wbxml_buffer_create(ext, len, len)) == NULL) {
+            wbxml_free(ext);
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        /** @todo Replace this local var by the direct creation of the result Buffer */
+        wbxml_free(ext);
+    }
+  
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML entity
+ * @param parser The WBXML Parser
+ * @param result The resulting parsed entity
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note entity = ENTITY entcode
+ * @note http://www.w3.org/TR/wbxml/ : 
+ *         "The character entity token (ENTITY) encodes a numeric character entity. This has the same semantics
+ *          as an XML numeric character entity (eg, &#32;). The mb_u_int32 refers to a character in the UCS-4
+ *          character encoding. All entities in the source XML document must be represented using either a string
+ *          token (eg, STR_I or the ENTITY token."
+ * @warning The resulting entity paramater MUST be freed by caller !
+ */
+static WBXMLError parse_entity(WBXMLParser *parser, WBXMLBuffer **result)
+{
+    WB_ULONG   code   = 0;
+    WBXMLError ret    = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing entity", parser->pos));
+  
+    /* Skip ENTITY */
+    parser->pos++;
+  
+    if ( (ret = parse_entcode(parser, &code)) != WBXML_OK ) {
+        return ret;
+    }
+  
+    /*
+     * Convert the UCS-4 code to a UTF-8 encoded string.
+     */
+
+    assert(code < 0x80000000);
+
+    if (code < 0x80)
+    {
+        /* For codes under 0x80, we don't need any fancy formatting. */
+        WB_TINY entity[2] = {(WB_TINY)code, 0};
+
+        /* Create result buffer */
+        if ( (*result = wbxml_buffer_create_from_cstr(entity)) == NULL ) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+      
+        return WBXML_OK;
+    }
+    else
+    {
+        WB_UTINY masks[5] = {0xFC, 0xF8, 0xF0, 0xE0, 0xC0};
+        WB_UTINY entity[7] = {0, 0, 0, 0, 0, 0, 0};
+
+        int index = 5;
+        while (code >= 0x40)
+        {
+            entity[index] = 0x80 | (code & 0x3F);
+            code >>= 6; index--;
+        }
+        entity[index] = masks[index] | code;
+
+        /* Create result buffer */
+        if ( (*result = wbxml_buffer_create_from_cstr((WB_TINY *) entity + index)) == NULL ) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+      
+        return WBXML_OK;        
+    }
+}
+
+
+/**
+ * @brief Parse WBXML opaque
+ * @param parser The WBXML Parser
+ * @param result Resulting opaque data parsed
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note opaque = OPAQUE length *byte
+ * @note length = mb_u_int32
+ */
+static WBXMLError parse_opaque(WBXMLParser *parser, WBXMLBuffer **result)
+{
+    WB_ULONG   len = 0;
+    WBXMLError ret = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing opaque", parser->pos));
+  
+    if (parser->version < WBXML_VERSION_11) {
+        WBXML_WARNING((WBXML_PARSER, "No 'opaque' support in WBXML < %s", WBXML_VERSION_TEXT_11));
+    }
+  
+    /* Skip OPAQUE */
+    parser->pos++;
+  
+    if ((ret = parse_mb_uint32(parser, &len)) != WBXML_OK) {
+        return ret;
+    }
+
+    /* Check that length specified in OPAQUE doesn't overflow wbxml length */
+    if (len > wbxml_buffer_len(parser->wbxml) - parser->pos) {
+        return WBXML_ERROR_BAD_OPAQUE_LENGTH;
+    }
+
+    /**
+     * Create result buffer (don't create a static buffer, because this can be
+     * modified while trying to decode this content)
+     */
+    *result = wbxml_buffer_create(wbxml_buffer_get_cstr(parser->wbxml) + parser->pos, len, len);
+    if (*result == NULL) {
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+  
+    parser->pos += len;
+  
+    return ret;
+}
+
+
+/**
+ * @brief Parse WBXML literalTag
+ * @param parser The WBXML Parser
+ * @param mask   Resulting tag mask (WBXML_TOKEN_MASK          |
+ *                                   WBXML_TOKEN_WITH_CONTENT  |
+ *                                   WBXML_TOKEN_WITH_ATTRS    |
+ *                                   (WBXML_TOKEN_WITH_CONTENT || WBXML_TOKEN_WITH_ATTRS))
+ * @param result The resulting parsed literal
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note    result = ( literalTag index )
+ *            literalTag = LITERAL | LITERAL_A | LITERAL_C | LITERAL_AC
+ */
+static WBXMLError parse_literal(WBXMLParser  *parser,
+                                WB_UTINY     *mask,
+                                WBXMLBuffer **result)
+{
+    WBXMLError ret     = WBXML_OK;
+    WB_UTINY   token   = 0;
+    WB_ULONG   index   = 0;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing literalTag", parser->pos));
+  
+    /* Parse literalTag */
+    if ( (ret = parse_uint8(parser, &token)) != WBXML_OK ) {
+        return ret;
+    }
+  
+    /* Parse index */
+    if ( (ret = parse_mb_uint32(parser, &index)) != WBXML_OK ) {
+        return ret;
+    }
+  
+    /* Get string */
+    if ( (ret = get_strtbl_reference(parser, index, result)) != WBXML_OK ) {
+        return ret;
+    }
+
+    /* Build Tag Mask */
+    switch(token) {
+    case WBXML_LITERAL:
+        *mask = WBXML_TOKEN_MASK;
+        break;
+
+    case WBXML_LITERAL_C:
+        *mask = WBXML_TOKEN_WITH_CONTENT;
+        break;
+
+    case WBXML_LITERAL_A:
+        *mask = WBXML_TOKEN_WITH_ATTRS;
+        break;
+
+    case WBXML_LITERAL_AC:
+        *mask = ( WBXML_TOKEN_WITH_CONTENT | WBXML_TOKEN_WITH_ATTRS );
+        break;
+
+    default:
+        return WBXML_ERROR_INTERNAL;
+    }
+  
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML attrStart
+ * @param parser The WBXML Parser
+ * @param name The Attribute Name parsed
+ * @param value The Attribute Value associated, if any
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note attrStart = ([switchPage] ATTRSTART) | ( LITERAL index )
+ */
+static WBXMLError parse_attr_start(WBXMLParser         *parser,
+                                   WBXMLAttributeName **name,
+                                   const WB_UTINY     **value)
+{
+    WBXMLBuffer *literal_str = NULL;
+    WB_UTINY     literal     = 0;    
+    WB_UTINY     tag         = 0;
+    WBXMLError   ret         = WBXML_OK;
+    WB_ULONG     index       = 0;
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing attrStart", parser->pos));
+  
+  
+    /**************************
+     * Case: ( LITERAL index ) 
+     */
+  
+    if (is_token(parser, WBXML_LITERAL)) {
+        if ((ret = parse_literal(parser, &literal, &literal_str)) != WBXML_OK) {
+            return ret;
+        }
+    
+        if ((*name = wbxml_attribute_name_create_literal(wbxml_buffer_get_cstr(literal_str))) == NULL) {
+            ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    
+        /**
+         * @todo Return Warning if 'literal' is different from 'WBML_TOKEN_MASK' (because it MUST be a 'LITERAL' token, not
+         *       LITERAL_A, nor LITERAL_C, nor LITERAL_AC
+         */
+
+        wbxml_buffer_destroy(literal_str);
+        return WBXML_OK;
+    }
+  
+  
+    /***********************************
+     * Case: ( [switchPage] ATTRSTART )
+     */
+  
+    /* Parse switchPage */
+    if (is_token(parser, WBXML_SWITCH_PAGE)) {
+        if ((ret = parse_switch_page(parser, WBXML_ATTR_TOKEN)) != WBXML_OK) {
+            return ret;
+        }
+    }
+  
+    /* Parse UINT8 */
+    if ((ret = parse_uint8(parser, &tag)) != WBXML_OK) {
+        return ret;
+    }
+  
+    WBXML_DEBUG((WBXML_PARSER, "\tToken: 0x%X", tag));
+  
+    /* Search tag in Tags Table */
+    if (parser->langTable == NULL) {
+        return WBXML_ERROR_LANG_TABLE_UNDEFINED;
+    }
+  
+    if (parser->langTable->attrTable == NULL) { 
+        return WBXML_ERROR_ATTR_TABLE_UNDEFINED;
+    }
+
+    while ((parser->langTable->attrTable[index].xmlName != NULL) &&
+           ((parser->langTable->attrTable[index].wbxmlToken != tag) ||
+            (parser->langTable->attrTable[index].wbxmlCodePage != parser->attrCodePage)))
+    {
+        index++;
+    }
+  
+    if (parser->langTable->attrTable[index].xmlName == NULL) {
+#if WBXML_PARSER_BEST_EFFORT
+        /* Create "unknown" Attribute Name */
+        if ((*name = wbxml_attribute_name_create_literal(WBXML_PARSER_UNKNOWN_STRING)) == NULL) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    
+        return WBXML_OK;
+#else
+        return WBXML_ERROR_UNKNOWN_ATTR;
+#endif /* WBXML_PARSER_BEST_EFFORT */
+    }
+  
+    /* Create Token Attribute Name */
+    if ((*name = wbxml_attribute_name_create(WBXML_VALUE_TOKEN)) == NULL) {
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+  
+    (*name)->u.token = &(parser->langTable->attrTable[index]);
+  
+    /* Get Attribute start value (if any) */
+    if (parser->langTable->attrTable[index].xmlValue != NULL) {
+        *value = (const WB_UTINY *) parser->langTable->attrTable[index].xmlValue;
+    }
+  
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML attrValue
+ * @param parser [in]  The WBXML Parser
+ * @param result [out] The resulting Value parsed
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note attrValue = ([switchPage] ATTRVALUE) | string | extension | entity | opaque
+ */
+static WBXMLError parse_attr_value(WBXMLParser  *parser,
+                                   WBXMLBuffer **result)
+{
+    WB_ULONG   index = 0;
+    WB_UTINY   tag   = 0;
+    WBXMLError ret   = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing attrValue", parser->pos));
+  
+    /* Parse extension */
+    if (is_extension(parser)) {
+        return parse_extension(parser, WBXML_ATTR_TOKEN, result);
+    }
+  
+    /* Parse entity */
+    if (is_token(parser, WBXML_ENTITY)) {
+        return parse_entity(parser, result);
+    }
+  
+    /* Parse string */
+    if (is_string(parser)) {
+        return parse_string(parser, result);
+    }
+
+    /* Parse opaque */
+    if (is_token(parser, WBXML_OPAQUE)) {
+        if (parser->version < WBXML_VERSION_12) {
+            WBXML_ERROR((WBXML_PARSER, "An Attribute value can't be 'opaque' in WBXML version < %s", WBXML_VERSION_TEXT_12));
+        }
+        
+        if ((ret = parse_opaque(parser, result)) != WBXML_OK) 
+            return ret;
+        
+        return decode_opaque_attr_value(parser, result);
+    }
+  
+  
+    /*****************************
+     *    ([switchPage] ATTRVALUE)
+     */
+  
+    /* Parse switchPage */
+    if (is_token(parser, WBXML_SWITCH_PAGE)) {
+        ret = parse_switch_page(parser, WBXML_ATTR_TOKEN);
+        if (ret != WBXML_OK) {
+            return ret;
+        }
+    }
+  
+    /* Parse UINT8 */
+    ret = parse_uint8(parser, &tag);
+    if (ret != WBXML_OK) {
+        return ret;
+    }
+  
+    /* Search tag in Tags Table */
+    if (parser->langTable == NULL) {
+        return WBXML_ERROR_LANG_TABLE_UNDEFINED;
+    }
+  
+    if (parser->langTable->attrValueTable == NULL) {
+        return WBXML_ERROR_ATTR_VALUE_TABLE_UNDEFINED;
+    }
+  
+    while ((parser->langTable->attrValueTable[index].xmlName != NULL) &&
+           ((parser->langTable->attrValueTable[index].wbxmlToken != tag) ||
+            (parser->langTable->attrValueTable[index].wbxmlCodePage != parser->attrCodePage)))
+    {
+        index++;
+    }
+  
+    if (parser->langTable->attrValueTable[index].xmlName == NULL) {
+        return WBXML_ERROR_UNKNOWN_ATTR_VALUE;
+    }
+
+    *result = wbxml_buffer_sta_create_from_cstr(parser->langTable->attrValueTable[index].xmlName);
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML termstr
+ * @param parser [in]  The WBXML Parser
+ * @param result [out] The resulting parsed string
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note termstr = charset-dependent string with termination
+ */
+static WBXMLError parse_termstr(WBXMLParser  *parser,
+                                WBXMLBuffer **result)
+{
+    WB_ULONG   max_len  = 0;
+    WBXMLError ret      = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing termstr", parser->pos));
+
+    /* Get max possible string length */
+    max_len = wbxml_buffer_len(parser->wbxml) - parser->pos;
+  
+    /* Convert to UTF-8 Buffer */
+    if ((ret = wbxml_charset_conv_term((const WB_TINY *) (wbxml_buffer_get_cstr(parser->wbxml) + parser->pos),
+                                       &max_len,
+                                       parser->charset,
+                                       result,
+                                       WBXML_CHARSET_UTF_8)) != WBXML_OK) {
+        return ret;
+    }
+
+    parser->pos += max_len;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) termstr: %s", parser->pos, wbxml_buffer_get_cstr(*result)));
+  
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse WBXML inline
+ * @param parser [in]  The WBXML Parser
+ * @param result [out] The resulting parsed string
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note inline = STR_I termstr
+ */
+static WBXMLError parse_inline(WBXMLParser  *parser,
+                               WBXMLBuffer **result)
+{
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing inline", parser->pos));
+  
+    /* Skip STR_I */
+    parser->pos++;
+  
+    return parse_termstr(parser, result);
+}
+
+
+/**
+ * @brief Parse WBXML tableref
+ * @param parser The WBXML Parser
+ * @param result The resulting parsed string
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note tableref = STR_T index
+ * @note index = mb_u_int32
+ */
+static WBXMLError parse_tableref(WBXMLParser  *parser,
+                                 WBXMLBuffer **result)
+{
+    WB_ULONG index;
+    WBXMLError ret = WBXML_OK;
+  
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing tableref", parser->pos));
+  
+    /* Skip STR_T */
+    parser->pos++;
+  
+    /* Parse index */
+    if ((ret = parse_mb_uint32(parser, &index)) != WBXML_OK) {
+        return ret;
+    }
+  
+    return get_strtbl_reference(parser, index, result);
+}
+
+
+/**
+ * @brief Parse WBXML entcode
+ * @param parser [in] The WBXML Parser
+ * @param result [out] The entcode parsed
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note entcode = mb_u_int32 // UCS-4 character code
+ */
+static WBXMLError parse_entcode(WBXMLParser *parser,
+                                WB_ULONG    *result)
+{
+    WBXML_DEBUG((WBXML_PARSER, "(%d) Parsing entcode", parser->pos));
+  
+    return parse_mb_uint32(parser, result);
+}
+
+
+/**
+ * @brief Get a string from String Table
+ * @param parser The WBXML Parser
+ * @param index  Index of string in String Table
+ * @param result The resulting parsed string
+ * @return WBXML_OK if OK, an error code otherwise
+ */
+static WBXMLError get_strtbl_reference(WBXMLParser  *parser,
+                                       WB_ULONG      index,
+                                       WBXMLBuffer **result)
+{
+    WB_ULONG   max_len = 0;
+    WBXMLError ret     = WBXML_OK;
+
+    /* WORKAROUND: 2011-Jan-21 Michael Bell
+     * WORKAROUND:
+     * WORKAROUND: Nokia encodes the name space not only in the publicid.
+     * WORKAROUND: Some Nokia software encodes the SyncML name space
+     * WORKAROUND: as an attribute without a name and without a string
+     * WORKAROUND: table but with a LITAERAL and an index.
+     * WORKAROUND:
+     * WORKAROUND: Example:  ED 04 00 03 SYNCML:SYNCML1.2 00
+     * WORKAROUND:   ED => 2D => SyncML
+     * WORKAROUND:   04 => LITERAL (incl. ATTRSTART)
+     * WORKAROUND:   00 => index 0 (without string table)
+     * WORKAROUND:   03 => TOKEN_STR_I (inline sring)
+     * WORKAROUND:
+     * WORKAROUND: If this mistake is detected then "xmlns" is returned.
+     */
+    if (parser->strstbl == NULL && index == 0) {
+        WBXML_DEBUG((WBXML_PARSER, "(%d) Workaround Nokia: NO string table, index 0 => encoded xmlns", parser->pos));
+
+        /* UTF-8 xmlns */
+        if ((*result = wbxml_buffer_create_from_cstr("xmlns")) == NULL) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+        
+        return WBXML_OK;
+    }
+  
+    /* Check if strtbl is NULL */
+    if (parser->strstbl == NULL) {
+        return WBXML_ERROR_NULL_STRING_TABLE;
+    }
+  
+    if (index >= wbxml_buffer_len(parser->strstbl)) {
+        return WBXML_ERROR_INVALID_STRTBL_INDEX;
+    }
+
+    /* Get max possible string length */
+    max_len = wbxml_buffer_len(parser->strstbl) - index;
+
+    /* Convert to UTF-8 Buffer */
+    if ((ret = wbxml_charset_conv_term((const WB_TINY *) (wbxml_buffer_get_cstr(parser->strstbl) + index),
+                                       &max_len,
+                                       parser->charset,
+                                       result,
+                                       WBXML_CHARSET_UTF_8)) != WBXML_OK) {
+        return ret;
+    }
+
+    WBXML_DEBUG((WBXML_PARSER, "(%d) String Table Reference: %s", parser->pos, wbxml_buffer_get_cstr(*result)));
+
+    return WBXML_OK;
+}
+
+
+/********************************
+ *    Basic Types Parse functions
+ */
+
+/**
+ * @brief Parse UINT8
+ * @param parser [in] The WBXML Parser
+ * @param result [out] Parsed UINT8
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note u_int8 = 8 bit unsigned integer
+ */
+static WBXMLError parse_uint8(WBXMLParser *parser, WB_UTINY *result)
+{
+    if (parser == NULL)
+        return WBXML_ERROR_NULL_PARSER;
+
+    if (result == NULL)
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    if (parser->pos == wbxml_buffer_len(parser->wbxml))
+        return WBXML_ERROR_END_OF_BUFFER;
+
+    if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, result))
+        return WBXML_ERROR_END_OF_BUFFER;
+
+    parser->pos++;
+
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Parse a MultiByte UINT32
+ * @param parser The WBXML Parser
+ * @param result The parsed MultiByte
+ * @return WBXML_OK if parsing is OK, an error code otherwise
+ * @note mb_u_int32 = 32 bit unsigned integer, encoded in multi-byte format
+ */
+static WBXMLError parse_mb_uint32(WBXMLParser *parser, WB_ULONG *result)
+{
+    WB_ULONG uint = 0, byte_pos;
+    WB_UTINY cur_byte;
+
+    if (parser == NULL)
+        return WBXML_ERROR_NULL_PARSER;
+
+    if (result == NULL)
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    /* It's a 32bit integer, and so it fits to a maximum of 4 bytes */
+    for (byte_pos = 0; byte_pos < 5; byte_pos++) {
+        /* Get current byte */
+        if (!wbxml_buffer_get_char(parser->wbxml, parser->pos, &cur_byte))
+            return WBXML_ERROR_END_OF_BUFFER;
+
+        /* Move to next byte */
+        parser->pos++;
+
+        /* Update uint value */
+        uint = (uint << 7) | ((WB_UTINY)cur_byte & 0x7F);
+
+        /* Check first bit, and stop if value is zero */
+        if (!((WB_UTINY)cur_byte & 0x80)) {
+            *result = uint;
+            return WBXML_OK;
+        }
+    }
+
+    return WBXML_ERROR_UNVALID_MBUINT32;
+}
+
+
+/****************************************
+ * Language Specific Decoding Functions 
+ */
+
+/**
+ * @brief Decode a BASE64 value
+ * @param data [in/out]The value to decode
+ * @return WBXML_OK if OK, another error code otherwise
+ */
+static WBXMLError decode_base64_value(WBXMLBuffer **data)
+{
+    WB_UTINY   *result = NULL;
+    WBXMLError  ret    = WBXML_OK;
+    
+    if ((data == NULL) || (*data == NULL)) {
+        return WBXML_ERROR_INTERNAL;
+    }
+    
+    if ((result = wbxml_base64_encode((const WB_UTINY *) wbxml_buffer_get_cstr(*data),
+                                      wbxml_buffer_len(*data))) == NULL)
+    {
+        return WBXML_ERROR_B64_ENC;
+    }
+    
+    /* Reset buffer */
+    wbxml_buffer_delete(*data, 0, wbxml_buffer_len(*data));
+    
+    /* Set data */
+    if (!wbxml_buffer_append_cstr(*data, result)) {
+        ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+    
+    wbxml_free(result);
+    
+    return ret;
+}
+
+
+#if ( defined( WBXML_SUPPORT_SI ) || defined( WBXML_SUPPORT_EMN ) )
+
+/**************************************
+ * SI 1.0 / EMN 1.0
+ */
+
+/**
+ * @brief Decode a %Datetime Attribute Value
+ * @param buff The Attribute Value to convert
+ * @return WBXML_OK if OK, another error code otherwise
+ * @note Used for:
+ *      - SI 1.0: Decode date for 'created' and 'si-expires' attributes
+ *      - EMN 1.0: Decode date for 'timestamp' attribute
+ */
+static WBXMLError decode_datetime(WBXMLBuffer *buff)
+{
+    WB_ULONG len = 0;
+
+    /* Binary to Hexa */
+    if (!wbxml_buffer_binary_to_hex(buff, TRUE))
+        return WBXML_ERROR_INTERNAL;
+
+    /* Check Integrity */
+    len = wbxml_buffer_len(buff);
+    if ((len < 8) || (len > 14) || (len == 9) || (len == 11) || (len == 13))
+        return WBXML_ERROR_BAD_DATETIME;
+
+    /* Date */
+
+    /* "1999-" */
+    if (!wbxml_buffer_insert_cstr(buff, (WB_UTINY *)"-", 4))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* "1999-04-" */
+    if (!wbxml_buffer_insert_cstr(buff, (WB_UTINY *)"-", 7))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* "1999-04-30T" */
+    if (!wbxml_buffer_insert_cstr(buff, (WB_UTINY *)"T", 10))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Time */
+
+    /* Append ':' delimiters */
+    if (len > 10) {
+        if (!wbxml_buffer_insert_cstr(buff, (WB_UTINY *)":", 13))
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    if (len > 12) {
+        if (!wbxml_buffer_insert_cstr(buff, (WB_UTINY *)":", 16))
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Append Trailing Zeros */
+    switch (len) {
+    case 8:
+        if (!wbxml_buffer_append_cstr(buff, (WB_UTINY *)"00:00:00"))
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        break;
+    case 10:
+        if (!wbxml_buffer_append_cstr(buff, (WB_UTINY *)":00:00"))
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        break;
+    case 12:
+        if (!wbxml_buffer_append_cstr(buff, (WB_UTINY *)":00"))
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        break;
+    default:
+        /* 14 : Nothing to do */
+        break;
+    }
+
+    /* Append ending 'Z' character */
+    if (!wbxml_buffer_append_char(buff, 'Z'))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    return WBXML_OK;
+}
+
+#endif /* WBXML_SUPPORT_SI || WBXML_SUPPORT_EMN */
+
+
+/**
+ * @brief Decode an Opaque Content buffer
+ * @param parser The WBXML Parser
+ * @param data The Opaque data buffer
+ * @return WBXML_OK if OK, another error code otherwise
+ */
+static WBXMLError decode_opaque_content(WBXMLParser  *parser,
+                                        WBXMLBuffer **data)
+{
+    switch (parser->langTable->langID) 
+    {
+
+#if defined( WBXML_SUPPORT_WV )
+
+    case WBXML_LANG_WV_CSP11:
+    case WBXML_LANG_WV_CSP12:
+        return decode_wv_content(parser, data);
+        break;
+
+#endif /* WBXML_SUPPORT_WV */
+    
+#if defined( WBXML_SUPPORT_DRMREL )
+
+    case WBXML_LANG_DRMREL10:
+        /* ds:KeyValue */
+        if ((parser->current_tag->wbxmlCodePage == 0x00) &&
+            (parser->current_tag->wbxmlToken == 0x0C))
+        {
+            /* Decode base64 value */ 
+            return decode_base64_value(data);
+        }
+        break;
+
+#endif /* WBXML_SUPPORT_DRMREL */    
+
+#if defined( WBXML_SUPPORT_SYNCML )
+
+    case WBXML_LANG_SYNCML_SYNCML10: 
+    case WBXML_LANG_SYNCML_SYNCML11: 
+    case WBXML_LANG_SYNCML_SYNCML12: 
+        /* NextNonce */
+        if ((parser->current_tag->wbxmlCodePage == 0x01) &&
+            (parser->current_tag->wbxmlToken == 0x10)) 
+        {
+            /* Decode base64 value */ 
+            return decode_base64_value(data);
+        }
+        break;
+
+#endif /* WBXML_SUPPORT_SYNCML */    
+
+    default:
+        /* NOP */
+        break;
+    } /* switch */
+  
+    return WBXML_OK;
+}
+
+
+/**
+ * @brief Decode an Opaque Attribute Value buffer
+ * @param parser The WBXML Parser
+ * @param data The Opaque data buffer
+ * @return WBXML_OK if OK, another error code otherwise
+ */
+static WBXMLError decode_opaque_attr_value(WBXMLParser *parser, WBXMLBuffer **data)
+{
+    switch (parser->langTable->langID) 
+    {
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+
+    case WBXML_LANG_OTA_SETTINGS:
+    {
+        WBXMLError ret = WBXML_OK;
+        
+        /* Decode base64 value */
+        if ((ret = decode_base64_value(data)) != WBXML_OK)
+            return ret; 
+
+        return WBXML_OK;
+    }
+
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */ 
+
+    default:
+        /* NOP */
+        break;
+    } /* switch */
+  
+    return WBXML_OK;
+}
+
+
+#if defined( WBXML_SUPPORT_WV )
+
+/**************************************
+ * WV 1.1 / WV 1.2
+ */
+
+/**
+ * @brief Decode a WV Content encoded in an Opaque
+ * @param parser The WBXML Parser
+ * @param data The WV Integer to decode
+ * @return WBXML_OK if OK, another error code otherwise
+ * @note Used for:
+ *      - WV 1.1 / 1.2
+ */
+static WBXMLError decode_wv_content(WBXMLParser  *parser, WBXMLBuffer **data)
+{
+    WBXMLWVDataType data_type = WBXML_WV_DATA_TYPE_STRING;
+    WBXMLError      ret       = WBXML_OK;
+
+    /* Wireless-Village 1.1 / 1.2 */
+  
+    /* 
+     *  Specific WV Opaque Data Type Elements:
+     *
+     *        Integer:
+     *            Code (0x00 / 0x0B)
+     *            ContentSize (0x00 / 0x0F)
+     *            MessageCount (0x00 / 0x1A)
+     *            Validity (0x00 / 0x3C)
+     *            KeepAliveTime (0x01 / 0x1C)
+     *            SearchFindings (0x01 / 0x25)
+     *            SearchID (0x01 / 0x26)
+     *            SearchIndex (0x01 / 0x27)
+     *            SearchLimit (0x01 / 0x28)
+     *            TimeToLive (0x01 / 0x32)
+     *            AcceptedCharSet (0x03 / 0x05)
+     *            AcceptedContentLength (0x03 / 0x06)
+     *            MultiTrans (0x03 / 0x0C)
+     *            ParserSize (0x03 / 0x0D)
+     *            ServerPollMin (0x03 / 0x0E)
+     *            TCPPort (0x03 / 0x12)
+     *            UDPPort (0x03 / 0x13)
+     *            HistoryPeriod (0x09 / 0x08) [WV 1.2]
+     *            MaxWatcherList (0x09 / 0x0A) [WV 1.2]
+     *
+     *        Date and Time:
+     *            DateTime (0x00 / 0x11)
+     *            DeliveryTime (0x06 / 0x1A)
+     *
+     *        Binary:
+     *            ContentData (0x00 / 0x0D) (only if we have a:
+     *                                       "<ContentEncoding>BASE64</ContentEncoding>" associated)
+     */
+  
+    /***********************************************
+     * Check the Data Type, given the Current Tag 
+     */
+  
+    switch (parser->current_tag->wbxmlCodePage) {
+    case 0x00:
+        /* Code Page: 0x00 */
+        switch (parser->current_tag->wbxmlToken) {
+            case 0x0B: /* Code */
+            case 0x0F: /* ContentSize */
+            case 0x1A: /* MessageCount */
+            case 0x3C: /* Validity */
+                /* INTEGER */
+                data_type = WBXML_WV_DATA_TYPE_INTEGER;
+                break;
+
+            case 0x11: /* DateTime */
+                /* DATE_AND_TIME */
+                data_type = WBXML_WV_DATA_TYPE_DATE_AND_TIME;
+                break;
+
+            case 0x0D: /* ContentData */
+                /* BINARY */
+                /** @todo Check if we have a: "<ContentEncoding>BASE64</ContentEncoding>" associated */
+                /*
+                    if (base64_encoded)
+                        data_type = WBXML_WV_DATA_TYPE_BINARY;
+                    else
+                */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+            break;
+
+            default:
+                /* STRING */
+                data_type = WBXML_WV_DATA_TYPE_STRING;
+                break;
+            }
+            break;
+
+    case 0x01:
+        /* Code Page: 0x01 */
+        switch (parser->current_tag->wbxmlToken) {
+        case 0x1C: /* KeepAliveTime */
+        case 0x25: /* SearchFindings */
+        case 0x26: /* SearchID */
+        case 0x27: /* SearchIndex */
+        case 0x28: /* SearchLimit */
+        case 0x32: /* TimeToLive */
+            /* INTEGER */
+            data_type = WBXML_WV_DATA_TYPE_INTEGER;
+            break;
+
+        default:
+            /* STRING */
+            data_type = WBXML_WV_DATA_TYPE_STRING;
+            break;
+        }
+        break;
+
+    case 0x03:
+        /* Code Page: 0x03 */
+        switch (parser->current_tag->wbxmlToken) {
+        case 0x05: /* AcceptedCharSet */
+        case 0x06: /* AcceptedContentLength */
+        case 0x0C: /* MultiTrans */
+        case 0x0D: /* ParserSize */
+        case 0x0E: /* ServerPollMin */
+        case 0x12: /* TCPPort */
+        case 0x13: /* UDPPort */
+            /* INTEGER */
+            data_type = WBXML_WV_DATA_TYPE_INTEGER;
+            break;
+
+        default:
+            /* STRING */
+            data_type = WBXML_WV_DATA_TYPE_STRING;
+            break;
+        }
+        break;
+
+    case 0x05:
+        /* Code Page: 0x05 */
+        switch (parser->current_tag->wbxmlToken) {
+        case 0x05: /* Altitude */
+        case 0x09: /* Accuracy */
+        case 0x32: /* Cpriority */
+            /* INTEGER */
+            data_type = WBXML_WV_DATA_TYPE_INTEGER;
+            break;
+
+        default:
+            /* STRING */
+            data_type = WBXML_WV_DATA_TYPE_STRING;
+            break;
+        }
+        break;
+
+    case 0x06:
+        /* Code Page: 0x06 */
+        switch (parser->current_tag->wbxmlToken) {
+        case 0x1A: /* DeliveryTime */
+            /* DATE AND TIME */
+            data_type = WBXML_WV_DATA_TYPE_DATE_AND_TIME;
+            break;
+
+        default:
+            /* STRING */
+            data_type = WBXML_WV_DATA_TYPE_STRING;
+            break;
+        }
+        break;
+
+    case 0x09:
+        /* Code Page: 0x09 */
+        switch (parser->current_tag->wbxmlToken) {
+        case 0x08: /* HistoryPeriod */
+        case 0x0A: /* MaxWatcherList */
+            /* INTEGER */
+            data_type = WBXML_WV_DATA_TYPE_INTEGER;
+            break;
+
+        default:
+            /* STRING */
+            data_type = WBXML_WV_DATA_TYPE_STRING;
+            break;
+        }
+        break;
+
+    default:
+        data_type = WBXML_WV_DATA_TYPE_STRING;
+        break;
+    } /* switch */
+  
+  
+    /***********************************************
+     * Decode the Opaque, given the Data Type found 
+     */
+  
+    switch ( data_type ) {
+    case WBXML_WV_DATA_TYPE_INTEGER:
+        /* Decode Integer */
+        if ( (ret = decode_wv_integer(data)) != WBXML_OK )
+            return ret;
+    
+        return WBXML_OK;
+        break;
+
+    case WBXML_WV_DATA_TYPE_DATE_AND_TIME:
+        /* Decode Date and Time */
+        if ( (ret = decode_wv_datetime(data)) != WBXML_OK )
+            return ret;
+    
+        return WBXML_OK;
+        break;
+
+    case WBXML_WV_DATA_TYPE_BINARY:
+        /** @todo decode_wv_binary() */
+        break;
+
+    default:
+        /* Do nothing. Keep this data as is. */
+        break;
+    } /* switch */
+  
+    return WBXML_OK;
+}
+
+/**
+ * @brief Decode a WV Integer encoded in an Opaque
+ * @param data The WV Integer to decode
+ * @return WBXML_OK if OK, another error code otherwise
+ * @note Used for:
+ *      - WV 1.1 / 1.2
+ * @note [OMA-WV-CSP_DataTypes-V1_1-20021001-A.pdf] - 4.1:
+ *       "An integer is a number from 0-4294967295 expressed in decimal format."
+ *
+ * @warning Input 'data' parameter MUST be a static buffer, because its pointer
+ *          is released without being freed.
+ */
+static WBXMLError decode_wv_integer(WBXMLBuffer **data)
+{
+    WB_ULONG i       = 0;
+    WB_ULONG the_int = 0;
+    WB_UTINY ch      = 0;
+    WB_UTINY tmp[11];
+  
+    if ( (data == NULL) || (*data== NULL) )
+        return WBXML_ERROR_INTERNAL;
+
+    /* Get the integer */
+    for ( i = 0; i < wbxml_buffer_len(*data); i++ ) {
+        if (!wbxml_buffer_get_char(*data, i, &ch))
+            return WBXML_ERROR_INTERNAL;
+    
+        the_int = (the_int << 8) | (ch & 0xff);
+    }
+  
+    /* Check integer overflow */
+    if ( the_int > 0xffffffff )
+        return WBXML_ERROR_WV_INTEGER_OVERFLOW;
+  
+    sprintf((WB_TINY *)tmp, "%u", the_int);
+
+    /* Reset buffer */
+    wbxml_buffer_delete(*data, 0, wbxml_buffer_len(*data));
+
+    /* Set data */
+    if (!wbxml_buffer_append_cstr(*data, tmp))
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+  return WBXML_OK;
+}
+
+
+/**
+ * @brief Decode a WV Date and Time encoded in an Opaque
+ * @param data The WV Date Time to decode
+ * @return WBXML_OK if OK, another error code otherwise
+ * @note Used for:
+ *      - WV 1.1 / 1.2
+ * @note 
+ *  Encoded Format: (6 octets)
+ *      - The first 2 bits are reserved, and both must be 0.
+ *      - Year is encoded by 12 bits (0 to 4095)
+ *      - Month is encoded by 4 bits (1 to 12)
+ *      - Day is encoded by 5 bits (1 to 31)
+ *      - Hour is encoded by 5 bits (0 to 23)
+ *      - Minute is encoded by 6 bits (0 to 59)
+ *      - Second is encoded by 6 bits (0 to 59)
+ *      - Time zone is encoded in 1 byte [ISO8601].
+ *
+ *      eg:
+ *          Binary:  00 011111010001 1010 10011 01001 110010 011111 01011010
+ *          Octets:  (-------)(-------)(--------)(-------)(-------) (------)
+ *
+ *  Decoded Format:
+ *      eg: 20011019T095031Z or 20011019T095031
+ *
+ * @warning Input 'data' parameter MUST be a static buffer, because its pointer
+ *          is released without being freed. 
+ */
+static WBXMLError decode_wv_datetime(WBXMLBuffer **data)
+{
+    WB_UTINY *data_ptr = NULL;
+    WB_TINY   the_year[5], the_month[3],  the_date[3], 
+              the_hour[3], the_minute[3], the_second[3],
+              result[17];
+    WB_ULONG the_value = 0;
+    WBXMLError ret = WBXML_OK;
+  
+    /** @todo Test decode_wv_datetime() ! */
+  
+    if ((data == NULL) || (*data == NULL))
+        return WBXML_ERROR_INTERNAL;
+  
+    if (wbxml_buffer_len(*data) != 6)
+        return WBXML_ERROR_WV_DATETIME_FORMAT;
+
+
+    data_ptr = wbxml_buffer_get_cstr(*data);
+  
+    /* Get Year */
+    the_value = (WB_ULONG) (((data_ptr[0] & 0x3F) << 6) + ((data_ptr[1] >> 2) & 0x3F));
+    sprintf(the_year, "%u", the_value);
+  
+    /* Get Month */
+    the_value = (WB_ULONG) (((data_ptr[1] & 0x03) << 2) | ((data_ptr[2] >> 6) & 0x03));
+    sprintf(the_month, "%02u", the_value);
+  
+    /* Get Day */
+    the_value = (WB_ULONG) ((data_ptr[2] >> 1) & 0x1F);
+    sprintf(the_date, "%02u", the_value);
+  
+    /* Get Hour */
+    the_value = (WB_ULONG) (((data_ptr[2] & 0x01) << 4) | ((data_ptr[3] >> 4) & 0x0F));
+    sprintf(the_hour, "%02u", the_value);
+  
+    /* Get Minute */
+    the_value = (WB_ULONG) (((data_ptr[3] & 0x0F) << 2) | ((data_ptr[4] >> 6) & 0x03));
+    sprintf(the_minute, "%02u", the_value);
+  
+    /* Get Second */
+    the_value = (WB_ULONG) (data_ptr[4] & 0x3F);
+    sprintf(the_second, "%02u", the_value);
+  
+    /* Get Time Zone */
+    if (data_ptr[5] == 0) {
+        /* This is a bug in the WBXML document.
+         * If timezone UTC aka Zulu is used then a 'Z' must be set.
+         */
+        sprintf((WB_TINY *) result,
+                "%s%s%sT%s%s%sZ",
+                the_year, the_month, the_date, the_hour, the_minute, the_value ? the_second : "");
+    } else if (data_ptr[5] < 'A' ||
+               data_ptr[5] > 'Z' ||
+               data_ptr[5] == 'J')
+    {
+	/* This is a bug in the WBXML document.
+	 * The timezone byte is set and wrong.
+         * There is no way to recover cleanly from this.
+         * Therefore no timezone is set.
+         */
+        sprintf((WB_TINY *) result,
+                "%s%s%sT%s%s%s",
+                the_year, the_month, the_date, the_hour, the_minute, the_value ? the_second : "");
+    }
+    else {
+        sprintf((WB_TINY *) result,
+                "%s%s%sT%s%s%s%c",
+                the_year, the_month, the_date, the_hour, the_minute, the_value ? the_second : "", data_ptr[5]);
+    }
+  
+    /* Reset buffer */
+    wbxml_buffer_delete(*data, 0, wbxml_buffer_len(*data));
+
+    /* Set data */
+    if (!wbxml_buffer_append_cstr(*data, result)) {
+        ret = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+  
+    return WBXML_OK;
+}
+
+#endif /* WBXML_SUPPORT_WV */

--- a/src/libwbxml/wbxml_parser.h
+++ b/src/libwbxml/wbxml_parser.h
@@ -1,0 +1,162 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_parser.h
+ * @ingroup wbxml_parser
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/03/12
+ *
+ * @brief WBXML Parser - Parse a WBXML document and call user defined Callbacks
+ */
+
+#ifndef WBXML_PARSER_H
+#define WBXML_PARSER_H
+
+#include "wbxml.h"
+#include "wbxml_handlers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_parser 
+ *  @{ 
+ */
+
+/** 
+ * Default charset of the WBXML document. Used only in this case :
+ *  - No charset found in WBXML document
+ *  - No charset was indicated thanks to the function 'wbxml_parser_set_meta_charset()'
+ */
+#define WBXML_PARSER_DEFAULT_CHARSET WBXML_CHARSET_UTF_8
+
+
+typedef struct WBXMLParser_s WBXMLParser;
+
+/**
+ * @brief Create a WBXML Parser
+ * @return Return the newly created WBXMLParser, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLParser *) wbxml_parser_create(void);
+
+/**
+ * @brief Destroy a WBXML Parser
+ * @param parser The WBXMLParser to destroy
+ */
+WBXML_DECLARE(void) wbxml_parser_destroy(WBXMLParser *parser);
+
+/**
+ * @brief Parse a WBXML document, using User Defined callbacks
+ * @param parser The WBXML Parser to use for parsing 
+ * @param wbxml The WBXML document to parse
+ * @param wbxml_len The WBXML document length
+ * @brief Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_parser_parse(WBXMLParser *parser, WB_UTINY *wbxml, WB_ULONG wbxml_len);
+
+/**
+ * @brief Set User Data for a WBXML Parser
+ * @param parser The WBXML Parser
+ * @param user_data User data (returned as a parameter in every Content Handler callbacks)
+ */
+WBXML_DECLARE(void) wbxml_parser_set_user_data(WBXMLParser *parser, void *user_data);
+
+/**
+ * @brief Set Content Handler for a WBXML Parser
+ * @param parser The WBXML Parser
+ * @param content_handler The Content Handler structure
+ */
+WBXML_DECLARE(void) wbxml_parser_set_content_handler(WBXMLParser *parser, WBXMLContentHandler *content_handler);
+
+/**
+ * @brief Set Main WBXML Languages Table
+ * @param parser The WBXML Parser
+ * @param main_table The Main WBXML Languages Table to set
+ */
+WBXML_DECLARE(void) wbxml_parser_set_main_table(WBXMLParser *parser, const WBXMLLangEntry *main_table);
+
+/**
+ * @brief Force to parse the Document of a given Language
+ * @param parser The WBXML Parser
+ * @param lang The Language
+ * @return TRUE if Language is set, FALSE otherwise
+ * @note This permits to force the WBXML Parser to parse a WBXML Document of a given LanguageD.
+ *       If this fonction is used, the internal Public ID of the WBXML Document is ignored.
+ *       It is sometimes needed for documents that don't have any WBXML Public ID.
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_parser_set_language(WBXMLParser *parser, WBXMLLanguage lang);
+
+/**
+ * @brief Set additionnal meta-information to help determining the Charset Encoding of the Document to parse
+ * @param parser The WBXML Parser
+ * @param charset The Charset MIBEnum
+ * @return TRUE if Charset is set, FALSE otherwise
+ * @note This information is only used if the Charset Encoding is not specified in WBXML Document:
+ *       "The binary XML format contains a representation of the XML document character encoding.
+ *        This is the WBXML equivalent of the XML document format encoding attribute,
+ *        which is specified in the ?xml processing instruction ... In the case of
+ *        an unknown encoding, transport meta-information should be used to determine the character
+ *        encoding. If transport meta-information is unavailable, the default encoding of UTF-8
+ *        should be assumed."
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_parser_set_meta_charset(WBXMLParser *parser, WBXMLCharsetMIBEnum charset);
+
+/**
+ * @brief Get WBXML Public ID
+ * @param parser The WBXML Parser
+ * @return The WBXML Public ID of current parsing document
+ */
+WBXML_DECLARE(WB_ULONG) wbxml_parser_get_wbxml_public_id(WBXMLParser *parser);
+
+/**
+ * @brief Get XML Public ID
+ * @param parser The WBXML Parser
+ * @return The XML Public ID of current parsing document, or NULL if not found
+ */
+WBXML_DECLARE(const WB_UTINY *) wbxml_parser_get_xml_public_id(WBXMLParser *parser);
+
+/**
+ * @brief Get WBXML Version
+ * @param parser The WBXML Parser
+ * @return The WBXML Version of current parsing document
+ */
+WBXML_DECLARE(WBXMLVersion) wbxml_parser_get_wbxml_version(WBXMLParser *parser);
+
+/**
+ * @brief Return current parsing position in WBXML
+ * @param parser The WBXML Parser
+ * @return The parsing position in WBXML
+ */
+WBXML_DECLARE(WB_LONG) wbxml_parser_get_current_byte_index(WBXMLParser *parser);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_PARSER_H */

--- a/src/libwbxml/wbxml_tables.c
+++ b/src/libwbxml/wbxml_tables.c
@@ -1,0 +1,3878 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2008-2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tables.c
+ * @ingroup wbxml_tables
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/03/17
+ *
+ * @brief WBXML Tables
+ */
+
+#include "wbxml_tables.h"
+#include "wbxml_internals.h"
+#include "wbxml_log.h"
+
+/** 
+ * @brief If undefined, only the WML 1.3 tables are used for all WML versions (WML 1.0 / WML 1.1 / WML 1.2 / WML 1.3).
+ *        It saves space, and, well, every handset must supports WML 1.3 right now.
+ *        If defined, each version has its own exact tables.
+ */
+#undef WBXML_TABLES_SEPARATE_WML_VERSIONS
+
+
+/**************************************
+ * Languages Public IDs
+ */
+
+/* WAP */
+#if defined( WBXML_SUPPORT_WML )
+const WBXMLPublicIDEntry sv_wml10_public_id           = { WBXML_PUBLIC_ID_WML10,              XML_PUBLIC_ID_WML10,            "wml",                  "http://www.wapforum.org/DTD/wml.xml"               };
+const WBXMLPublicIDEntry sv_wml11_public_id           = { WBXML_PUBLIC_ID_WML11,              XML_PUBLIC_ID_WML11,            "wml",                  "http://www.wapforum.org/DTD/wml_1_1.dtd"           };
+const WBXMLPublicIDEntry sv_wml12_public_id           = { WBXML_PUBLIC_ID_WML12,              XML_PUBLIC_ID_WML12,            "wml",                  "http://www.wapforum.org/DTD/wml12.dtd"             };
+const WBXMLPublicIDEntry sv_wml13_public_id           = { WBXML_PUBLIC_ID_WML13,              XML_PUBLIC_ID_WML13,            "wml",                  "http://www.wapforum.org/DTD/wml13.dtd"             };
+#endif /* WBXML_SUPPORT_WML */
+
+#if defined( WBXML_SUPPORT_WTA )
+const WBXMLPublicIDEntry sv_wta10_public_id           = { WBXML_PUBLIC_ID_WTA10,              XML_PUBLIC_ID_WTA10,            "wtai",                 "wtai.dtd"                                          };
+const WBXMLPublicIDEntry sv_wtawml12_public_id        = { WBXML_PUBLIC_ID_WTAWML12,           XML_PUBLIC_ID_WTAWML12,         "wta-wml",              "http://www.wapforum.org/DTD/wta-wml12.dtd"         };
+const WBXMLPublicIDEntry sv_channel11_public_id       = { WBXML_PUBLIC_ID_CHANNEL11,          XML_PUBLIC_ID_CHANNEL11,        "channel",              ""                                                  };
+const WBXMLPublicIDEntry sv_channel12_public_id       = { WBXML_PUBLIC_ID_CHANNEL12,          XML_PUBLIC_ID_CHANNEL12,        "channel",              "http://www.wapforum.org/DTD/channel12.dtd"         };
+#endif /* WBXML_SUPPORT_WTA */
+
+#if defined( WBXML_SUPPORT_SI )
+const WBXMLPublicIDEntry sv_si10_public_id            = { WBXML_PUBLIC_ID_SI10,               XML_PUBLIC_ID_SI10,             "si",                   "http://www.wapforum.org/DTD/si.dtd"                };
+#endif /* WBXML_SUPPORT_SI */
+
+#if defined( WBXML_SUPPORT_SL )
+const WBXMLPublicIDEntry sv_sl10_public_id            = { WBXML_PUBLIC_ID_SL10,               XML_PUBLIC_ID_SL10,             "sl",                   "http://www.wapforum.org/DTD/sl.dtd"                };
+#endif /* WBXML_SUPPORT_SL */
+
+#if defined( WBXML_SUPPORT_CO )
+const WBXMLPublicIDEntry sv_co10_public_id            = { WBXML_PUBLIC_ID_CO10,               XML_PUBLIC_ID_CO10,             "co",                   "http://www.wapforum.org/DTD/co_1.0.dtd"            };
+#endif /* WBXML_SUPPORT_CO */
+
+#if defined( WBXML_SUPPORT_PROV )
+const WBXMLPublicIDEntry sv_prov10_public_id          = { WBXML_PUBLIC_ID_PROV10,             XML_PUBLIC_ID_PROV10,           "wap-provisioningdoc",  "http://www.wapforum.org/DTD/prov.dtd"              };
+#endif /* WBXML_SUPPORT_PROV */
+
+#if defined( WBXML_SUPPORT_EMN )
+const WBXMLPublicIDEntry sv_emn10_public_id           = { WBXML_PUBLIC_ID_EMN10,              XML_PUBLIC_ID_EMN10,            "emn",                  "http://www.wapforum.org/DTD/emn.dtd"               }; 
+#endif /* WBXML_SUPPORT_EMN */
+
+#if defined( WBXML_SUPPORT_DRMREL )
+const WBXMLPublicIDEntry sv_drmrel10_public_id        = { WBXML_PUBLIC_ID_DRMREL10,           XML_PUBLIC_ID_DRMREL10,         "o-ex:rights",          "http://www.openmobilealliance.org/DTD/drmrel10.dtd"};
+#endif /* WBXML_SUPPORT_DRMREL */
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+/* Ericsson / Nokia OTA Settings v7.0 */
+const WBXMLPublicIDEntry sv_ota_settings_public_id    = { WBXML_PUBLIC_ID_OTA_SETTINGS,       XML_PUBLIC_ID_OTA_SETTINGS,     "CHARACTERISTIC-LIST",  "characteristic-list.dtd"  };
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+#if defined( WBXML_SUPPORT_SYNCML )
+/* SyncML 1.0 */
+const WBXMLPublicIDEntry sv_syncml_syncml10_public_id = { WBXML_PUBLIC_ID_SYNCML_SYNCML10,    XML_PUBLIC_ID_SYNCML_SYNCML10,  "SyncML",               "http://www.syncml.org/docs/syncml_represent_v10_20001207.dtd"  };  
+const WBXMLPublicIDEntry sv_syncml_devinf10_public_id = { WBXML_PUBLIC_ID_SYNCML_DEVINF10,    XML_PUBLIC_ID_SYNCML_DEVINF10,  "DevInf",               "http://www.syncml.org/docs/syncml_devinf_v10_20001207.dtd"     };
+const WBXMLPublicIDEntry sv_syncml_metinf10_public_id = { WBXML_PUBLIC_ID_SYNCML_METINF10,    XML_PUBLIC_ID_SYNCML_METINF10,  "MetInf",               "http://www.syncml.org/docs/syncml_metinf_v10_20001207.dtd"     };
+
+/* SyncML 1.1 */
+const WBXMLPublicIDEntry sv_syncml_syncml11_public_id = { WBXML_PUBLIC_ID_SYNCML_SYNCML11,    XML_PUBLIC_ID_SYNCML_SYNCML11,  "SyncML",               "http://www.syncml.org/docs/syncml_represent_v11_20020213.dtd"  };
+const WBXMLPublicIDEntry sv_syncml_devinf11_public_id = { WBXML_PUBLIC_ID_SYNCML_DEVINF11,    XML_PUBLIC_ID_SYNCML_DEVINF11,  "DevInf",               "http://www.syncml.org/docs/devinf_v11_20020215.dtd"            };
+const WBXMLPublicIDEntry sv_syncml_metinf11_public_id = { WBXML_PUBLIC_ID_SYNCML_METINF11,    XML_PUBLIC_ID_SYNCML_METINF11,  "MetInf",               "http://www.syncml.org/docs/syncml_metinf_v11_20020215.dtd"     };
+
+/* SyncML 1.2 */
+const WBXMLPublicIDEntry sv_syncml_syncml12_public_id = { WBXML_PUBLIC_ID_SYNCML_SYNCML12,    XML_PUBLIC_ID_SYNCML_SYNCML12,  "SyncML",               "http://www.openmobilealliance.org/tech/DTD/OMA-TS-SyncML_RepPro_DTD-V1_2.dtd"         };
+const WBXMLPublicIDEntry sv_syncml_devinf12_public_id = { WBXML_PUBLIC_ID_SYNCML_DEVINF12,    XML_PUBLIC_ID_SYNCML_DEVINF12,  "DevInf",               "http://www.openmobilealliance.org/tech/DTD/OMA-SyncML-Device_Information-DTD-1.2.dtd" };
+const WBXMLPublicIDEntry sv_syncml_metinf12_public_id = { WBXML_PUBLIC_ID_SYNCML_METINF12,    XML_PUBLIC_ID_SYNCML_METINF12,  "MetInf",               "http://www.openmobilealliance.org/tech/DTD/OMA-TS-SyncML_MetaInfo_DTD-V1_2.dtd"       };
+const WBXMLPublicIDEntry sv_syncml_dmddf12_public_id = { WBXML_PUBLIC_ID_SYNCML_DMDDF12,    XML_PUBLIC_ID_SYNCML_DMDDF12,     "MgmtTree",                "http://www.openmobilealliance.org/tech/DTD/dm_ddf-v1_2.dtd" };
+#endif /* WBXML_SUPPORT_SYNCML */
+
+#if defined( WBXML_SUPPORT_WV )
+/* OMA Wireless Village CSP 1.1 / 1.2 */
+const WBXMLPublicIDEntry sv_wv_csp11_public_id        = { WBXML_PUBLIC_ID_WV_CSP11,           XML_PUBLIC_ID_WV_CSP11,         "WV-CSP-Message",       "http://www.openmobilealliance.org/DTD/WV-CSP.XML"  };
+const WBXMLPublicIDEntry sv_wv_csp12_public_id        = { WBXML_PUBLIC_ID_WV_CSP12,           XML_PUBLIC_ID_WV_CSP12,         "WV-CSP-Message",       "http://www.openmobilealliance.org/DTD/WV-CSP.DTD"  };
+#endif /* WBXML_SUPPORT_WV */
+
+#if defined( WBXML_SUPPORT_AIRSYNC )
+const WBXMLPublicIDEntry sv_airsync_public_id         = { WBXML_PUBLIC_ID_AIRSYNC,            XML_PUBLIC_ID_AIRSYNC,          "AirSync",              "http://www.microsoft.com/"};
+const WBXMLPublicIDEntry sv_activesync_public_id      = { WBXML_PUBLIC_ID_ACTIVESYNC,         XML_PUBLIC_ID_ACTIVESYNC,       "ActiveSync",           "http://www.microsoft.com/"};
+#endif /* WBXML_SUPPORT_AIRSYNC */
+
+#if defined( WBXML_SUPPORT_CONML )
+const WBXMLPublicIDEntry sv_conml_public_id         = { WBXML_PUBLIC_ID_CONML,                XML_PUBLIC_ID_CONML,            "ConML",                "http://www.nokia.com/"};
+#endif /* WBXML_SUPPORT_CONML */
+
+
+/**************************************
+ * Languages Tables
+ */
+
+#if defined( WBXML_SUPPORT_WML )
+
+#ifdef WBXML_TABLES_SEPARATE_WML_VERSIONS
+
+/********************************************
+ *    WML 1.0 (WAP 1.0: "WML-30-Apr-98.pdf")
+ */
+
+const WBXMLTagEntry sv_wml10_tag_table[] = {
+    { "a",         0x00, 0x22 },
+    { "access",    0x00, 0x23 },
+    { "b",         0x00, 0x24 },
+    { "big",       0x00, 0x25 },
+    { "br",        0x00, 0x26 },
+    { "card",      0x00, 0x27 },
+    { "do",        0x00, 0x28 },
+    { "em",        0x00, 0x29 },
+    { "fieldset",  0x00, 0x2a },
+    { "go",        0x00, 0x2b },
+    { "head",      0x00, 0x2c },
+    { "i",         0x00, 0x2d },
+    { "img",       0x00, 0x2e },
+    { "input",     0x00, 0x2f },
+    { "meta",      0x00, 0x30 },
+    { "noop",      0x00, 0x31 },
+    { "prev",      0x00, 0x32 },
+    { "onevent",   0x00, 0x33 },
+    { "optgroup",  0x00, 0x34 },
+    { "option",    0x00, 0x35 },
+    { "refresh",   0x00, 0x36 },
+    { "select",    0x00, 0x37 },
+    { "small",     0x00, 0x38 },
+    { "strong",    0x00, 0x39 },
+    { "tab",       0x00, 0x3a }, /* Deprecated */
+    { "template",  0x00, 0x3b },
+    { "timer",     0x00, 0x3c },
+    { "u",         0x00, 0x3d },
+    { "var",       0x00, 0x3e },
+    { "wml",       0x00, 0x3f },
+    { NULL,        0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_wml10_attr_table[] = {
+    { "accept-charset",  NULL,                                0x00, 0x05 },
+    { "align",           "bottom",                            0x00, 0x06 },
+    { "align",           "center",                            0x00, 0x07 },
+    { "align",           "left",                              0x00, 0x08 },
+    { "align",           "middle",                            0x00, 0x09 },
+    { "align",           "right",                             0x00, 0x0a },
+    { "align",           "top",                               0x00, 0x0b },
+    { "alt",             NULL,                                0x00, 0x0c },
+    { "content",         NULL,                                0x00, 0x0d },
+    { "default",         NULL,                                0x00, 0x0e },
+    { "domain",          NULL,                                0x00, 0x0f },
+    { "emptyok",         "false",                             0x00, 0x10 },
+    { "emptyok",         "true",                              0x00, 0x11 },
+    { "format",          NULL,                                0x00, 0x12 },
+    { "height",          NULL,                                0x00, 0x13 },
+    { "hspace",          NULL,                                0x00, 0x14 },
+    { "idefault",        NULL,                                0x00, 0x15 }, /* Deprecated */
+    { "ikey",            NULL,                                0x00, 0x16 }, /* Deprecated */
+    { "key",             NULL,                                0x00, 0x17 }, /* Deprecated */
+    { "label",           NULL,                                0x00, 0x18 },
+    { "localsrc",        NULL,                                0x00, 0x19 },
+    { "maxlength",       NULL,                                0x00, 0x1a },
+    { "method",          "get",                               0x00, 0x1b },
+    { "method",          "post",                              0x00, 0x1c },
+    { "mode",            "nowrap",                            0x00, 0x1d },
+    { "mode",            "wrap",                              0x00, 0x1e },
+    { "multiple",        "false",                             0x00, 0x1f },
+    { "multiple",        "true",                              0x00, 0x20 },
+    { "name",            NULL,                                0x00, 0x21 },
+    { "newcontext",      "false",                             0x00, 0x22 },
+    { "newcontext",      "true",                              0x00, 0x23 },
+    { "onclick",         NULL,                                0x00, 0x24 }, /* Deprecated */
+    { "onenterbackward", NULL,                                0x00, 0x25 },
+    { "onenterforward",  NULL,                                0x00, 0x26 },
+    { "ontimer",         NULL,                                0x00, 0x27 },
+    { "optional",        "false",                             0x00, 0x28 },
+    { "optional",        "true",                              0x00, 0x29 },
+    { "path",            NULL,                                0x00, 0x2a },
+    { "postdata",        NULL,                                0x00, 0x2b }, /* Deprecated */
+    { "public",          "false",                             0x00, 0x2c }, /* Deprecated */
+    { "public",          "true",                              0x00, 0x2d }, /* Deprecated */
+    { "scheme",          NULL,                                0x00, 0x2e },
+    { "sendreferer",     "false",                             0x00, 0x2f },
+    { "sendreferer",     "true",                              0x00, 0x30 },
+    { "size",            NULL,                                0x00, 0x31 },
+    { "src",             NULL,                                0x00, 0x32 },
+    { "style",           "list",                              0x00, 0x33 }, /* Deprecated */
+    { "style",           "set",                               0x00, 0x34 }, /* Deprecated */
+    { "tabindex",        NULL,                                0x00, 0x35 },
+    { "title",           NULL,                                0x00, 0x36 },
+    { "type",            NULL,                                0x00, 0x37 },
+    { "type",            "accept",                            0x00, 0x38 },
+    { "type",            "delete",                            0x00, 0x39 },
+    { "type",            "help",                              0x00, 0x3a },
+    { "type",            "password",                          0x00, 0x3b },
+    { "type",            "onpick",                            0x00, 0x3c },
+    { "type",            "onenterbackward",                   0x00, 0x3d },
+    { "type",            "onenterforward",                    0x00, 0x3e },
+    { "type",            "ontimer",                           0x00, 0x3f },
+    { "type",            "options",                           0x00, 0x45 },
+    { "type",            "prev",                              0x00, 0x46 },
+    { "type",            "reset",                             0x00, 0x47 },
+    { "type",            "text",                              0x00, 0x48 },
+    { "type",            "vnd.",                              0x00, 0x49 },
+    { "url",             NULL,                                0x00, 0x4a }, /* Deprecated */
+    { "url",             "http://",                           0x00, 0x4b }, /* Deprecated */
+    { "url",             "https://",                          0x00, 0x4c }, /* Deprecated */
+    { "user-agent",      NULL,                                0x00, 0x4d }, /* Deprecated */
+    { "value",           NULL,                                0x00, 0x4e },
+    { "vspace",          NULL,                                0x00, 0x4f },
+    { "width",           NULL,                                0x00, 0x50 },
+    { "xml:lang",        NULL,                                0x00, 0x51 },
+    { NULL,              NULL,                                0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_wml10_attr_value_table[] = {
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { "accept",          0x00, 0x89 },
+    { "bottom",          0x00, 0x8a },
+    { "clear",           0x00, 0x8b },
+    { "delete",          0x00, 0x8c },
+    { "help",            0x00, 0x8d },
+    /* Do NOT change the order in this table please ! */
+    { "http://www.",     0x00, 0x8f }, 
+    { "http://",         0x00, 0x8e },
+    { "https://www.",    0x00, 0x91 },
+    { "https://",        0x00, 0x90 },    
+    { "list",            0x00, 0x92 }, /* Deprecated */
+    { "middle",          0x00, 0x93 },
+    { "nowrap",          0x00, 0x94 },
+    { "onclick",         0x00, 0x95 }, /* Deprecated */
+    { "onenterbackward", 0x00, 0x96 },
+    { "onenterforward",  0x00, 0x97 },
+    { "ontimer",         0x00, 0x98 },
+    { "options",         0x00, 0x99 },
+    { "password",        0x00, 0x9a },
+    { "reset",           0x00, 0x9b },
+    { "set",             0x00, 0x9c }, /* Deprecated */
+    { "text",            0x00, 0x9d },
+    { "top",             0x00, 0x9e },
+    { "unknown",         0x00, 0x9f },
+    { "wrap",            0x00, 0xa0 },
+    { "www.",            0x00, 0xa1 },
+    { NULL,              0x00, 0x00 }
+};
+
+
+/***********************************************
+ *    WML 1.1 (WAP 1.1: "SPEC-WML-19990616.pdf")
+ */
+
+const WBXMLTagEntry sv_wml11_tag_table[] = {
+    { "a",         0x00, 0x1c },
+    { "anchor",    0x00, 0x22 }, /* WML 1.1 */
+    { "access",    0x00, 0x23 },
+    { "b",         0x00, 0x24 },
+    { "big",       0x00, 0x25 },
+    { "br",        0x00, 0x26 },
+    { "card",      0x00, 0x27 },
+    { "do",        0x00, 0x28 },
+    { "em",        0x00, 0x29 },
+    { "fieldset",  0x00, 0x2a },
+    { "go",        0x00, 0x2b },
+    { "head",      0x00, 0x2c },
+    { "i",         0x00, 0x2d },
+    { "img",       0x00, 0x2e },
+    { "input",     0x00, 0x2f },
+    { "meta",      0x00, 0x30 },
+    { "noop",      0x00, 0x31 },
+    { "p",         0x00, 0x20 }, /* WML 1.1 */
+    { "postfield", 0x00, 0x21 }, /* WML 1.1 */
+    { "prev",      0x00, 0x32 },
+    { "onevent",   0x00, 0x33 },
+    { "optgroup",  0x00, 0x34 },
+    { "option",    0x00, 0x35 },
+    { "refresh",   0x00, 0x36 },
+    { "select",    0x00, 0x37 },
+    { "setvar",    0x00, 0x3e }, /* WML 1.1 */
+    { "small",     0x00, 0x38 }, 
+    { "strong",    0x00, 0x39 },
+    { "table",     0x00, 0x1f }, /* WML 1.1 */
+    { "td",        0x00, 0x1d }, /* WML 1.1 */
+    { "template",  0x00, 0x3b },
+    { "timer",     0x00, 0x3c },
+    { "tr",        0x00, 0x1e }, /* WML 1.1 */
+    { "u",         0x00, 0x3d },
+    { "wml",       0x00, 0x3f },
+    { NULL,        0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_wml11_attr_table[] = {
+    { "accept-charset",  NULL,                                0x00, 0x05 },
+    { "align",           NULL,                                0x00, 0x52 }, /* WML 1.1 */
+    { "align",           "bottom",                            0x00, 0x06 },
+    { "align",           "center",                            0x00, 0x07 },
+    { "align",           "left",                              0x00, 0x08 },
+    { "align",           "middle",                            0x00, 0x09 },
+    { "align",           "right",                             0x00, 0x0a },
+    { "align",           "top",                               0x00, 0x0b },
+    { "alt",             NULL,                                0x00, 0x0c },
+    { "class",           NULL,                                0x00, 0x54 }, /* WML 1.1 */
+    { "columns",         NULL,                                0x00, 0x53 }, /* WML 1.1 */
+    { "content",         NULL,                                0x00, 0x0d },
+    { "content",         "application/vnd.wap.wmlc;charset=", 0x00, 0x5c }, /* WML 1.1 */
+    { "domain",          NULL,                                0x00, 0x0f },
+    { "emptyok",         "false",                             0x00, 0x10 },
+    { "emptyok",         "true",                              0x00, 0x11 },
+    { "format",          NULL,                                0x00, 0x12 },
+    { "forua",           "false",                             0x00, 0x56 }, /* WML 1.1 */
+    { "forua",           "true",                              0x00, 0x57 }, /* WML 1.1 */
+    { "height",          NULL,                                0x00, 0x13 },
+    { "href",            NULL,                                0x00, 0x4a }, /* WML 1.1 */
+    { "href",            "http://",                           0x00, 0x4b }, /* WML 1.1 */
+    { "href",            "https://",                          0x00, 0x4c }, /* WML 1.1 */
+    { "hspace",          NULL,                                0x00, 0x14 },
+    { "http-equiv",      NULL,                                0x00, 0x5a }, /* WML 1.1 */
+    { "http-equiv",      "Content-Type",                      0x00, 0x5b }, /* WML 1.1 */
+    { "http-equiv",      "Expires",                           0x00, 0x5d }, /* WML 1.1 */
+    { "id",              NULL,                                0x00, 0x55 }, /* WML 1.1 */
+    { "ivalue",          NULL,                                0x00, 0x15 }, /* WML 1.1 */
+    { "iname",           NULL,                                0x00, 0x16 }, /* WML 1.1 */
+    { "label",           NULL,                                0x00, 0x18 },
+    { "localsrc",        NULL,                                0x00, 0x19 },
+    { "maxlength",       NULL,                                0x00, 0x1a },
+    { "method",          "get",                               0x00, 0x1b },
+    { "method",          "post",                              0x00, 0x1c },
+    { "mode",            "nowrap",                            0x00, 0x1d },
+    { "mode",            "wrap",                              0x00, 0x1e },
+    { "multiple",        "false",                             0x00, 0x1f },
+    { "multiple",        "true",                              0x00, 0x20 },
+    { "name",            NULL,                                0x00, 0x21 },
+    { "newcontext",      "false",                             0x00, 0x22 },
+    { "newcontext",      "true",                              0x00, 0x23 },
+    { "onenterbackward", NULL,                                0x00, 0x25 },
+    { "onenterforward",  NULL,                                0x00, 0x26 },
+    { "onpick",          NULL,                                0x00, 0x24 }, /* WML 1.1 */
+    { "ontimer",         NULL,                                0x00, 0x27 },
+    { "optional",        "false",                             0x00, 0x28 },
+    { "optional",        "true",                              0x00, 0x29 },
+    { "path",            NULL,                                0x00, 0x2a },
+    { "scheme",          NULL,                                0x00, 0x2e },
+    { "sendreferer",     "false",                             0x00, 0x2f },
+    { "sendreferer",     "true",                              0x00, 0x30 },
+    { "size",            NULL,                                0x00, 0x31 },
+    { "src",             NULL,                                0x00, 0x32 },
+    { "src",             "http://",                           0x00, 0x58 }, /* WML 1.1 */
+    { "src",             "https://",                          0x00, 0x59 }, /* WML 1.1 */
+    { "ordered",         "true",                              0x00, 0x33 }, /* WML 1.1 */
+    { "ordered",         "false",                             0x00, 0x34 }, /* WML 1.1 */
+    { "tabindex",        NULL,                                0x00, 0x35 },
+    { "title",           NULL,                                0x00, 0x36 },
+    { "type",            NULL,                                0x00, 0x37 },
+    { "type",            "accept",                            0x00, 0x38 },
+    { "type",            "delete",                            0x00, 0x39 },
+    { "type",            "help",                              0x00, 0x3a },
+    { "type",            "password",                          0x00, 0x3b },
+    { "type",            "onpick",                            0x00, 0x3c },
+    { "type",            "onenterbackward",                   0x00, 0x3d },
+    { "type",            "onenterforward",                    0x00, 0x3e },
+    { "type",            "ontimer",                           0x00, 0x3f },
+    { "type",            "options",                           0x00, 0x45 },
+    { "type",            "prev",                              0x00, 0x46 },
+    { "type",            "reset",                             0x00, 0x47 },
+    { "type",            "text",                              0x00, 0x48 },
+    { "type",            "vnd.",                              0x00, 0x49 },
+    { "value",           NULL,                                0x00, 0x4d },
+    { "vspace",          NULL,                                0x00, 0x4e },
+    { "width",           NULL,                                0x00, 0x4f },
+    { "xml:lang",        NULL,                                0x00, 0x50 },
+    { NULL,              NULL,                                0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_wml11_attr_value_table[] = {
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { "accept",          0x00, 0x89 },
+    { "bottom",          0x00, 0x8a },
+    { "clear",           0x00, 0x8b },
+    { "delete",          0x00, 0x8c },
+    { "help",            0x00, 0x8d },
+    /* Do NOT change the order in this table please ! */
+    { "http://www.",     0x00, 0x8f },
+    { "http://",         0x00, 0x8e },
+    { "https://www.",    0x00, 0x91 },
+    { "https://",        0x00, 0x90 },    
+    { "middle",          0x00, 0x93 },
+    { "nowrap",          0x00, 0x94 },
+    { "onenterbackward", 0x00, 0x96 },
+    { "onenterforward",  0x00, 0x97 },
+    { "onpick",          0x00, 0x95 }, /* WML 1.1 */
+    { "ontimer",         0x00, 0x98 },
+    { "options",         0x00, 0x99 },
+    { "password",        0x00, 0x9a },
+    { "reset",           0x00, 0x9b },
+    { "text",            0x00, 0x9d },
+    { "top",             0x00, 0x9e },
+    { "unknown",         0x00, 0x9f },
+    { "wrap",            0x00, 0xa0 },
+    { "www.",            0x00, 0xa1 },
+    { NULL,              0x00, 0x00 }
+};
+
+
+/***********************************************
+ *    WML 1.2 (WAP 1.2: "SPEC-WML-19991104.pdf")
+ */
+
+const WBXMLTagEntry sv_wml12_tag_table[] = {
+    { "a",         0x00, 0x1c },
+    { "anchor",    0x00, 0x22 },
+    { "access",    0x00, 0x23 },
+    { "b",         0x00, 0x24 },
+    { "big",       0x00, 0x25 },
+    { "br",        0x00, 0x26 },
+    { "card",      0x00, 0x27 },
+    { "do",        0x00, 0x28 },
+    { "em",        0x00, 0x29 },
+    { "fieldset",  0x00, 0x2a },
+    { "go",        0x00, 0x2b },
+    { "head",      0x00, 0x2c },
+    { "i",         0x00, 0x2d },
+    { "img",       0x00, 0x2e },
+    { "input",     0x00, 0x2f },
+    { "meta",      0x00, 0x30 },
+    { "noop",      0x00, 0x31 },
+    { "p",         0x00, 0x20 },
+    { "postfield", 0x00, 0x21 },
+    { "pre",       0x00, 0x1b },
+    { "prev",      0x00, 0x32 },
+    { "onevent",   0x00, 0x33 },
+    { "optgroup",  0x00, 0x34 },
+    { "option",    0x00, 0x35 },
+    { "refresh",   0x00, 0x36 },
+    { "select",    0x00, 0x37 },
+    { "setvar",    0x00, 0x3e },
+    { "small",     0x00, 0x38 },
+    { "strong",    0x00, 0x39 },
+    { "table",     0x00, 0x1f },
+    { "td",        0x00, 0x1d },
+    { "template",  0x00, 0x3b },
+    { "timer",     0x00, 0x3c },
+    { "tr",        0x00, 0x1e },
+    { "u",         0x00, 0x3d },
+    { "wml",       0x00, 0x3f },
+    { NULL,        0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_wml12_attr_table[] = {
+    { "accept-charset",  NULL,                                0x00, 0x05 },
+    { "accesskey",       NULL,                                0x00, 0x5e }, /* WML 1.2 */
+    { "align",           NULL,                                0x00, 0x52 },
+    { "align",           "bottom",                            0x00, 0x06 },
+    { "align",           "center",                            0x00, 0x07 },
+    { "align",           "left",                              0x00, 0x08 },
+    { "align",           "middle",                            0x00, 0x09 },
+    { "align",           "right",                             0x00, 0x0a },
+    { "align",           "top",                               0x00, 0x0b },
+    { "alt",             NULL,                                0x00, 0x0c },
+    { "class",           NULL,                                0x00, 0x54 },
+    { "columns",         NULL,                                0x00, 0x53 },
+    { "content",         NULL,                                0x00, 0x0d },
+    { "content",         "application/vnd.wap.wmlc;charset=", 0x00, 0x5c },
+    { "domain",          NULL,                                0x00, 0x0f },
+    { "emptyok",         "false",                             0x00, 0x10 },
+    { "emptyok",         "true",                              0x00, 0x11 },
+    { "enctype",         NULL,                                0x00, 0x5f }, /* WML 1.2 */
+    { "enctype",         "application/x-www-form-urlencoded", 0x00, 0x60 }, /* WML 1.2 */
+    { "enctype",         "multipart/form-data",               0x00, 0x61 }, /* WML 1.2 */
+    { "format",          NULL,                                0x00, 0x12 },
+    { "forua",           "false",                             0x00, 0x56 },
+    { "forua",           "true",                              0x00, 0x57 },
+    { "height",          NULL,                                0x00, 0x13 },
+    { "href",            NULL,                                0x00, 0x4a },
+    { "href",            "http://",                           0x00, 0x4b },
+    { "href",            "https://",                          0x00, 0x4c },
+    { "hspace",          NULL,                                0x00, 0x14 },
+    { "http-equiv",      NULL,                                0x00, 0x5a },
+    { "http-equiv",      "Content-Type",                      0x00, 0x5b },
+    { "http-equiv",      "Expires",                           0x00, 0x5d },
+    { "id",              NULL,                                0x00, 0x55 },
+    { "ivalue",          NULL,                                0x00, 0x15 },
+    { "iname",           NULL,                                0x00, 0x16 },
+    { "label",           NULL,                                0x00, 0x18 },
+    { "localsrc",        NULL,                                0x00, 0x19 },
+    { "maxlength",       NULL,                                0x00, 0x1a },
+    { "method",          "get",                               0x00, 0x1b },
+    { "method",          "post",                              0x00, 0x1c },
+    { "mode",            "nowrap",                            0x00, 0x1d },
+    { "mode",            "wrap",                              0x00, 0x1e },
+    { "multiple",        "false",                             0x00, 0x1f },
+    { "multiple",        "true",                              0x00, 0x20 },
+    { "name",            NULL,                                0x00, 0x21 },
+    { "newcontext",      "false",                             0x00, 0x22 },
+    { "newcontext",      "true",                              0x00, 0x23 },
+    { "onenterbackward", NULL,                                0x00, 0x25 },
+    { "onenterforward",  NULL,                                0x00, 0x26 },
+    { "onpick",          NULL,                                0x00, 0x24 },
+    { "ontimer",         NULL,                                0x00, 0x27 },
+    { "optional",        "false",                             0x00, 0x28 },
+    { "optional",        "true",                              0x00, 0x29 },
+    { "path",            NULL,                                0x00, 0x2a },
+    { "scheme",          NULL,                                0x00, 0x2e },
+    { "sendreferer",     "false",                             0x00, 0x2f },
+    { "sendreferer",     "true",                              0x00, 0x30 },
+    { "size",            NULL,                                0x00, 0x31 },
+    { "src",             NULL,                                0x00, 0x32 },
+    { "src",             "http://",                           0x00, 0x58 },
+    { "src",             "https://",                          0x00, 0x59 },
+    { "ordered",         "true",                              0x00, 0x33 },
+    { "ordered",         "false",                             0x00, 0x34 },
+    { "tabindex",        NULL,                                0x00, 0x35 },
+    { "title",           NULL,                                0x00, 0x36 },
+    { "type",            NULL,                                0x00, 0x37 },
+    { "type",            "accept",                            0x00, 0x38 },
+    { "type",            "delete",                            0x00, 0x39 },
+    { "type",            "help",                              0x00, 0x3a },
+    { "type",            "password",                          0x00, 0x3b },
+    { "type",            "onpick",                            0x00, 0x3c },
+    { "type",            "onenterbackward",                   0x00, 0x3d },
+    { "type",            "onenterforward",                    0x00, 0x3e },
+    { "type",            "ontimer",                           0x00, 0x3f },
+    { "type",            "options",                           0x00, 0x45 },
+    { "type",            "prev",                              0x00, 0x46 },
+    { "type",            "reset",                             0x00, 0x47 },
+    { "type",            "text",                              0x00, 0x48 },
+    { "type",            "vnd.",                              0x00, 0x49 },
+    { "value",           NULL,                                0x00, 0x4d },
+    { "vspace",          NULL,                                0x00, 0x4e },
+    { "width",           NULL,                                0x00, 0x4f },
+    { "xml:lang",        NULL,                                0x00, 0x50 },
+    { NULL,              NULL,                                0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_wml12_attr_value_table[] = {
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { "accept",          0x00, 0x89 },
+    { "bottom",          0x00, 0x8a },
+    { "clear",           0x00, 0x8b },
+    { "delete",          0x00, 0x8c },
+    { "help",            0x00, 0x8d },
+    /* Do NOT change the order in this table please ! */
+    { "http://www.",     0x00, 0x8f },
+    { "http://",         0x00, 0x8e },
+    { "https://www.",    0x00, 0x91 },
+    { "https://",        0x00, 0x90 },    
+    { "middle",          0x00, 0x93 },
+    { "nowrap",          0x00, 0x94 },
+    { "onenterbackward", 0x00, 0x96 },
+    { "onenterforward",  0x00, 0x97 },
+    { "onpick",          0x00, 0x95 },
+    { "ontimer",         0x00, 0x98 },
+    { "options",         0x00, 0x99 },
+    { "password",        0x00, 0x9a },
+    { "reset",           0x00, 0x9b },
+    { "text",            0x00, 0x9d },
+    { "top",             0x00, 0x9e },
+    { "unknown",         0x00, 0x9f },
+    { "wrap",            0x00, 0xa0 },
+    { "www.",            0x00, 0xa1 },
+    { NULL,              0x00, 0x00 }
+};
+
+#endif /* WBXML_TABLES_SEPARATE_WML_VERSIONS */
+
+
+/******************************************************
+ *    WML 1.3 (WAP 1.2.1: "WAP-191-WML-20000219-a.pdf")
+ */
+
+const WBXMLTagEntry sv_wml13_tag_table[] = {
+    { "a",         0x00, 0x1c },
+    { "anchor",    0x00, 0x22 }, /* WML 1.1 */
+    { "access",    0x00, 0x23 },
+    { "b",         0x00, 0x24 },
+    { "big",       0x00, 0x25 },
+    { "br",        0x00, 0x26 },
+    { "card",      0x00, 0x27 },
+    { "do",        0x00, 0x28 },
+    { "em",        0x00, 0x29 },
+    { "fieldset",  0x00, 0x2a },
+    { "go",        0x00, 0x2b },
+    { "head",      0x00, 0x2c },
+    { "i",         0x00, 0x2d },
+    { "img",       0x00, 0x2e },
+    { "input",     0x00, 0x2f },
+    { "meta",      0x00, 0x30 },
+    { "noop",      0x00, 0x31 },
+    { "p",         0x00, 0x20 }, /* WML 1.1 */
+    { "postfield", 0x00, 0x21 }, /* WML 1.1 */
+    { "pre",       0x00, 0x1b },
+    { "prev",      0x00, 0x32 },
+    { "onevent",   0x00, 0x33 },
+    { "optgroup",  0x00, 0x34 },
+    { "option",    0x00, 0x35 },
+    { "refresh",   0x00, 0x36 },
+    { "select",    0x00, 0x37 },
+    { "setvar",    0x00, 0x3e }, /* WML 1.1 */
+    { "small",     0x00, 0x38 },
+    { "strong",    0x00, 0x39 },
+    { "table",     0x00, 0x1f }, /* WML 1.1 */
+    { "td",        0x00, 0x1d }, /* WML 1.1 */
+    { "template",  0x00, 0x3b },
+    { "timer",     0x00, 0x3c },
+    { "tr",        0x00, 0x1e }, /* WML 1.1 */
+    { "u",         0x00, 0x3d },
+    { "wml",       0x00, 0x3f },
+    { NULL,        0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_wml13_attr_table[] = {
+    { "accept-charset",  NULL,                                0x00, 0x05 },
+    { "accesskey",       NULL,                                0x00, 0x5e }, /* WML 1.2 */
+    { "align",           NULL,                                0x00, 0x52 }, /* WML 1.1 */
+    { "align",           "bottom",                            0x00, 0x06 },
+    { "align",           "center",                            0x00, 0x07 },
+    { "align",           "left",                              0x00, 0x08 },
+    { "align",           "middle",                            0x00, 0x09 },
+    { "align",           "right",                             0x00, 0x0a },
+    { "align",           "top",                               0x00, 0x0b },
+    { "alt",             NULL,                                0x00, 0x0c },
+    { "cache-control",   "no-cache",                          0x00, 0x64 }, /* WML 1.3 */
+    { "class",           NULL,                                0x00, 0x54 }, /* WML 1.1 */
+    { "columns",         NULL,                                0x00, 0x53 }, /* WML 1.1 */
+    { "content",         NULL,                                0x00, 0x0d }, 
+    { "content",         "application/vnd.wap.wmlc;charset=", 0x00, 0x5c }, /* WML 1.1 */
+    { "domain",          NULL,                                0x00, 0x0f },
+    { "emptyok",         "false",                             0x00, 0x10 },
+    { "emptyok",         "true",                              0x00, 0x11 },
+    { "enctype",         NULL,                                0x00, 0x5f }, /* WML 1.2 */
+    { "enctype",         "application/x-www-form-urlencoded", 0x00, 0x60 }, /* WML 1.2 */
+    { "enctype",         "multipart/form-data",               0x00, 0x61 }, /* WML 1.2 */
+    { "format",          NULL,                                0x00, 0x12 },
+    { "forua",           "false",                             0x00, 0x56 }, /* WML 1.1 */
+    { "forua",           "true",                              0x00, 0x57 }, /* WML 1.1 */
+    { "height",          NULL,                                0x00, 0x13 },
+    { "href",            NULL,                                0x00, 0x4a }, /* WML 1.1 */
+    { "href",            "http://",                           0x00, 0x4b }, /* WML 1.1 */
+    { "href",            "https://",                          0x00, 0x4c }, /* WML 1.1 */
+    { "hspace",          NULL,                                0x00, 0x14 },
+    { "http-equiv",      NULL,                                0x00, 0x5a }, /* WML 1.1 */
+    { "http-equiv",      "Content-Type",                      0x00, 0x5b }, /* WML 1.1 */
+    { "http-equiv",      "Expires",                           0x00, 0x5d }, /* WML 1.1 */
+    { "id",              NULL,                                0x00, 0x55 }, /* WML 1.1 */
+    { "ivalue",          NULL,                                0x00, 0x15 }, /* WML 1.1 */
+    { "iname",           NULL,                                0x00, 0x16 }, /* WML 1.1 */
+    { "label",           NULL,                                0x00, 0x18 },
+    { "localsrc",        NULL,                                0x00, 0x19 },
+    { "maxlength",       NULL,                                0x00, 0x1a },
+    { "method",          "get",                               0x00, 0x1b },
+    { "method",          "post",                              0x00, 0x1c },
+    { "mode",            "nowrap",                            0x00, 0x1d },
+    { "mode",            "wrap",                              0x00, 0x1e },
+    { "multiple",        "false",                             0x00, 0x1f },
+    { "multiple",        "true",                              0x00, 0x20 },
+    { "name",            NULL,                                0x00, 0x21 },
+    { "newcontext",      "false",                             0x00, 0x22 },
+    { "newcontext",      "true",                              0x00, 0x23 },
+    { "onenterbackward", NULL,                                0x00, 0x25 },
+    { "onenterforward",  NULL,                                0x00, 0x26 },
+    { "onpick",          NULL,                                0x00, 0x24 }, /* WML 1.1 */
+    { "ontimer",         NULL,                                0x00, 0x27 },
+    { "optional",        "false",                             0x00, 0x28 },
+    { "optional",        "true",                              0x00, 0x29 },
+    { "path",            NULL,                                0x00, 0x2a },
+    { "scheme",          NULL,                                0x00, 0x2e },
+    { "sendreferer",     "false",                             0x00, 0x2f },
+    { "sendreferer",     "true",                              0x00, 0x30 },
+    { "size",            NULL,                                0x00, 0x31 },
+    { "src",             NULL,                                0x00, 0x32 },
+    { "src",             "http://",                           0x00, 0x58 }, /* WML 1.1 */
+    { "src",             "https://",                          0x00, 0x59 }, /* WML 1.1 */
+    { "ordered",         "true",                              0x00, 0x33 }, /* WML 1.1 */
+    { "ordered",         "false",                             0x00, 0x34 }, /* WML 1.1 */
+    { "tabindex",        NULL,                                0x00, 0x35 },
+    { "title",           NULL,                                0x00, 0x36 },
+    { "type",            NULL,                                0x00, 0x37 },
+    { "type",            "accept",                            0x00, 0x38 },
+    { "type",            "delete",                            0x00, 0x39 },
+    { "type",            "help",                              0x00, 0x3a },
+    { "type",            "password",                          0x00, 0x3b },
+    { "type",            "onpick",                            0x00, 0x3c },
+    { "type",            "onenterbackward",                   0x00, 0x3d },
+    { "type",            "onenterforward",                    0x00, 0x3e },
+    { "type",            "ontimer",                           0x00, 0x3f },
+    { "type",            "options",                           0x00, 0x45 },
+    { "type",            "prev",                              0x00, 0x46 },
+    { "type",            "reset",                             0x00, 0x47 },
+    { "type",            "text",                              0x00, 0x48 },
+    { "type",            "vnd.",                              0x00, 0x49 },
+    { "value",           NULL,                                0x00, 0x4d },
+    { "vspace",          NULL,                                0x00, 0x4e },
+    { "width",           NULL,                                0x00, 0x4f },
+    { "xml:lang",        NULL,                                0x00, 0x50 },
+    { "xml:space",       "preserve",                          0x00, 0x62 }, /* WML 1.3 */
+    { "xml:space",       "default",                           0x00, 0x63 }, /* WML 1.3 */
+    { NULL,              NULL,                                0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_wml13_attr_value_table[] = {
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { "accept",          0x00, 0x89 },
+    { "bottom",          0x00, 0x8a },
+    { "clear",           0x00, 0x8b },
+    { "delete",          0x00, 0x8c },
+    { "help",            0x00, 0x8d },
+    /* Do NOT change the order in this table please ! */
+    { "http://www.",     0x00, 0x8f },
+    { "http://",         0x00, 0x8e },
+    { "https://www.",    0x00, 0x91 },
+    { "https://",        0x00, 0x90 },    
+    { "middle",          0x00, 0x93 },
+    { "nowrap",          0x00, 0x94 },
+    { "onenterbackward", 0x00, 0x96 },
+    { "onenterforward",  0x00, 0x97 },
+    { "onpick",          0x00, 0x95 }, /* WML 1.1 */
+    { "ontimer",         0x00, 0x98 },
+    { "options",         0x00, 0x99 },
+    { "password",        0x00, 0x9a },
+    { "reset",           0x00, 0x9b },
+    { "text",            0x00, 0x9d },
+    { "top",             0x00, 0x9e },
+    { "unknown",         0x00, 0x9f },
+    { "wrap",            0x00, 0xa0 },
+    { "www.",            0x00, 0xa1 },
+    { NULL,              0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_WML */
+
+
+
+#if defined( WBXML_SUPPORT_WTA )
+
+/********************************************
+ *    WTA 1.0 (WAP 1.0: "wta-30-apr-98.pdf")
+ */
+
+const WBXMLTagEntry sv_wta10_tag_table[] = {
+    { "EVENT",          0x00, 0x05 },
+    { "EVENTTABLE",     0x00, 0x06 },
+    { "TYPE",           0x00, 0x07 },
+    { "URL",            0x00, 0x08 },
+    { "WTAI",           0x00, 0x09 },
+    { NULL,             0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_wta10_attr_table[] = {
+    { "NAME",       NULL,                    0x00, 0x05 },
+    { "VALUE",      NULL,                    0x00, 0x06 },
+    { NULL,         NULL,                    0x00, 0x00 }
+};
+
+
+/***********************************************
+ *    WTA WML 1.2 ("WAP-266-WTA-20010908-a.pdf")
+ */
+
+const WBXMLTagEntry sv_wtawml12_tag_table[] = {
+    /* Code Page 0 (WML 1.2) */
+    { "a",         0x00, 0x1c },
+    { "anchor",    0x00, 0x22 },
+    { "access",    0x00, 0x23 },
+    { "b",         0x00, 0x24 },
+    { "big",       0x00, 0x25 },
+    { "br",        0x00, 0x26 },
+    { "card",      0x00, 0x27 },
+    { "do",        0x00, 0x28 },
+    { "em",        0x00, 0x29 },
+    { "fieldset",  0x00, 0x2a },
+    { "go",        0x00, 0x2b },
+    { "head",      0x00, 0x2c },
+    { "i",         0x00, 0x2d },
+    { "img",       0x00, 0x2e },
+    { "input",     0x00, 0x2f },
+    { "meta",      0x00, 0x30 },
+    { "noop",      0x00, 0x31 },
+    { "p",         0x00, 0x20 },
+    { "postfield", 0x00, 0x21 },
+    { "pre",       0x00, 0x1b },
+    { "prev",      0x00, 0x32 },
+    { "onevent",   0x00, 0x33 },
+    { "optgroup",  0x00, 0x34 },
+    { "option",    0x00, 0x35 },
+    { "refresh",   0x00, 0x36 },
+    { "select",    0x00, 0x37 },
+    { "setvar",    0x00, 0x3e },
+    { "small",     0x00, 0x38 },
+    { "strong",    0x00, 0x39 },
+    { "table",     0x00, 0x1f },
+    { "td",        0x00, 0x1d },
+    { "template",  0x00, 0x3b },
+    { "timer",     0x00, 0x3c },
+    { "tr",        0x00, 0x1e },
+    { "u",         0x00, 0x3d },
+    { "wml",       0x00, 0x3f },
+
+    /* Code Page 1 (WTA) */
+    { "wta-wml",   0x01, 0x3f },
+    { NULL,        0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_wtawml12_attr_table[] = {
+    /* Code Page 0 (WML 1.2) */
+    { "accept-charset",  NULL,                                0x00, 0x05 },
+    { "accesskey",       NULL,                                0x00, 0x5e },
+    { "align",           NULL,                                0x00, 0x52 },
+    { "align",           "bottom",                            0x00, 0x06 },
+    { "align",           "center",                            0x00, 0x07 },
+    { "align",           "left",                              0x00, 0x08 },
+    { "align",           "middle",                            0x00, 0x09 },
+    { "align",           "right",                             0x00, 0x0a },
+    { "align",           "top",                               0x00, 0x0b },
+    { "alt",             NULL,                                0x00, 0x0c },
+    { "class",           NULL,                                0x00, 0x54 },
+    { "columns",         NULL,                                0x00, 0x53 },
+    { "content",         NULL,                                0x00, 0x0d },
+    { "content",         "application/vnd.wap.wmlc;charset=", 0x00, 0x5c },
+    { "domain",          NULL,                                0x00, 0x0f },
+    { "emptyok",         "false",                             0x00, 0x10 },
+    { "emptyok",         "true",                              0x00, 0x11 },
+    { "enctype",         NULL,                                0x00, 0x5f },
+    { "enctype",         "application/x-www-form-urlencoded", 0x00, 0x60 },    
+    { "enctype",         "multipart/form-data",               0x00, 0x61 },
+    { "format",          NULL,                                0x00, 0x12 },
+    { "forua",           "false",                             0x00, 0x56 },
+    { "forua",           "true",                              0x00, 0x57 },
+    { "height",          NULL,                                0x00, 0x13 },
+    { "href",            NULL,                                0x00, 0x4a },
+    { "href",            "http://",                           0x00, 0x4b },
+    { "href",            "https://",                          0x00, 0x4c },
+    { "hspace",          NULL,                                0x00, 0x14 },
+    { "http-equiv",      NULL,                                0x00, 0x5a },
+    { "http-equiv",      "Content-Type",                      0x00, 0x5b },
+    { "http-equiv",      "Expires",                           0x00, 0x5d },
+    { "id",              NULL,                                0x00, 0x55 },
+    { "ivalue",          NULL,                                0x00, 0x15 },
+    { "iname",           NULL,                                0x00, 0x16 },
+    { "label",           NULL,                                0x00, 0x18 },
+    { "localsrc",        NULL,                                0x00, 0x19 },
+    { "maxlength",       NULL,                                0x00, 0x1a },
+    { "method",          "get",                               0x00, 0x1b },
+    { "method",          "post",                              0x00, 0x1c },
+    { "mode",            "nowrap",                            0x00, 0x1d },
+    { "mode",            "wrap",                              0x00, 0x1e },
+    { "multiple",        "false",                             0x00, 0x1f },
+    { "multiple",        "true",                              0x00, 0x20 },
+    { "name",            NULL,                                0x00, 0x21 },
+    { "newcontext",      "false",                             0x00, 0x22 },
+    { "newcontext",      "true",                              0x00, 0x23 },
+    { "onenterbackward", NULL,                                0x00, 0x25 },
+    { "onenterforward",  NULL,                                0x00, 0x26 },
+    { "onpick",          NULL,                                0x00, 0x24 },
+    { "ontimer",         NULL,                                0x00, 0x27 },
+    { "optional",        "false",                             0x00, 0x28 },
+    { "optional",        "true",                              0x00, 0x29 },
+    { "path",            NULL,                                0x00, 0x2a },
+    { "scheme",          NULL,                                0x00, 0x2e },
+    { "sendreferer",     "false",                             0x00, 0x2f },
+    { "sendreferer",     "true",                              0x00, 0x30 },
+    { "size",            NULL,                                0x00, 0x31 },
+    { "src",             NULL,                                0x00, 0x32 },
+    { "src",             "http://",                           0x00, 0x58 },
+    { "src",             "https://",                          0x00, 0x59 },
+    { "ordered",         "true",                              0x00, 0x33 },
+    { "ordered",         "false",                             0x00, 0x34 },
+    { "tabindex",        NULL,                                0x00, 0x35 },
+    { "title",           NULL,                                0x00, 0x36 },
+    { "type",            NULL,                                0x00, 0x37 },
+    { "type",            "accept",                            0x00, 0x38 },
+    { "type",            "delete",                            0x00, 0x39 },
+    { "type",            "help",                              0x00, 0x3a },
+    { "type",            "password",                          0x00, 0x3b },
+    { "type",            "onpick",                            0x00, 0x3c },
+    { "type",            "onenterbackward",                   0x00, 0x3d },
+    { "type",            "onenterforward",                    0x00, 0x3e },
+    { "type",            "ontimer",                           0x00, 0x3f },
+    { "type",            "options",                           0x00, 0x45 },
+    { "type",            "prev",                              0x00, 0x46 },
+    { "type",            "reset",                             0x00, 0x47 },
+    { "type",            "text",                              0x00, 0x48 },
+    { "type",            "vnd.",                              0x00, 0x49 },
+    { "value",           NULL,                                0x00, 0x4d },
+    { "vspace",          NULL,                                0x00, 0x4e },
+    { "width",           NULL,                                0x00, 0x4f },
+    { "xml:lang",        NULL,                                0x00, 0x50 },
+
+    /* Code Page 1 (WTA) */
+    /* Do NOT change the order in this table please ! */
+    { "href",             "wtai://wp/mc;",                      0x01, 0x06 },
+    { "href",             "wtai://wp/sd;",                      0x01, 0x07 },
+    { "href",             "wtai://wp/ap;",                      0x01, 0x08 },
+    { "href",             "wtai://ms/ec;",                      0x01, 0x09 },
+    { "href",             "wtai://",                            0x01, 0x05 },        
+    { "type",             "wtaev-cc/ic",                        0x01, 0x12 },
+    { "type",             "wtaev-cc/cl",                        0x01, 0x13 },
+    { "type",             "wtaev-cc/co",                        0x01, 0x14 },
+    { "type",             "wtaev-cc/oc",                        0x01, 0x15 },
+    { "type",             "wtaev-cc/cc",                        0x01, 0x16 },
+    { "type",             "wtaev-cc/dtmf",                      0x01, 0x17 },
+    { "type",             "wtaev-nt/it",                        0x01, 0x21 },
+    { "type",             "wtaev-nt/st",                        0x01, 0x22 },
+    { "type",             "wtaev-nt/",                          0x01, 0x20 },
+    { "type",             "wtaev-pb/",                          0x01, 0x30 },
+    { "type",             "wtaev-lg/",                          0x01, 0x38 },
+    { "type",             "wtaev-ms/ns",                        0x01, 0x51 },
+    { "type",             "wtaev-ms/",                          0x01, 0x50 },
+    { "type",             "wtaev-gsm/ru",                       0x01, 0x59 },
+    { "type",             "wtaev-gsm/ch",                       0x01, 0x5a },
+    { "type",             "wtaev-gsm/ca",                       0x01, 0x5b },
+    { "type",             "wtaev-gsm/",                         0x01, 0x58 },
+    { "type",             "wtaev-pdc",                          0x01, 0x60 },
+    { "type",             "wtaev-ansi136/ia",                   0x01, 0x69 },
+    { "type",             "wtaev-ansi136/if",                   0x01, 0x6a },
+    { "type",             "wtaev-ansi136",                      0x01, 0x68 },
+    { "type",             "wtaev-cdma/",                        0x01, 0x70 },
+    { "type",             "wtaev-cc",                           0x01, 0x11 },
+    { "type",             "wtaev-",                             0x01, 0x10 },
+    { NULL,               NULL,                                 0x00, 0x00 }
+};
+
+const WBXMLAttrValueEntry sv_wtawml12_attr_value_table[] = {
+    /* Code Page 0 (WML 1.2) */
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { "accept",          0x00, 0x89 },
+    { "bottom",          0x00, 0x8a },
+    { "clear",           0x00, 0x8b },
+    { "delete",          0x00, 0x8c },
+    { "help",            0x00, 0x8d },
+    /* Do NOT change the order in this table please ! */
+    { "http://www.",     0x00, 0x8f },
+    { "http://",         0x00, 0x8e },    
+    { "https://www.",    0x00, 0x91 },
+    { "https://",        0x00, 0x90 },    
+    { "middle",          0x00, 0x93 },
+    { "nowrap",          0x00, 0x94 },
+    { "onenterbackward", 0x00, 0x96 },
+    { "onenterforward",  0x00, 0x97 },
+    { "onpick",          0x00, 0x95 },
+    { "ontimer",         0x00, 0x98 },
+    { "options",         0x00, 0x99 },
+    { "password",        0x00, 0x9a },
+    { "reset",           0x00, 0x9b },
+    { "text",            0x00, 0x9d },
+    { "top",             0x00, 0x9e },
+    { "unknown",         0x00, 0x9f },
+    { "wrap",            0x00, 0xa0 },
+    { "www.",            0x00, 0xa1 },
+    { NULL,              0x00, 0x00 }
+};
+
+
+/***************************************************
+ *    CHANNEL 1.1 (WAP 1.1: "SPEC-WTA-19990716.pdf")
+ */
+
+const WBXMLTagEntry sv_channel11_tag_table[] = {
+    { "channel",        0x00, 0x05 },
+    { "title",          0x00, 0x06 },
+    { "abstract",       0x00, 0x07 },
+    { "resource",       0x00, 0x08 },
+    { NULL,             0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_channel11_attr_table[] = {
+    { "maxspace",   NULL,           0x00, 0x05 },
+    { "base",       NULL,           0x00, 0x06 },
+    { "href",       NULL,           0x00, 0x07 },
+    { "href",       "http://",      0x00, 0x08 },
+    { "href",       "https://",     0x00, 0x09 },
+    { "lastmod",    NULL,           0x00, 0x0a },
+    { "etag",       NULL,           0x00, 0x0b },
+    { "md5",        NULL,           0x00, 0x0c },
+    { "success",    NULL,           0x00, 0x0d },
+    { "success",    "http://",      0x00, 0x0e },
+    { "success",    "https://",     0x00, 0x0f },
+    { "failure",    NULL,           0x00, 0x10 },
+    { "failure",    "http://",      0x00, 0x11 },
+    { "failure",    "https://",     0x00, 0x12 },
+    { "EventId",    NULL,           0x00, 0x13 },
+    { NULL,         NULL,           0x00, 0x00 }
+};
+
+
+/***********************************************
+ *    CHANNEL 1.2 ("WAP-266-WTA-20010908-a.pdf")
+ */
+
+const WBXMLTagEntry sv_channel12_tag_table[] = {
+    { "channel",        0x00, 0x05 },
+    { "title",          0x00, 0x06 },
+    { "abstract",       0x00, 0x07 },
+    { "resource",       0x00, 0x08 },
+    { NULL,             0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_channel12_attr_table[] = {
+    { "maxspace",       NULL,           0x00, 0x05 },
+    { "base",           NULL,           0x00, 0x06 },
+    { "href",           NULL,           0x00, 0x07 },
+    { "href",           "http://",      0x00, 0x08 },
+    { "href",           "https://",     0x00, 0x09 },
+    { "lastmod",        NULL,           0x00, 0x0a },
+    { "etag",            NULL,          0x00, 0x0b },
+    { "md5",            NULL,           0x00, 0x0c },
+    { "success",        NULL,           0x00, 0x0d },
+    { "success",        "http://",      0x00, 0x0e },
+    { "success",        "https://",     0x00, 0x0f },
+    { "failure",        NULL,           0x00, 0x10 },
+    { "failure",        "http://",      0x00, 0x11 },
+    { "failure",        "https://",     0x00, 0x12 },
+    { "eventid",        NULL,           0x00, 0x13 },
+    { "eventid",            "wtaev-",   0x00, 0x14 },
+    { "channelid",          NULL,       0x00, 0x15 },
+    { "useraccessible",     NULL,       0x00, 0x16 },
+    { NULL,                 NULL,       0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_WTA */
+
+
+#if defined( WBXML_SUPPORT_SI )
+
+/*************************************************
+ *    SI 1.0 ("WAP-167-ServiceInd-20010731-a.pdf")
+ */
+
+const WBXMLTagEntry sv_si10_tag_table[] = {
+    { "si",             0x00, 0x05 },
+    { "indication",     0x00, 0x06 },
+    { "info",           0x00, 0x07 },
+    { "item",           0x00, 0x08 },
+    { NULL,             0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_si10_attr_table[] = {
+    { "action",  "signal-none",             0x00, 0x05 },
+    { "action",  "signal-low",              0x00, 0x06 },
+    { "action",  "signal-medium",           0x00, 0x07 },
+    { "action",  "signal-high",             0x00, 0x08 },
+    { "action",  "delete",                  0x00, 0x09 },
+    { "created", NULL,                      0x00, 0x0a },
+    { "href",    NULL,                      0x00, 0x0b },
+    /* Do NOT change the order in this table please ! */
+    { "href",    "http://www.",             0x00, 0x0d },
+    { "href",    "http://",                 0x00, 0x0c },
+    { "href",    "https://www.",            0x00, 0x0f },
+    { "href",    "https://",                0x00, 0x0e },    
+    { "si-expires", NULL,                   0x00, 0x10 },
+    { "si-id",      NULL,                   0x00, 0x11 },
+    { "class",      NULL,                   0x00, 0x12 },
+    { NULL,         NULL,                   0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_si10_attr_value_table[] = {
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { NULL,              0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_SI */
+
+
+#if defined( WBXML_SUPPORT_SL )
+
+/**************************************************
+ *    SL 1.0 ("WAP-168-ServiceLoad-20010731-a.pdf")
+ */
+
+const WBXMLTagEntry sv_sl10_tag_table[] = {
+    { "sl",              0x00, 0x05 },
+    { NULL,              0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_sl10_attr_table[] = {
+    { "action",  "execute-low",         0x00, 0x05 },
+    { "action",  "execute-high",        0x00, 0x06 },
+    { "action",  "cache",               0x00, 0x07 },
+    { "href",    NULL,                  0x00, 0x08 },
+    /* Do NOT change the order in this table please ! */
+    { "href",    "http://www.",         0x00, 0x0a },
+    { "href",    "http://",             0x00, 0x09 },
+    { "href",    "https://www.",        0x00, 0x0c },
+    { "href",    "https://",            0x00, 0x0b },    
+    { NULL,      NULL,                  0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_sl10_attr_value_table[] = {
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { NULL,              0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_SL */
+
+
+#if defined( WBXML_SUPPORT_CO )
+
+/***********************************************
+ *    CO 1.0 ("WAP-175-CacheOp-20010731-a.pdf")
+ */
+
+const WBXMLTagEntry sv_co10_tag_table[] = {
+    { "co",                     0x00, 0x05 },
+    { "invalidate-object",      0x00, 0x06 },
+    { "invalidate-service",     0x00, 0x07 },
+    { NULL,                     0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_co10_attr_table[] = {
+    { "uri",    NULL,                   0x00, 0x05 },
+    /* Do NOT change the order in this table please ! */
+    { "uri",    "http://www.",          0x00, 0x07 },
+    { "uri",    "http://",              0x00, 0x06 },
+    { "uri",    "https://www.",         0x00, 0x09 },
+    { "uri",    "https://",             0x00, 0x08 },    
+    { NULL,     NULL,                   0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_co10_attr_value_table[] = {
+    { ".com/",           0x00, 0x85 },
+    { ".edu/",           0x00, 0x86 },
+    { ".net/",           0x00, 0x87 },
+    { ".org/",           0x00, 0x88 },
+    { NULL,              0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_CO */
+
+
+#if defined( WBXML_SUPPORT_PROV )
+
+/** Use OMA PROV 1.1 Tables (only 'sv_prov10_attr_value_table' changed) */
+#define WBXML_SUPPORT_PROV_11
+
+/**********************************************************
+ *    PROV 1.0
+ *      WAP 2.0: "WAP-183-PROVCONT-20010724-a.pdf"
+ *      OMA: "OMA-WAP-ProvCont-v1_1-20021112-C.PDF"
+ *
+ *    PROV 1.1
+ *      OMA: OMA-WAP-ProvCont-v1_1-20050428-Cchangebars.doc
+ *      There is no new Public ID defined for this new version,
+ *      so how should we handle this ??
+ */
+
+const WBXMLTagEntry sv_prov10_tag_table[] = {
+    { "wap-provisioningdoc",        0x00, 0x05 },
+    { "characteristic",             0x00, 0x06 },
+    { "parm",                       0x00, 0x07 },
+    
+    { "characteristic",             0x01, 0x06 }, /* OMA */
+    { "parm",                       0x01, 0x07 }, /* OMA */
+    { NULL,                         0x00, 0x00 }
+};
+
+
+const WBXMLAttrEntry sv_prov10_attr_table[] = {
+    /* Wap-provisioningdoc */
+    { "version",    NULL,               0x00, 0x45 },
+    { "version",    "1.0",              0x00, 0x46 },
+
+    /* Characteristic */
+    { "type",        NULL,                  0x00, 0x50 },
+    { "type",        "PXLOGICAL",           0x00, 0x51 },
+    { "type",        "PXPHYSICAL",          0x00, 0x52 },
+    { "type",        "PORT",                0x00, 0x53 },
+    { "type",        "VALIDITY",            0x00, 0x54 },
+    { "type",        "NAPDEF",              0x00, 0x55 },
+    { "type",        "BOOTSTRAP",           0x00, 0x56 },
+    { "type",        "VENDORCONFIG",        0x00, 0x57 },
+    { "type",        "CLIENTIDENTITY",      0x00, 0x58 },
+    { "type",        "PXAUTHINFO",          0x00, 0x59 },
+    { "type",        "NAPAUTHINFO",         0x00, 0x5a },
+    { "type",        "ACCESS",              0x00, 0x5b }, /* OMA */
+    
+    { "type",        NULL,                  0x01, 0x50 }, /* OMA */
+    { "type",        "PORT",                0x01, 0x53 }, /* OMA */
+    { "type",        "CLIENTIDENTITY",      0x01, 0x58 }, /* OMA */
+    { "type",        "APPLICATION",         0x01, 0x55 }, /* OMA */
+    { "type",        "APPADDR",             0x01, 0x56 }, /* OMA */
+    { "type",        "APPAUTH",             0x01, 0x57 }, /* OMA */
+    { "type",        "RESOURCE",            0x01, 0x59 }, /* OMA */
+
+    /* Parm */
+    { "name",        NULL,                  0x00, 0x05 },
+    { "value",       NULL,                  0x00, 0x06 },
+    { "name",        "NAME",                0x00, 0x07 },
+    { "name",        "NAP-ADDRESS",         0x00, 0x08 },
+    { "name",        "NAP-ADDRTYPE",        0x00, 0x09 },
+    { "name",        "CALLTYPE",            0x00, 0x0a },
+    { "name",        "VALIDUNTIL",          0x00, 0x0b },
+    { "name",        "AUTHTYPE",            0x00, 0x0c },
+    { "name",        "AUTHNAME",            0x00, 0x0d },
+    { "name",        "AUTHSECRET",          0x00, 0x0e },
+    { "name",        "LINGER",              0x00, 0x0f },
+    { "name",        "BEARER",              0x00, 0x10 },
+    { "name",        "NAPID",               0x00, 0x11 },
+    { "name",        "COUNTRY",             0x00, 0x12 },
+    { "name",        "NETWORK",             0x00, 0x13 },
+    { "name",        "INTERNET",            0x00, 0x14 },
+    { "name",        "PROXY-ID",            0x00, 0x15 },
+    { "name",        "PROXY-PROVIDER-ID",   0x00, 0x16 },
+    { "name",        "DOMAIN",              0x00, 0x17 },
+    { "name",        "PROVURL",             0x00, 0x18 },
+    { "name",        "PXAUTH-TYPE",         0x00, 0x19 },
+    { "name",        "PXAUTH-ID",           0x00, 0x1a },
+    { "name",        "PXAUTH-PW",           0x00, 0x1b },
+    { "name",        "STARTPAGE",           0x00, 0x1c },
+    { "name",        "BASAUTH-ID",          0x00, 0x1d },
+    { "name",        "BASAUTH-PW",          0x00, 0x1e },
+    { "name",        "PUSHENABLED",         0x00, 0x1f },
+    { "name",        "PXADDR",              0x00, 0x20 },
+    { "name",        "PXADDRTYPE",          0x00, 0x21 },
+    { "name",        "TO-NAPID",            0x00, 0x22 },
+    { "name",        "PORTNBR",             0x00, 0x23 },
+    { "name",        "SERVICE",             0x00, 0x24 },
+    { "name",        "LINKSPEED",           0x00, 0x25 },
+    { "name",        "DNLINKSPEED",         0x00, 0x26 },
+    { "name",        "LOCAL-ADDR",          0x00, 0x27 },
+    { "name",        "LOCAL-ADDRTYPE",      0x00, 0x28 },
+    { "name",        "CONTEXT-ALLOW",       0x00, 0x29 },
+    { "name",        "TRUST",               0x00, 0x2a },
+    { "name",        "MASTER",              0x00, 0x2b },
+    { "name",        "SID",                 0x00, 0x2c },
+    { "name",        "SOC",                 0x00, 0x2d },
+    { "name",        "WSP-VERSION",         0x00, 0x2e },
+    { "name",        "PHYSICAL-PROXY-ID",   0x00, 0x2f },
+    { "name",        "CLIENT-ID",           0x00, 0x30 },
+    { "name",        "DELIVERY-ERR-SDU",    0x00, 0x31 },
+    { "name",        "DELIVERY-ORDER",      0x00, 0x32 },
+    { "name",        "TRAFFIC-CLASS",       0x00, 0x33 },
+    { "name",        "MAX-SDU-SIZE",        0x00, 0x34 },
+    { "name",        "MAX-BITRATE-UPLINK",  0x00, 0x35 },
+    { "name",        "MAX-BITRATE-DNLINK",  0x00, 0x36 },
+    { "name",        "RESIDUAL-BER",        0x00, 0x37 },
+    { "name",        "SDU-ERROR-RATIO",     0x00, 0x38 },
+    { "name",        "TRAFFIC-HANDL-PRIO",  0x00, 0x39 },
+    { "name",        "TRANSFER-DELAY",      0x00, 0x3a },
+    { "name",        "GUARANTEED-BITRATE-UPLINK",   0x00, 0x3b },
+    { "name",        "GUARANTEED-BITRATE-DNLINK",   0x00, 0x3c },
+    { "name",        "PXADDR-FQDN",         0x00, 0x3d }, /* OMA */
+    { "name",        "PROXY-PW",            0x00, 0x3e }, /* OMA */
+    { "name",        "PPGAUTH-TYPE",        0x00, 0x3f }, /* OMA */
+    { "name",        "PULLENABLED",         0x00, 0x47 }, /* OMA */
+    { "name",        "DNS-ADDR",            0x00, 0x48 }, /* OMA */
+    { "name",        "MAX-NUM-RETRY",       0x00, 0x49 }, /* OMA */
+    { "name",        "FIRST-RETRY-TIMEOUT", 0x00, 0x4a }, /* OMA */
+    { "name",        "REREG-THRESHOLD",     0x00, 0x4b }, /* OMA */
+    { "name",        "T-BIT",               0x00, 0x4c }, /* OMA */
+    { "name",        "AUTH-ENTITY",         0x00, 0x4e }, /* OMA */
+    { "name",        "SPI",                 0x00, 0x4f }, /* OMA */
+    
+    { "name",        NULL,                  0x01, 0x05 }, /* OMA */
+    { "value",       NULL,                  0x01, 0x06 }, /* OMA */
+    { "name",        "NAME",                0x01, 0x07 }, /* OMA */
+    { "name",        "INTERNET",            0x01, 0x14 }, /* OMA */
+    { "name",        "STARTPAGE",           0x01, 0x1c }, /* OMA */
+    { "name",        "TO-NAPID",            0x01, 0x22 }, /* OMA */
+    { "name",        "PORTNBR",             0x01, 0x23 }, /* OMA */
+    { "name",        "SERVICE",             0x01, 0x24 }, /* OMA */
+    { "name",        "AACCEPT",             0x01, 0x2e }, /* OMA */
+    { "name",        "AAUTHDATA",           0x01, 0x2f }, /* OMA */
+    { "name",        "AAUTHLEVEL",          0x01, 0x30 }, /* OMA */
+    { "name",        "AAUTHNAME",           0x01, 0x31 }, /* OMA */
+    { "name",        "AAUTHSECRET",         0x01, 0x32 }, /* OMA */
+    { "name",        "AAUTHTYPE",           0x01, 0x33 }, /* OMA */
+    { "name",        "ADDR",                0x01, 0x34 }, /* OMA */
+    { "name",        "ADDRTYPE",            0x01, 0x35 }, /* OMA */
+    { "name",        "APPID",               0x01, 0x36 }, /* OMA */
+    { "name",        "APROTOCOL",           0x01, 0x37 }, /* OMA */
+    { "name",        "PROVIDER-ID",         0x01, 0x38 }, /* OMA */
+    { "name",        "TO-PROXY",            0x01, 0x39 }, /* OMA */
+    { "name",        "URI",                 0x01, 0x3a }, /* OMA */
+    { "name",        "RULE",                0x01, 0x3b }, /* OMA */
+    
+    { NULL,          NULL,                  0x00, 0x00 }
+};
+
+
+const WBXMLAttrValueEntry sv_prov10_attr_value_table[] = {
+    /* ADDRTYPE */
+    { "IPV4",                   0x00, 0x85 },
+    { "IPV6",                   0x00, 0x86 },
+    { "E164",                   0x00, 0x87 },
+    { "ALPHA",                  0x00, 0x88 },
+    { "APN",                    0x00, 0x89 },
+    { "SCODE",                  0x00, 0x8a },
+    { "TETRA-ITSI",             0x00, 0x8b },
+    { "MAN",                    0x00, 0x8c },
+    
+    { "IPV6",                   0x01, 0x86 }, /* OMA */
+    { "E164",                   0x01, 0x87 }, /* OMA */
+    { "ALPHA",                  0x01, 0x88 }, /* OMA */
+    { "APPSRV",                 0x01, 0x8d }, /* OMA */
+    { "OBEX",                   0x01, 0x8e }, /* OMA */
+
+    /* CALLTYPE */
+    { "ANALOG-MODEM",           0x00, 0x90 },
+    { "V.120",                  0x00, 0x91 },
+    { "V.110",                  0x00, 0x92 },
+    { "X.31",                   0x00, 0x93 },
+    { "BIT-TRANSPARENT",        0x00, 0x94 },
+    { "DIRECT-ASYNCHRONOUS-DATA-SERVICE",    0x00, 0x95 },
+
+    /* AUTHTYPE/PXAUTH-TYPE */
+    { "PAP",                    0x00, 0x9a },
+    { "CHAP",                   0x00, 0x9b },
+    { "HTTP-BASIC",             0x00, 0x9c },
+    { "HTTP-DIGEST",            0x00, 0x9d },
+    { "WTLS-SS",                0x00, 0x9e },
+    { "MD5",                    0x00, 0x9f }, /* OMA */
+
+    /* BEARER */
+    { "GSM-USSD",               0x00, 0xa2 },
+    { "GSM-SMS",                0x00, 0xa3 },
+    { "ANSI-136-GUTS",          0x00, 0xa4 },
+    { "IS-95-CDMA-SMS",         0x00, 0xa5 },
+    { "IS-95-CDMA-CSD",         0x00, 0xa6 },
+    { "IS-95-CDMA-PACKET",      0x00, 0xa7 },
+    { "ANSI-136-CSD",           0x00, 0xa8 },
+    { "ANSI-136-GPRS",          0x00, 0xa9 },
+    { "GSM-CSD",                0x00, 0xaa },
+    { "GSM-GPRS",               0x00, 0xab },
+    { "AMPS-CDPD",              0x00, 0xac },
+    { "PDC-CSD",                0x00, 0xad },
+    { "PDC-PACKET",             0x00, 0xae },
+    { "IDEN-SMS",               0x00, 0xaf },
+    { "IDEN-CSD",               0x00, 0xb0 },
+    { "IDEN-PACKET",            0x00, 0xb1 },
+    { "FLEX/REFLEX",            0x00, 0xb2 },
+    { "PHS-SMS",                0x00, 0xb3 },
+    { "PHS-CSD",                0x00, 0xb4 },
+    { "TRETRA-SDS",             0x00, 0xb5 },
+    { "TRETRA-PACKET",          0x00, 0xb6 },
+    { "ANSI-136-GHOST",         0x00, 0xb7 },
+    { "MOBITEX-MPAK",           0x00, 0xb8 },
+    { "CDMA2000-1X-SIMPLE-IP",  0x00, 0xb9 }, /* OMA */
+    { "CDMA2000-1X-MOBILE-IP",  0x00, 0xba }, /* OMA */
+
+    /* LINKSPEED */
+    { "AUTOBAUDING",            0x00, 0xc5 },
+
+    /* SERVICE */
+    { "CL-WSP",                 0x00, 0xca },
+    { "CO-WSP",                 0x00, 0xcb },
+    { "CL-SEC-WSP",             0x00, 0xcc },
+    { "CO-SEC-WSP",             0x00, 0xcd },
+    { "CL-SEC-WTA",             0x00, 0xce },
+    { "CO-SEC-WTA",             0x00, 0xcf },
+    { "OTA-HTTP-TO",            0x00, 0xd0 }, /* OMA */
+    { "OTA-HTTP-TLS-TO",        0x00, 0xd1 }, /* OMA */
+    { "OTA-HTTP-PO",            0x00, 0xd2 }, /* OMA */
+    { "OTA-HTTP-TLS-PO",        0x00, 0xd3 }, /* OMA */
+    
+    /* AAUTHTYPE */
+#if defined( WBXML_SUPPORT_PROV_11 )
+    
+    { ",",                      0x01, 0x90 }, /* OMA */
+    { "HTTP-",                  0x01, 0x91 }, /* OMA */
+    { "BASIC",                  0x01, 0x92 }, /* OMA */
+    { "DIGEST",                 0x01, 0x93 }, /* OMA */
+    
+#else
+
+    { ",",                      0x01, 0x80 }, /* OMA */
+    { "HTTP-",                  0x01, 0x81 }, /* OMA */
+    { "BASIC",                  0x01, 0x82 }, /* OMA */
+    { "DIGEST",                 0x01, 0x83 }, /* OMA */
+    
+#endif /* WBXML_SUPPORT_PROV_11 */
+    
+    /* AUTH-ENTITY */
+    { "AAA",                    0x00, 0xe0 }, /* OMA */
+    { "HA",                     0x00, 0xe1 }, /* OMA */
+
+    { NULL,                     0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_PROV */
+
+
+#if defined( WBXML_SUPPORT_EMN )
+
+/*************************************************
+ *    Email Notification 1.0 ("OMA-Push-EMN-v1_0-20020830-C.PDF")
+ */
+
+const WBXMLTagEntry sv_emn10_tag_table[] = {
+    { "emn",    0x00, 0x05 },
+    { NULL,     0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_emn10_attr_table[] = {
+    { "timestamp",      NULL,           0x00, 0x05 },
+    { "mailbox",        NULL,           0x00, 0x06 },
+    { "mailbox",        "mailat:",      0x00, 0x07 },
+    { "mailbox",        "pop://",       0x00, 0x08 },
+    { "mailbox",        "imap://",      0x00, 0x09 },
+    /* Do NOT change the order in this table please ! */
+    { "mailbox",        "http://www.",  0x00, 0x0b },
+    { "mailbox",        "http://",      0x00, 0x0a },
+    { "mailbox",        "https://www.", 0x00, 0x0d },
+    { "mailbox",        "https://",     0x00, 0x0c },    
+    { NULL,             NULL,           0x00, 0x00 }
+};
+
+const WBXMLAttrValueEntry sv_emn10_attr_value_table[] = {
+    { ".com",       0x00, 0x85 },
+    { ".edu",       0x00, 0x86 },
+    { ".net",       0x00, 0x87 },
+    { ".org",       0x00, 0x88 },
+    { NULL,         0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_EMN */
+
+
+#if defined( WBXML_SUPPORT_DRMREL )
+
+/*************************************************
+ *    Rights Expression Language Version 1.0 ("OMA-Download-DRMREL-v1_0-20020913-a.pdf")
+ */
+ 
+const WBXMLTagEntry sv_drmrel10_tag_table[] = {
+    { "o-ex:rights",    0x00, 0x05 },
+    { "o-ex:context",   0x00, 0x06 },
+    { "o-dd:version",   0x00, 0x07 },
+    { "o-dd:uid",       0x00, 0x08 },
+    { "o-ex:agreement", 0x00, 0x09 },
+    { "o-ex:asset",     0x00, 0x0A },
+    { "ds:KeyInfo",     0x00, 0x0B },
+    { "ds:KeyValue",    0x00, 0x0C },
+    { "o-ex:permission",0x00, 0x0D },
+    { "o-dd:play",      0x00, 0x0E },
+    { "o-dd:display",   0x00, 0x0F },
+    { "o-dd:execute",   0x00, 0x10 },
+    { "o-dd:print",     0x00, 0x11 },
+    { "o-ex:constraint",0x00, 0x12 },
+    { "o-dd:count",     0x00, 0x13 },
+    { "o-dd:datetime",  0x00, 0x14 },
+    { "o-dd:start",     0x00, 0x15 },
+    { "o-dd:end",       0x00, 0x16 },
+    { "o-dd:interval",  0x00, 0x17 },
+    { NULL,             0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_drmrel10_attr_table[] = {
+    { "xmlns:o-ex",     NULL,       0x00, 0x05 },
+    { "xmlns:o-dd",     NULL,       0x00, 0x06 },
+    { "xmlns:ds",       NULL,       0x00, 0x07 },
+    { NULL,             NULL,       0x00, 0x00 }
+};
+
+const WBXMLAttrValueEntry sv_drmrel10_attr_value_table[] = {
+    { "http://odrl.net/1.1/ODRL-EX",        0x00, 0x85 },
+    { "http://odrl.net/1.1/ODRL-DD",        0x00, 0x86 },
+    { "http://www.w3.org/2000/09/xmldsig#/",0x00, 0x87 },
+    { NULL,                                 0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_DRMREL */
+
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+
+/********************************************************************
+ *    Ericsson / Nokia OTA Settings ("OTA_settings_general_7_0.pdf")
+ */
+ 
+const WBXMLTagEntry sv_ota_settings_tag_table[] = {
+    { "CHARACTERISTIC-LIST",        0x00, 0x05 },
+    { "CHARACTERISTIC",             0x00, 0x06 },
+    { "PARM",                       0x00, 0x07 },
+    
+    { NULL,                         0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_ota_settings_attr_table[] = {
+    /* Characteristic */
+    { "TYPE",        "ADDRESS",             0x00, 0x06 },
+    { "TYPE",        "URL",                 0x00, 0x07 },
+    { "TYPE",        "NAME",                0x00, 0x08 },
+    { "NAME",        NULL,                  0x00, 0x10 },
+    { "VALUE",       NULL,                  0x00, 0x11 },
+    { "NAME",        "BEARER",              0x00, 0x12 },
+    { "NAME",        "PROXY",               0x00, 0x13 },
+    { "NAME",        "PORT",                0x00, 0x14 },
+    { "NAME",        "NAME",                0x00, 0x15 },
+    { "NAME",        "PROXY_TYPE",          0x00, 0x16 },
+    { "NAME",        "URL",                 0x00, 0x17 },
+    { "NAME",        "PROXY_AUTHNAME",      0x00, 0x18 },
+    { "NAME",        "PROXY_AUTHSECRET",    0x00, 0x19 },
+    { "NAME",        "SMS_SMSC_ADDRESS",    0x00, 0x1A },
+    { "NAME",        "USSD_SERVICE_CODE",   0x00, 0x1B },
+    { "NAME",        "GPRS_ACCESSPOINTNAME",0x00, 0x1C },
+    { "NAME",        "PPP_LOGINTYPE",       0x00, 0x1D },
+    { "NAME",        "PROXY_LOGINTYPE",     0x00, 0x1E },
+    { "NAME",        "CSD_DIALSTRING",      0x00, 0x21 },
+    { "NAME",        "CSD_CALLTYPE",        0x00, 0x28 },
+    { "NAME",        "CSD_CALLSPEED",       0x00, 0x29 },
+    { "NAME",        "PPP_AUTHTYPE",        0x00, 0x22 },
+    { "NAME",        "PPP_AUTHNAME",        0x00, 0x23 },
+    { "NAME",        "PPP_AUTHSECRET",      0x00, 0x24 },
+    { "VALUE",       "GSM/CSD",             0x00, 0x45 },
+    { "VALUE",       "GSM/SMS",             0x00, 0x46 },
+    { "VALUE",       "GSM/USSD",            0x00, 0x47 },
+    { "VALUE",       "IS-136/CSD",          0x00, 0x48 },
+    { "VALUE",       "GPRS",                0x00, 0x49 },
+    { "VALUE",       "9200",                0x00, 0x60 },
+    { "VALUE",       "9201",                0x00, 0x61 },
+    { "VALUE",       "9202",                0x00, 0x62 },
+    { "VALUE",       "9203",                0x00, 0x63 },
+    { "VALUE",       "AUTOMATIC",           0x00, 0x64 },
+    { "VALUE",       "MANUAL",              0x00, 0x65 },
+    { "VALUE",       "AUTO",                0x00, 0x6A },
+    { "VALUE",       "9600",                0x00, 0x6B },
+    { "VALUE",       "14400",               0x00, 0x6C },
+    { "VALUE",       "19200",               0x00, 0x6D },
+    { "VALUE",       "28800",               0x00, 0x6E },
+    { "VALUE",       "38400",               0x00, 0x6F },
+    { "VALUE",       "PAP",                 0x00, 0x70 },
+    { "VALUE",       "CHAP",                0x00, 0x71 },
+    { "VALUE",       "ANALOGUE",            0x00, 0x72 },
+    { "VALUE",       "ISDN",                0x00, 0x73 },
+    { "VALUE",       "43200",               0x00, 0x74 },
+    { "VALUE",       "57600",               0x00, 0x75 },
+    { "VALUE",       "MSISDN_NO",           0x00, 0x76 },
+    { "VALUE",       "IPV4",                0x00, 0x77 },
+    { "VALUE",       "MS_CHAP",             0x00, 0x78 },
+    { "TYPE",        "MMSURL",              0x00, 0x7C },
+    { "TYPE",        "ID",                  0x00, 0x7D },
+    { "NAME",        "ISP_NAME",            0x00, 0x7E },
+    { "TYPE",        "BOOKMARK",            0x00, 0x7F },
+    
+    { NULL,          NULL,                  0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+
+#if defined( WBXML_SUPPORT_SYNCML )
+
+const WBXMLNameSpaceEntry sv_syncml_syncml10_ns_table[] = {
+    { "SYNCML:SYNCML1.0",   0x00 },     /**< Code Page 0: SYNCML1.0 */
+    { "syncml:metinf",      0x01 },     /**< Code Page 1: metinf */
+    { NULL,                 0x00 }
+};
+
+
+const WBXMLNameSpaceEntry sv_syncml_syncml11_ns_table[] = {
+    { "SYNCML:SYNCML1.1",   0x00 },     /**< Code Page 0: SYNCML1.1 */
+    { "syncml:metinf",      0x01 },     /**< Code Page 1: metinf */
+    { NULL,                 0x00 }
+};
+
+
+const WBXMLNameSpaceEntry sv_syncml_syncml12_ns_table[] = {
+    { "SYNCML:SYNCML1.2",   0x00 },     /**< Code Page 0: SYNCML1.2 */
+    { "syncml:metinf",      0x01 },     /**< Code Page 1: metinf */
+    { NULL,                 0x00 }
+};
+
+
+/******************************************************
+ *    SyncML 1.1 ("syncml_represent_v11_20020215.pdf")
+ */
+
+const WBXMLTagEntry sv_syncml_syncml11_tag_table[] = {
+    /* Code Page 0: SyncML */
+    { "Add",            0x00, 0x05 },
+    { "Alert",          0x00, 0x06 },
+    { "Archive",        0x00, 0x07 },
+    { "Atomic",         0x00, 0x08 },
+    { "Chal",           0x00, 0x09 },
+    { "Cmd",            0x00, 0x0a },
+    { "CmdID",          0x00, 0x0b },
+    { "CmdRef",         0x00, 0x0c },
+    { "Copy",           0x00, 0x0d },
+    { "Cred",           0x00, 0x0e },
+    { "Data",           0x00, 0x0f },
+    { "Delete",         0x00, 0x10 },
+    { "Exec",           0x00, 0x11 },
+    { "Final",          0x00, 0x12 },
+    { "Get",            0x00, 0x13 },
+    { "Item",           0x00, 0x14 },
+    { "Lang",           0x00, 0x15 },
+    { "LocName",        0x00, 0x16 },
+    { "LocURI",         0x00, 0x17 },
+    { "Map",            0x00, 0x18 },
+    { "MapItem",        0x00, 0x19 },
+    { "Meta",           0x00, 0x1a },
+    { "MsgID",          0x00, 0x1b },
+    { "MsgRef",         0x00, 0x1c },
+    { "NoResp",         0x00, 0x1d },
+    { "NoResults",      0x00, 0x1e },
+    { "Put",            0x00, 0x1f },
+    { "Replace",        0x00, 0x20 },
+    { "RespURI",        0x00, 0x21 },
+    { "Results",        0x00, 0x22 },
+    { "Search",         0x00, 0x23 },
+    { "Sequence",       0x00, 0x24 },
+    { "SessionID",      0x00, 0x25 },
+    { "SftDel",         0x00, 0x26 },
+    { "Source",         0x00, 0x27 },
+    { "SourceRef",      0x00, 0x28 },
+    { "Status",         0x00, 0x29 },
+    { "Sync",           0x00, 0x2a },
+    { "SyncBody",       0x00, 0x2b },
+    { "SyncHdr",        0x00, 0x2c },
+    { "SyncML",         0x00, 0x2d },
+    { "Target",         0x00, 0x2e },
+    { "TargetRef",      0x00, 0x2f },
+    { "Reserved for future use",    0x00, 0x30 },
+    { "VerDTD",         0x00, 0x31 },
+    { "VerProto",       0x00, 0x32 },
+    { "NumberOfChanges",0x00, 0x33 },
+    { "MoreData",       0x00, 0x34 },
+
+    /* SourceParent is officially only specified for SyncML 1.2.
+     * Nevertheless Nokia uses this tag during the synchronization
+     * of SMS. So this is a proprietary extension to avoid that
+     * there is a tag called "unknown".
+     */
+    { "SourceParent",   0x00, 0x39 },
+
+    /* Code Page 1: MetInf11 */
+    { "Anchor",         0x01, 0x05 },
+    { "EMI",            0x01, 0x06 },
+    { "Format",         0x01, 0x07 },
+    { "FreeID",         0x01, 0x08 },
+    { "FreeMem",        0x01, 0x09 },
+    { "Last",           0x01, 0x0a },
+    { "Mark",           0x01, 0x0b },
+    { "MaxMsgSize",     0x01, 0x0c },
+    { "Mem",            0x01, 0x0d },
+    { "MetInf",         0x01, 0x0e },
+    { "Next",           0x01, 0x0f },
+    { "NextNonce",      0x01, 0x10 },
+    { "SharedMem",      0x01, 0x11 },
+    { "Size",           0x01, 0x12 },
+    { "Type",           0x01, 0x13 },
+    { "Version",        0x01, 0x14 },
+    { "MaxObjSize",     0x01, 0x15 },
+    { NULL,             0x00, 0x00 }
+};
+
+
+/*********************************************************
+ *    SyncML DevInf 1.1 ("syncml_devinf_v11_20020215.pdf")
+ */
+
+const WBXMLTagEntry sv_syncml_devinf11_tag_table[] = {
+    { "CTCap",          0x00, 0x05 },
+    { "CTType",         0x00, 0x06 },
+    { "DataStore",      0x00, 0x07 },
+    { "DataType",       0x00, 0x08 },
+    { "DevID",          0x00, 0x09 },
+    { "DevInf",         0x00, 0x0a },
+    { "DevTyp",         0x00, 0x0b },
+    { "DisplayName",    0x00, 0x0c },
+    { "DSMem",          0x00, 0x0d },
+    { "Ext",            0x00, 0x0e },
+    { "FwV",            0x00, 0x0f },
+    { "HwV",            0x00, 0x10 },
+    { "Man",            0x00, 0x11 },
+    { "MaxGUIDSize",    0x00, 0x12 },
+    { "MaxID",          0x00, 0x13 },
+    { "MaxMem",         0x00, 0x14 },
+    { "Mod",            0x00, 0x15 },
+    { "OEM",            0x00, 0x16 },
+    { "ParamName",      0x00, 0x17 },
+    { "PropName",       0x00, 0x18 },
+    { "Rx",             0x00, 0x19 },
+    { "Rx-Pref",        0x00, 0x1a },
+    { "SharedMem",      0x00, 0x1b },
+    { "Size",           0x00, 0x1c },
+    { "SourceRef",      0x00, 0x1d },
+    { "SwV",            0x00, 0x1e },
+    { "SyncCap",        0x00, 0x1f },
+    { "SyncType",       0x00, 0x20 },
+    { "Tx",             0x00, 0x21 },
+    { "Tx-Pref",        0x00, 0x22 },
+    { "ValEnum",        0x00, 0x23 },
+    { "VerCT",          0x00, 0x24 },
+    { "VerDTD",         0x00, 0x25 },
+    { "XNam",           0x00, 0x26 },
+    { "XVal",           0x00, 0x27 },
+    { "UTC",            0x00, 0x28 },
+    { "SupportNumberOfChanges", 0x00, 0x29 },
+    { "SupportLargeObjs",       0x00, 0x2a },
+    { NULL,                0x00, 0x00 }
+};
+
+
+const WBXMLNameSpaceEntry sv_syncml_devinf11_ns_table[] = {
+    { "syncml:devinf",  0x00 },     /**< Code Page 0: devinf */
+    { NULL,             0x00 }
+};
+
+
+/*********************************************************
+ *    SyncML MetInf 1.1 ("syncml_metinf_v11_20020215.pdf")
+ */
+
+const WBXMLTagEntry sv_syncml_metinf11_tag_table[] = {
+    { "Anchor",         0x01, 0x05 },
+    { "EMI",            0x01, 0x06 },
+    { "Format",         0x01, 0x07 },
+    { "FreeID",         0x01, 0x08 },
+    { "FreeMem",        0x01, 0x09 },
+    { "Last",           0x01, 0x0a },
+    { "Mark",           0x01, 0x0b },
+    { "MaxMsgSize",     0x01, 0x0c },
+    { "Mem",            0x01, 0x0d },
+    { "MetInf",         0x01, 0x0e },
+    { "Next",           0x01, 0x0f },
+    { "NextNonce",      0x01, 0x10 },
+    { "SharedMem",      0x01, 0x11 },
+    { "Size",           0x01, 0x12 },
+    { "Type",           0x01, 0x13 },
+    { "Version",        0x01, 0x14 },
+    { "MaxObjSize",     0x01, 0x15 },
+    { NULL,             0x00, 0x00 }
+};
+
+
+/******************************************************
+ *    SyncML 1.2 ("OMA-TS-SyncML_RepPro-V1_2-20050509-C.pdf")
+ */
+
+const WBXMLTagEntry sv_syncml_syncml12_tag_table[] = {
+    /* Code Page 0: SyncML */
+    { "Add",            0x00, 0x05 },
+    { "Alert",          0x00, 0x06 },
+    { "Archive",        0x00, 0x07 },
+    { "Atomic",         0x00, 0x08 },
+    { "Chal",           0x00, 0x09 },
+    { "Cmd",            0x00, 0x0a },
+    { "CmdID",          0x00, 0x0b },
+    { "CmdRef",         0x00, 0x0c },
+    { "Copy",           0x00, 0x0d },
+    { "Cred",           0x00, 0x0e },
+    { "Data",           0x00, 0x0f },
+    { "Delete",         0x00, 0x10 },
+    { "Exec",           0x00, 0x11 },
+    { "Final",          0x00, 0x12 },
+    { "Get",            0x00, 0x13 },
+    { "Item",           0x00, 0x14 },
+    { "Lang",           0x00, 0x15 },
+    { "LocName",        0x00, 0x16 },
+    { "LocURI",         0x00, 0x17 },
+    { "Map",            0x00, 0x18 },
+    { "MapItem",        0x00, 0x19 },
+    { "Meta",           0x00, 0x1a },
+    { "MsgID",          0x00, 0x1b },
+    { "MsgRef",         0x00, 0x1c },
+    { "NoResp",         0x00, 0x1d },
+    { "NoResults",      0x00, 0x1e },
+    { "Put",            0x00, 0x1f },
+    { "Replace",        0x00, 0x20 },
+    { "RespURI",        0x00, 0x21 },
+    { "Results",        0x00, 0x22 },
+    { "Search",         0x00, 0x23 },
+    { "Sequence",       0x00, 0x24 },
+    { "SessionID",      0x00, 0x25 },
+    { "SftDel",         0x00, 0x26 },
+    { "Source",         0x00, 0x27 },
+    { "SourceRef",      0x00, 0x28 },
+    { "Status",         0x00, 0x29 },
+    { "Sync",           0x00, 0x2a },
+    { "SyncBody",       0x00, 0x2b },
+    { "SyncHdr",        0x00, 0x2c },
+    { "SyncML",         0x00, 0x2d },
+    { "Target",         0x00, 0x2e },
+    { "TargetRef",      0x00, 0x2f },
+    { "Reserved for future use",    0x00, 0x30 },
+    { "VerDTD",         0x00, 0x31 },
+    { "VerProto",       0x00, 0x32 },
+    { "NumberOfChanges",0x00, 0x33 },
+    { "MoreData",       0x00, 0x34 },
+    { "Field",          0x00, 0x35 },
+    { "Filter",         0x00, 0x36 },
+    { "Record",         0x00, 0x37 },
+    { "FilterType",     0x00, 0x38 },
+    { "SourceParent",   0x00, 0x39 },
+    { "TargetParent",   0x00, 0x3a },
+    { "Move",           0x00, 0x3b },
+    { "Correlator",     0x00, 0x3c },
+
+    /* Code Page 1: MetInf */
+    { "Anchor",         0x01, 0x05 },
+    { "EMI",            0x01, 0x06 },
+    { "Format",         0x01, 0x07 },
+    { "FreeID",         0x01, 0x08 },
+    { "FreeMem",        0x01, 0x09 },
+    { "Last",           0x01, 0x0a },
+    { "Mark",           0x01, 0x0b },
+    { "MaxMsgSize",     0x01, 0x0c },
+    { "Mem",            0x01, 0x0d },
+    { "MetInf",         0x01, 0x0e },
+    { "Next",           0x01, 0x0f },
+    { "NextNonce",      0x01, 0x10 },
+    { "SharedMem",      0x01, 0x11 },
+    { "Size",           0x01, 0x12 },
+    { "Type",           0x01, 0x13 },
+    { "Version",        0x01, 0x14 },
+    { "MaxObjSize",     0x01, 0x15 },
+    { "FieldLevel",     0x01, 0x16 },
+    { NULL,             0x00, 0x00 }
+};
+
+
+/*********************************************************
+ *    SyncML DevInf 1.2 ("OMA-TS-DS_DevInf-V1_2-20060710-A.pdf")
+ */
+
+const WBXMLTagEntry sv_syncml_devinf12_tag_table[] = {
+    { "CTCap",          0x00, 0x05 },
+    { "CTType",         0x00, 0x06 },
+    { "DataStore",      0x00, 0x07 },
+    { "DataType",       0x00, 0x08 },
+    { "DevID",          0x00, 0x09 },
+    { "DevInf",         0x00, 0x0a },
+    { "DevTyp",         0x00, 0x0b },
+    { "DisplayName",    0x00, 0x0c },
+    { "DSMem",          0x00, 0x0d },
+    { "Ext",            0x00, 0x0e },
+    { "FwV",            0x00, 0x0f },
+    { "HwV",            0x00, 0x10 },
+    { "Man",            0x00, 0x11 },
+    { "MaxGUIDSize",    0x00, 0x12 },
+    { "MaxID",          0x00, 0x13 },
+    { "MaxMem",         0x00, 0x14 },
+    { "Mod",            0x00, 0x15 },
+    { "OEM",            0x00, 0x16 },
+    { "ParamName",      0x00, 0x17 },
+    { "PropName",       0x00, 0x18 },
+    { "Rx",             0x00, 0x19 },
+    { "Rx-Pref",        0x00, 0x1a },
+    { "SharedMem",      0x00, 0x1b },
+    { "MaxSize",        0x00, 0x1c },
+    { "SourceRef",      0x00, 0x1d },
+    { "SwV",            0x00, 0x1e },
+    { "SyncCap",        0x00, 0x1f },
+    { "SyncType",       0x00, 0x20 },
+    { "Tx",             0x00, 0x21 },
+    { "Tx-Pref",        0x00, 0x22 },
+    { "ValEnum",        0x00, 0x23 },
+    { "VerCT",          0x00, 0x24 },
+    { "VerDTD",         0x00, 0x25 },
+    { "XNam",           0x00, 0x26 },
+    { "XVal",           0x00, 0x27 },
+    { "UTC",            0x00, 0x28 },
+    { "SupportNumberOfChanges", 0x00, 0x29 },
+    { "SupportLargeObjs",       0x00, 0x2a },
+    { "Property",       0x00, 0x2b },
+    { "PropParam",      0x00, 0x2c },
+    { "MaxOccur",       0x00, 0x2d },
+    { "NoTruncate",     0x00, 0x2e },
+    { "Filter-Rx",      0x00, 0x30 },
+    { "FilterCap",      0x00, 0x31 },
+    { "FilterKeyword",  0x00, 0x32 },
+    { "FieldLevel",     0x00, 0x33 },
+    { "SupportHierarchicalSync", 0x00, 0x34 },
+    { NULL,             0x00, 0x00 }
+};
+
+
+const WBXMLNameSpaceEntry sv_syncml_devinf12_ns_table[] = {
+    { "syncml:devinf",  0x00 },     /**< Code Page 0: devinf */
+    { NULL,             0x00 }
+};
+
+
+/*********************************************************
+ *    SyncML MetInf 1.2 ("OMA-TS-SyncML_MetaInfo-V1_2-20050509-C.pdf")
+ */
+
+const WBXMLTagEntry sv_syncml_metinf12_tag_table[] = {
+    { "Anchor",         0x01, 0x05 },
+    { "EMI",            0x01, 0x06 },
+    { "Format",         0x01, 0x07 },
+    { "FreeID",         0x01, 0x08 },
+    { "FreeMem",        0x01, 0x09 },
+    { "Last",           0x01, 0x0a },
+    { "Mark",           0x01, 0x0b },
+    { "MaxMsgSize",     0x01, 0x0c },
+    { "Mem",            0x01, 0x0d },
+    { "MetInf",         0x01, 0x0e },
+    { "Next",           0x01, 0x0f },
+    { "NextNonce",      0x01, 0x10 },
+    { "SharedMem",      0x01, 0x11 },
+    { "Size",           0x01, 0x12 },
+    { "Type",           0x01, 0x13 },
+    { "Version",        0x01, 0x14 },
+    { "MaxObjSize",     0x01, 0x15 },
+    { "FieldLevel",     0x01, 0x16 },
+    { NULL,             0x00, 0x00 }
+};
+
+/*********************************************************
+ *    SyncML DM DDF 1.2 ("OMA-TS-DM_TND-V1_2_1-20080617-A.pdf")
+ */
+
+const WBXMLTagEntry sv_syncml_dmddf12_tag_table[] = {
+    { "AccessType",     0x02, 0x05 },
+    { "ACL",            0x02, 0x06 },
+    { "Add",            0x02, 0x07 },
+    { "b64",            0x02, 0x08 },
+    { "bin",            0x02, 0x09 },
+    { "bool",           0x02, 0x0A },
+    { "chr",            0x02, 0x0B },
+    { "CaseSense",      0x02, 0x0C },
+    { "CIS",            0x02, 0x0D },
+    { "Copy",           0x02, 0x0E },
+    { "CS",             0x02, 0x0F },
+    { "date",           0x02, 0x10 },
+    { "DDFName",        0x02, 0x11 },
+    { "DefaultValue",   0x02, 0x12 },
+    { "Delete",         0x02, 0x13 },
+    { "Description",    0x02, 0x14 },
+    { "DFFormat",       0x02, 0x15 },
+    { "DFProperties",   0x02, 0x16 },
+    { "DFTitle",        0x02, 0x17 },
+    { "DFType",         0x02, 0x18 },
+    { "Dynamic",        0x02, 0x19 },
+    { "Exec",           0x02, 0x1A },
+    { "float",          0x02, 0x1B },
+    { "Format",         0x02, 0x1C },
+    { "Get",            0x02, 0x1D },
+    { "int",            0x02, 0x1E },
+    { "Man",            0x02, 0x1F },
+    { "MgmtTree",       0x02, 0x20 },
+    { "MIME",           0x02, 0x21 },
+    { "Mod",            0x02, 0x22 },
+    { "Name",           0x02, 0x23 },
+    { "Node",           0x02, 0x24 },
+    { "node",           0x02, 0x25 },
+    { "NodeName",       0x02, 0x26 },
+    { "null",           0x02, 0x27 },
+    { "Occurrence",     0x02, 0x28 },
+    { "One",            0x02, 0x29 },
+    { "OneOrMore",      0x02, 0x2A },
+    { "OneOrN",         0x02, 0x2B },
+    { "Path",           0x02, 0x2C },
+    { "Permanent",      0x02, 0x2D },
+    { "Replace",        0x02, 0x2E },
+    { "RTProperties",   0x02, 0x2F },
+    { "Scope",          0x02, 0x30 },
+    { "Size",           0x02, 0x31 },
+    { "time",           0x02, 0x32 },
+    { "Title",          0x02, 0x33 },
+    { "TStamp",         0x02, 0x34 },
+    { "Type",           0x02, 0x35 },
+    { "Value",          0x02, 0x36 },
+    { "VerDTD",         0x02, 0x37 },
+    { "VerNo",          0x02, 0x38 },
+    { "xml",            0x02, 0x39 },
+    { "ZeroOrMore",     0x02, 0x3A },
+    { "ZeroOrN",        0x02, 0x3B },
+    { "ZeroOrOne",      0x02, 0x3C },
+    { NULL,             0x00, 0x00 }
+};
+
+const WBXMLNameSpaceEntry sv_syncml_dmddf12_ns_table[] = {
+    { "syncml:dmddf1.2", 0x02 },     /**< Code Page 2: OMA DM DDF */
+    { NULL,              0x00 }
+};
+
+#endif /* WBXML_SUPPORT_SYNCML */
+
+
+#if defined( WBXML_SUPPORT_WV )
+
+/*****************************************************************************
+ *    Wireless Village CSP 1.1 ("OMA-WV-CSP-V1_1-20021001-A.pdf")
+ *    Wireless Village CSP 1.2 ("OMA-IMPS-WV-CSP_WBXML-V1_2-20040522-C.pdf")
+ */
+
+const WBXMLTagEntry sv_wv_csp_tag_table[] = {
+    /* Common ... continue on Page 0x09 */
+    { "Acceptance",     0x00, 0x05 },
+    { "AddList",        0x00, 0x06 },
+    { "AddNickList",    0x00, 0x07 },
+    { "ClientID",       0x00, 0x0A },
+    { "Code",           0x00, 0x0B },
+    { "ContactList",    0x00, 0x0C },
+    { "ContentData",    0x00, 0x0D },
+    { "ContentEncoding",0x00, 0x0E },
+    { "ContentSize",    0x00, 0x0F },
+    { "ContentType",    0x00, 0x10 },
+    { "DateTime",       0x00, 0x11 },
+    { "Description",    0x00, 0x12 },
+    { "DetailedResult", 0x00, 0x13 },
+    { "EntityList",     0x00, 0x14 },
+    { "Group",          0x00, 0x15 },
+    { "GroupID",        0x00, 0x16 },
+    { "GroupList",      0x00, 0x17 },
+    { "InUse",          0x00, 0x18 },
+    { "Logo",           0x00, 0x19 },
+    { "MessageCount",   0x00, 0x1A },
+    { "MessageID",      0x00, 0x1B },
+    { "MessageURI",     0x00, 0x1C },
+    { "MSISDN",         0x00, 0x1D },
+    { "Name",           0x00, 0x1E },
+    { "NickList",       0x00, 0x1F },
+    { "NickName",       0x00, 0x20 },
+    { "Poll",           0x00, 0x21 },
+    { "Presence",       0x00, 0x22 },
+    { "PresenceSubList",0x00, 0x23 },
+    { "PresenceValue",  0x00, 0x24 },
+    { "Property",       0x00, 0x25 },
+    { "Qualifier",      0x00, 0x26 },
+    { "Recipient",      0x00, 0x27 },
+    { "RemoveList",     0x00, 0x28 },
+    { "RemoveNickList", 0x00, 0x29 },
+    { "Result",         0x00, 0x2A },
+    { "ScreenName",     0x00, 0x2B },
+    { "Sender",         0x00, 0x2C },
+    { "Session",        0x00, 0x2D },
+    { "SessionDescriptor",      0x00, 0x2E },
+    { "SessionID",              0x00, 0x2F },
+    { "SessionType",            0x00, 0x30 },
+    { "SName",                  0x00, 0x08 },
+    { "Status",                 0x00, 0x31 },
+    { "Transaction",            0x00, 0x32 },
+    { "TransactionContent",     0x00, 0x33 },
+    { "TransactionDescriptor",  0x00, 0x34 },
+    { "TransactionID",  0x00, 0x35 },
+    { "TransactionMode",0x00, 0x36 },
+    { "URL",            0x00, 0x37 },
+    { "URLList",        0x00, 0x38 },
+    { "User",           0x00, 0x39 },
+    { "UserID",         0x00, 0x3A },
+    { "UserList",       0x00, 0x3B },
+    { "Validity",       0x00, 0x3C },
+    { "Value",          0x00, 0x3D },
+    { "WV-CSP-Message", 0x00, 0x09 },
+    
+    /* Access ... continue on Page 0x0A */
+    { "AgreedCapabilityList",       0x01, 0x3A }, /* WV 1.2 */
+    { "AllFunctions",               0x01, 0x05 },
+    { "AllFunctionsRequest",        0x01, 0x06 },
+    { "CancelInvite-Request",       0x01, 0x07 },
+    { "CancelInviteUser-Request",   0x01, 0x08 },
+    { "Capability",                 0x01, 0x09 },
+    { "CapabilityList",             0x01, 0x0A },
+    { "CapabilityRequest",          0x01, 0x0B },
+    { "ClientCapability-Request",   0x01, 0x0C },
+    { "ClientCapability-Response",  0x01, 0x0D },
+    { "CompletionFlag",         0x01, 0x34 },
+    { "DigestBytes",            0x01, 0x0E },
+    { "DigestSchema",           0x01, 0x0F },
+    { "Disconnect",             0x01, 0x10 },
+    { "Extended-Request",       0x01, 0x38 }, /* WV 1.2 */
+    { "Extended-Response",      0x01, 0x39 }, /* WV 1.2 */
+    { "Extended-Data",          0x01, 0x3B }, /* WV 1.2 */
+    { "Functions",              0x01, 0x11 },
+    { "GetSPInfo-Request",      0x01, 0x12 },
+    { "GetSPInfo-Response",     0x01, 0x13 },
+    { "InviteID",               0x01, 0x14 },
+    { "InviteNote",             0x01, 0x15 },
+    { "Invite-Request",         0x01, 0x16 },
+    { "Invite-Response",        0x01, 0x17 },
+    { "InviteType",             0x01, 0x18 },
+    { "InviteUser-Request",     0x01, 0x19 },
+    { "InviteUser-Response",    0x01, 0x1A },
+    { "KeepAlive-Request",      0x01, 0x1B },
+    { "KeepAlive-Response",     0x01, 0x29 },
+    { "KeepAliveTime",          0x01, 0x1C },
+    { "Login-Request",          0x01, 0x1D },
+    { "Login-Response",         0x01, 0x1E },
+    { "Logout-Request",         0x01, 0x1F },
+    { "Nonce",                  0x01, 0x20 },
+    { "OtherServer",            0x01, 0x3C }, /* WV 1.2 */
+    { "Password",               0x01, 0x21 },
+    { "Polling-Request",        0x01, 0x22 },
+    { "PresenceAttributeNSName",0x01, 0x3D }, /* WV 1.2 */
+    { "ReceiveList",            0x01, 0x36 }, /* WV 1.2 */
+    { "ResponseNote",           0x01, 0x23 },
+    { "SearchElement",          0x01, 0x24 },
+    { "SearchFindings",         0x01, 0x25 },
+    { "SearchID",               0x01, 0x26 },
+    { "SearchIndex",            0x01, 0x27 },
+    { "SearchLimit",            0x01, 0x28 },
+    { "SearchPairList",         0x01, 0x2A },
+    { "Search-Request",         0x01, 0x2B },
+    { "Search-Response",        0x01, 0x2C },
+    { "SearchResult",           0x01, 0x2D },
+    { "SearchString",           0x01, 0x33 },
+    { "Service-Request",        0x01, 0x2E },
+    { "Service-Response",       0x01, 0x2F },
+    { "SessionCookie",          0x01, 0x30 },
+    { "SessionNSName",          0x01, 0x3E }, /* WV 1.2 */
+    { "StopSearch-Request",     0x01, 0x31 },
+    { "TimeToLive",             0x01, 0x32 },
+    { "TransactionNSName",      0x01, 0x3F }, /* WV 1.2 */
+    { "VerifyID-Request",       0x01, 0x37 }, /* WV 1.2 */
+        
+    /* Service ... continue on Page 0x08 */
+    { "ADDGM",          0x02, 0x05 },
+    { "AttListFunc",    0x02, 0x06 },
+    { "BLENT",          0x02, 0x07 },
+    { "CAAUT",          0x02, 0x08 },
+    { "CAINV",          0x02, 0x09 },
+    { "CALI",           0x02, 0x0A },
+    { "CCLI",           0x02, 0x0B },
+    { "ContListFunc",   0x02, 0x0C },
+    { "CREAG",          0x02, 0x0D },
+    { "DALI",           0x02, 0x0E },
+    { "DCLI",           0x02, 0x0F },
+    { "DELGR",          0x02, 0x10 },
+    { "FundamentalFeat",0x02, 0x11 },
+    { "FWMSG",          0x02, 0x12 },
+    { "GALS",           0x02, 0x13 },
+    { "GCLI",           0x02, 0x14 },
+    { "GETGM",          0x02, 0x15 },
+    { "GETGP",          0x02, 0x16 },
+    { "GETLM",          0x02, 0x17 },
+    { "GETM",           0x02, 0x18 },
+    { "GETPR",          0x02, 0x19 },
+    { "GETSPI",         0x02, 0x1A },
+    { "GETWL",          0x02, 0x1B },
+    { "GLBLU",          0x02, 0x1C },
+    { "GRCHN",          0x02, 0x1D },
+    { "GroupAuthFunc",  0x02, 0x1E },
+    { "GroupFeat",      0x02, 0x1F },
+    { "GroupMgmtFunc",  0x02, 0x20 },
+    { "GroupUseFunc",   0x02, 0x21 },
+    { "IMAuthFunc",     0x02, 0x22 },
+    { "IMFeat",         0x02, 0x23 },
+    { "IMReceiveFunc",  0x02, 0x24 },
+    { "IMSendFunc",     0x02, 0x25 },
+    { "INVIT",          0x02, 0x26 },
+    { "InviteFunc",     0x02, 0x27 },
+    { "MBRAC",          0x02, 0x28 },
+    { "MCLS",           0x02, 0x29 },
+    { "MF",             0x02, 0x3D }, /* WV 1.2 */
+    { "MG",             0x02, 0x3E }, /* WV 1.2 */
+    { "MM",             0x02, 0x3F }, /* WV 1.2 */
+    { "MDELIV",         0x02, 0x2A },
+    { "NEWM",           0x02, 0x2B },
+    { "NOTIF",          0x02, 0x2C },
+    { "PresenceAuthFunc",   0x02, 0x2D },
+    { "PresenceDeliverFunc",0x02, 0x2E },
+    { "PresenceFeat",       0x02, 0x2F },
+    { "REACT",          0x02, 0x30 },
+    { "REJCM",          0x02, 0x31 },
+    { "REJEC",          0x02, 0x32 },
+    { "RMVGM",          0x02, 0x33 },
+    { "SearchFunc",     0x02, 0x34 },
+    { "ServiceFunc",    0x02, 0x35 },
+    { "SETD",           0x02, 0x36 },
+    { "SETGP",          0x02, 0x37 },
+    { "SRCH",           0x02, 0x38 },
+    { "STSRC",          0x02, 0x39 },
+    { "SUBGCN",         0x02, 0x3A },
+    { "UPDPR",          0x02, 0x3B },
+    { "WVCSPFeat",      0x02, 0x3C },
+    
+    /* Client Capability */
+    { "AcceptedCharset",            0x03, 0x05 },
+    { "AcceptedContentLength",      0x03, 0x06 },
+    { "AcceptedContentType",        0x03, 0x07 },
+    { "AcceptedTransferEncoding",   0x03, 0x08 },
+    { "AnyContent",                 0x03, 0x09 },
+    { "DefaultLanguage",            0x03, 0x0A },
+    { "InitialDeliveryMethod",      0x03, 0x0B },
+    { "MultiTrans",                 0x03, 0x0C },
+    { "ParserSize",                 0x03, 0x0D },
+    { "ServerPollMin",              0x03, 0x0E },
+    { "SupportedBearer",            0x03, 0x0F },
+    { "SupportedCIRMethod",         0x03, 0x10 },
+    { "TCPAddress",                 0x03, 0x11 },
+    { "TCPPort",                    0x03, 0x12 },
+    { "UDPPort",                    0x03, 0x13 },    
+    
+    /* Presence Primitive */
+    { "Auto-Subscribe",                 0x04, 0x1E }, /* WV 1.2 */
+    { "CancelAuth-Request",             0x04, 0x05 },
+    { "ContactListProperties",          0x04, 0x06 },
+    { "CreateAttributeList-Request",    0x04, 0x07 },
+    { "CreateList-Request",             0x04, 0x08 },
+    { "DefaultAttributeList",           0x04, 0x09 },
+    { "DefaultContactList",             0x04, 0x0A },
+    { "DefaultList",                    0x04, 0x0B },
+    { "DeleteAttributeList-Request",    0x04, 0x0C },
+    { "DeleteList-Request",             0x04, 0x0D },
+    { "GetAttributeList-Request",       0x04, 0x0E },
+    { "GetAttributeList-Response",      0x04, 0x0F },
+    { "GetList-Request",                0x04, 0x10 },
+    { "GetList-Response",               0x04, 0x11 },
+    { "GetPresence-Request",            0x04, 0x12 },
+    { "GetPresence-Response",           0x04, 0x13 },
+    { "GetReactiveAuthStatus-Request",  0x04, 0x1F }, /* WV 1.2 */
+    { "GetReactiveAuthStatus-Response", 0x04, 0x20 }, /* WV 1.2 */
+    { "GetWatcherList-Request",         0x04, 0x14 },
+    { "GetWatcherList-Response",        0x04, 0x15 },
+    { "ListManage-Request",             0x04, 0x16 },
+    { "ListManage-Response",            0x04, 0x17 },
+    { "PresenceAuth-Request",           0x04, 0x19 },
+    { "PresenceAuth-User",              0x04, 0x1A },
+    { "PresenceNotification-Request",   0x04, 0x1B },
+    { "SubscribePresence-Request",      0x04, 0x1D },
+    { "UnsubscribePresence-Request",    0x04, 0x18 },
+    { "UpdatePresence-Request",         0x04, 0x1C },
+    
+    /* Presence Attribute */
+    { "Accuracy",           0x05, 0x05 },
+    { "Address",            0x05, 0x06 },
+    { "AddrPref",           0x05, 0x07 },
+    { "Alias",              0x05, 0x08 },
+    { "Altitude",           0x05, 0x09 },
+    { "Building",           0x05, 0x0A },
+    { "Caddr",              0x05, 0x0B },
+    { "Cap",                0x05, 0x2F },
+    { "City",               0x05, 0x0C },
+    { "ClientInfo",         0x05, 0x0D },
+    { "ClientProducer",     0x05, 0x0E },
+    { "ClientType",         0x05, 0x0F },
+    { "ClientVersion",      0x05, 0x10 },
+    { "Cname",              0x05, 0x30 },
+    { "CommC",              0x05, 0x11 },
+    { "CommCap",            0x05, 0x12 },
+    { "Contact",            0x05, 0x31 },
+    { "ContactInfo",        0x05, 0x13 },
+    { "ContainedvCard",     0x05, 0x14 },
+                                          /* WV 1.2: removed in last version */
+    { "Country",            0x05, 0x15 },
+    { "Cpriority",          0x05, 0x32 },
+    { "Crossing1",          0x05, 0x16 },
+    { "Crossing2",          0x05, 0x17 },
+    { "Cstatus",            0x05, 0x33 },
+    { "DevManufacturer",    0x05, 0x18 },
+    { "DirectContent",      0x05, 0x19 },
+    { "FreeTextLocation",   0x05, 0x1A },
+    { "GeoLocation",        0x05, 0x1B },
+    { "Inf_link",           0x05, 0x37 }, /* WV 1.2 */
+    { "InfoLink",           0x05, 0x38 }, /* WV 1.2 */
+    { "Language",           0x05, 0x1C },
+    { "Latitude",           0x05, 0x1D },
+    { "Link",               0x05, 0x39 }, /* WV 1.2 */
+    { "Longitude",          0x05, 0x1E },
+    { "Model",              0x05, 0x1F },
+    { "NamedArea",          0x05, 0x20 },    
+    { "Note",               0x05, 0x34 }, /* WV 1.2 */
+    { "OnlineStatus",       0x05, 0x21 },
+    { "PLMN",               0x05, 0x22 },
+    { "PrefC",              0x05, 0x23 },
+    { "PreferredContacts",  0x05, 0x24 },
+    { "PreferredLanguage",  0x05, 0x25 },
+    { "PreferredContent",   0x05, 0x26 },
+    { "PreferredvCard",     0x05, 0x27 },
+    { "Registration",       0x05, 0x28 },
+    { "StatusContent",      0x05, 0x29 },
+    { "StatusMood",         0x05, 0x2A },
+    { "StatusText",         0x05, 0x2B },
+    { "Street",             0x05, 0x2C },
+    { "Text",               0x05, 0x3A }, /* WV 1.2 */
+    { "TimeZone",           0x05, 0x2D },
+    { "UserAvailability",   0x05, 0x2E },
+    { "Zone",               0x05, 0x35 },
+        
+    /* Messaging */
+    { "BlockList",                  0x06, 0x05 },
+    { "BlockEntity-Request",        0x06, 0x06 }, /* WV 1.2 : changed from 'BlockUser-Request' in WV 1.1 */
+    { "DeliveryMethod",             0x06, 0x07 },
+    { "DeliveryReport",             0x06, 0x08 },
+    { "DeliveryReport-Request",     0x06, 0x09 },
+    { "DeliveryTime",               0x06, 0x1A },
+    { "ForwardMessage-Request",     0x06, 0x0A },
+    { "GetBlockedList-Request",     0x06, 0x0B },
+    { "GetBlockedList-Response",    0x06, 0x0C },
+    { "GetMessageList-Request",     0x06, 0x0D },
+    { "GetMessageList-Response",    0x06, 0x0E },
+    { "GetMessage-Request",         0x06, 0x0F },
+    { "GetMessage-Response",        0x06, 0x10 },
+    { "GrantList",                  0x06, 0x11 },
+    { "MessageDelivered",           0x06, 0x12 },
+    { "MessageInfo",                0x06, 0x13 },
+    { "MessageNotification",        0x06, 0x14 },
+    { "NewMessage",                 0x06, 0x15 },
+    { "RejectMessage-Request",      0x06, 0x16 },
+    { "SendMessage-Request",        0x06, 0x17 },
+    { "SendMessage-Response",       0x06, 0x18 },
+    { "SetDeliveryMethod-Request",  0x06, 0x19 },
+    
+    /* Group */
+    { "AddGroupMembers-Request",    0x07, 0x05 },
+    { "Admin",                      0x07, 0x06 },
+    { "AdminMapList",               0x07, 0x26 }, /* WV 1.2 */
+    { "AdminMapping",               0x07, 0x27 }, /* WV 1.2 */
+    { "CreateGroup-Request",        0x07, 0x07 },
+    { "DeleteGroup-Request",        0x07, 0x08 },
+    { "GetGroupMembers-Request",    0x07, 0x09 },
+    { "GetGroupMembers-Response",   0x07, 0x0A },
+    { "GetGroupProps-Request",      0x07, 0x0B },
+    { "GetGroupProps-Response",     0x07, 0x0C },
+    { "GetJoinedUsers-Request",     0x07, 0x24 }, /* WV 1.2 */
+    { "GetJoinedUsers-Response",    0x07, 0x25 }, /* WV 1.2 */
+    { "GroupChangeNotice",          0x07, 0x0D },
+    { "GroupProperties",            0x07, 0x0E },
+    { "Joined",                     0x07, 0x0F },
+    { "JoinGroup",                  0x07, 0x21 },
+    { "JoinedRequest",              0x07, 0x10 },
+    { "JoinGroup-Request",          0x07, 0x11 },
+    { "JoinGroup-Response",         0x07, 0x12 },
+    { "LeaveGroup-Request",         0x07, 0x13 },
+    { "LeaveGroup-Response",        0x07, 0x14 },
+    { "Left",                       0x07, 0x15 },
+    { "Mapping",                    0x07, 0x28 }, /* WV 1.2 */
+    { "MemberAccess-Request",       0x07, 0x16 },
+    { "Mod",                        0x07, 0x17 },
+    { "ModMapping",                 0x07, 0x29 }, /* WV 1.2 */
+    { "OwnProperties",              0x07, 0x18 },
+    { "RejectList-Request",         0x07, 0x19 },
+    { "RejectList-Response",        0x07, 0x1A },
+    { "RemoveGroupMembers-Request", 0x07, 0x1B },
+    { "SetGroupProps-Request",      0x07, 0x1C },
+    { "SubscribeGroupNotice-Request",   0x07, 0x1D },
+    { "SubscribeGroupNotice-Response",  0x07, 0x1E },
+    { "SubscribeNotification",          0x07, 0x22 },
+    { "SubscribeType",                  0x07, 0x23 },
+    { "UserMapList",                0x07, 0x2A }, /* WV 1.2 */
+    { "UserMapping",                0x07, 0x2B }, /* WV 1.2 */
+    { "Users",                      0x07, 0x1F },
+    { "WelcomeNote",                0x07, 0x20 },
+
+    /* Service ... continued */
+    { "GETAUT",                     0x08, 0x06 }, /* WV 1.2 */
+    { "GETJU",                      0x08, 0x07 }, /* WV 1.2 */
+    { "MP",                         0x08, 0x05 }, /* WV 1.2 */
+    { "VRID",                       0x08, 0x08 }, /* WV 1.2 */
+    { "VerifyIDFunc",               0x08, 0x09 }, /* WV 1.2 */
+
+    /* Common ... continued */
+    { "CIR",                        0x09, 0x05 }, /* WV 1.2 */
+    { "Domain",                     0x09, 0x06 }, /* WV 1.2 */
+    { "ExtBlock",                   0x09, 0x07 }, /* WV 1.2 */
+    { "HistoryPeriod",              0x09, 0x08 }, /* WV 1.2 */
+    { "IDList",                     0x09, 0x09 }, /* WV 1.2 */
+    { "MaxWatcherList",             0x09, 0x0A }, /* WV 1.2 */
+    { "ReactiveAuthState",          0x09, 0x0B }, /* WV 1.2 */
+    { "ReactiveAuthStatus",         0x09, 0x0C }, /* WV 1.2 */
+    { "ReactiveAuthStatusList",     0x09, 0x0D }, /* WV 1.2 */
+    { "Watcher",                    0x09, 0x0E }, /* WV 1.2 */
+    { "WatcherStatus",              0x09, 0x0F }, /* WV 1.2 */
+
+    /* Access ... continued */
+    { "WV-CSP-VersionDiscovery-Request",  0x0A, 0x05 }, /* WV 1.2 */
+    { "WV-CSP-VersionDiscovery-Response", 0x0A, 0x06 }, /* WV 1.2 */
+    { "VersionList",                      0x0A, 0x07 }, /* WV 1.2 */
+
+    { NULL,                         0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_wv_csp_attr_table[] = {
+    { "xmlns",      "http://www.wireless-village.org/CSP",  0x00, 0x05 },
+    { "xmlns",      "http://www.wireless-village.org/PA",   0x00, 0x06 },
+    { "xmlns",      "http://www.wireless-village.org/TRC",  0x00, 0x07 },
+    { "xmlns",      "http://www.openmobilealliance.org/DTD/WV-CSP",     0x00, 0x08 },
+    { "xmlns",      "http://www.openmobilealliance.org/DTD/WV-PA",      0x00, 0x09 },
+    { "xmlns",      "http://www.openmobilealliance.org/DTD/WV-TRC",     0x00, 0x0A },
+    { NULL,         NULL,                                   0x00, 0x00 }
+};
+
+const WBXMLExtValueEntry sv_wv_csp_ext_table[] = {
+    /*
+     * DO NOT CHANGE THIS TABLE ORDER PLEASE ! 
+     * Extension Tokens must be sorted by length !
+     */
+
+    { "application/vnd.wap.mms-message",    0x04 }, /* Common value token */
+    { "www.wireless-village.org",           0x30 }, /* Common value token */
+    { "GROUP_USER_ID_AUTOJOIN",             0x50 }, /* Access value token */ /* WV 1.2 */
+    { "GROUP_USER_ID_JOINED",               0x40 }, /* Access value token */
+    { "GROUP_USER_ID_OWNER",                0x41 }, /* Access value token */
+    { "USER_EMAIL_ADDRESS",                 0x47 }, /* Access value token */
+    { "USER_MOBILE_NUMBER",                 0x4b }, /* Access value token */
+    { "USER_ONLINE_STATUS",                 0x4c }, /* Access value token */
+    { "application/x-sms",                  0x05 }, /* Common value token */
+    { "PrivateMessaging",                   0x1c }, /* Common value token */
+    { "text/x-vCalendar",                   0x29 }, /* Common value token */
+    { "USER_FIRST_NAME",                    0x48 }, /* Access value token */
+    { "MaxActiveUsers",                     0x13 }, /* Common value token */
+    { "PrivilegeLevel",                     0x1d }, /* Common value token */
+    { "USER_LAST_NAME",                     0x4a }, /* Access value token */
+    { "NOT_AVAILABLE",                      0x70 }, /* Presence value token */
+    { "application/",                       0x03 }, /* Common value token */
+    { "text/x-vCard",                       0x2a }, /* Common value token */
+    { "MOBILE_PHONE",                       0x6f }, /* Presence value token */   
+    { "VIDEO_STREAM",                       0x77 }, /* Presence value token */
+    { "ActiveUsers",                        0x01 }, /* Common value token */
+    { "DisplayName",                        0x0a }, /* Common value token */
+    { "GROUP_TOPIC",                        0x3f }, /* Access value token */
+    { "AccessType",                         0x00 }, /* Common value token */
+    { "AutoDelete",                         0x31 }, /* Common value token */ /* WV 1.2 */
+    { "Restricted",                         0x22 }, /* Common value token */
+    { "ScreenName",                         0x23 }, /* Common value token */
+    { "Searchable",                         0x24 }, /* Common value token */
+    { "text/plain",                         0x28 }, /* Common value token */
+    { "GROUP_NAME",                         0x3e }, /* Access value token */
+    { "USER_ALIAS",                         0x46 }, /* Access value token */
+    { "AUDIO_CALL",                         0x5e }, /* Presence value token */
+    { "IM_OFFLINE",                         0x69 }, /* Presence value token */
+    { "INVINCIBLE",                         0x6c }, /* Presence value token */
+    { "VIDEO_CALL",                         0x76 }, /* Presence value token */
+    { "AVAILABLE",                          0x5f }, /* Presence value token */
+    { "IM_ONLINE",                          0x6a }, /* Presence value token */
+    { "https://",                           0x0f }, /* Common value token */
+    { "AutoJoin",                           0x06 }, /* Common value token */
+    { "Response",                           0x21 }, /* Common value token */
+    { "Validity",                           0x33 }, /* Common value token */ /* WV 1.2 */
+    { "GROUP_ID",                           0x3d }, /* Access value token */
+    { "COMPUTER",                           0x63 }, /* Presence value token */
+    { "DISCREET",                           0x64 }, /* Presence value token */
+    { "Default",                            0x09 }, /* Common value token */
+    { "GRANTED",                            0x35 }, /* Common value token */ /* WV 1.2 */
+    { "http://",                            0x0e }, /* Common value token */
+    { "Outband",                            0x19 }, /* Common value token */
+    { "PENDING",                            0x36 }, /* Common value token */ /* WV 1.2 */
+    { "Private",                            0x1b }, /* Common value token */
+    { "Request",                            0x20 }, /* Common value token */
+    { "USER_ID",                            0x49 }, /* Access value token */
+    { "ANXIOUS",                            0x5c }, /* Presence value token */
+    { "ASHAMED",                            0x5d }, /* Presence value token */
+    { "EXCITED",                            0x66 }, /* Presence value token */
+    { "IN_LOVE",                            0x6b }, /* Presence value token */
+    { "JEALOUS",                            0x6d }, /* Presence value token */
+    { "BASE64",                             0x07 }, /* Common value token */
+    { "Closed",                             0x08 }, /* Common value token */
+    { "image/",                             0x10 }, /* Common value token */
+    { "Inband",                             0x11 }, /* Common value token */
+    { "Public",                             0x1e }, /* Common value token */    
+    { "DENIED",                             0x34 }, /* Common value token */ /* WV 1.2 */  
+    { "WAPSMS",                             0x4d }, /* Access value token */
+    { "WAPUDP",                             0x4e }, /* Access value token */  
+    { "SLEEPY",                             0x74 }, /* Presence value token */
+    { "ShowID",                             0x37 }, /* Common value token */ /* WV 1.2 */
+    { "Admin",                              0x02 }, /* Common value token */
+    { "text/",                              0x27 }, /* Common value token */
+    { "Topic",                              0x2b }, /* Common value token */
+    { "ANGRY",                              0x5b }, /* Presence value token */
+    { "BORED",                              0x60 }, /* Presence value token */
+    { "EMAIL",                              0x65 }, /* Presence value token */
+    { "HAPPY",                              0x67 }, /* Presence value token */
+    { "OTHER",                              0x71 }, /* Presence value token */
+    { "Name",                               0x15 }, /* Common value token */
+    { "None",                               0x16 }, /* Common value token */
+    { "Open",                               0x18 }, /* Common value token */
+    { "Type",                               0x2d }, /* Common value token */
+    { "HTTP",                               0x42 }, /* Access value token */
+    { "STCP",                               0x44 }, /* Access value token */
+    { "SUDP",                               0x45 }, /* Access value token */
+    { "CALL",                               0x61 }, /* Presence value token */
+    { "Mod",                                0x14 }, /* Common value token */
+    { "SMS",                                0x43 }, /* Access value token */
+    { "WSP",                                0x4f }, /* Access value token */
+    { "CLI",                                0x62 }, /* Presence value token */
+    { "MMS",                                0x6e }, /* Presence value token */
+    { "PDA",                                0x72 }, /* Presence value token */
+    { "SAD",                                0x73 }, /* Presence value token */
+    { "SMS",                                0x75 }, /* Presence value token */
+    { "GM",                                 0x32 }, /* Common value token */ /* WV 1.2 */
+    { "GR",                                 0x0d }, /* Common value token */
+    { "IM",                                 0x12 }, /* Common value token */    
+    { "PR",                                 0x1a }, /* Common value token */
+    { "SC",                                 0x26 }, /* Common value token */
+    { "US",                                 0x2f }, /* Common value token */
+    { "IM",                                 0x68 }, /* Presence value token */ /* Obsolete in WV 1.2 */
+    { "F",                                  0x0b }, /* Common value token */
+    { "G",                                  0x0c }, /* Common value token */
+    { "N",                                  0x17 }, /* Common value token */
+    { "P",                                  0x1f }, /* Common value token */
+    { "S",                                  0x25 }, /* Common value token */
+    { "T",                                  0x2c }, /* Common value token */
+    { "U",                                  0x2e }, /* Common value token */
+
+    { NULL,                                 0x00 }, /* Presence value token */
+};
+
+#endif /* WBXML_SUPPORT_WV */
+
+
+#if defined( WBXML_SUPPORT_AIRSYNC )
+
+/*************************************************
+ *    Microsoft ActiveSync (aka AirSync)
+ *
+ *    Actually the table represent [MS-ASWBXML] 8.0.
+ *
+ *    The version means the protocol version (e.g. v12.0).
+ *    The revision means the revision of the specification document (e.g. r8.0).
+ * 
+ *    mainly used by Microsoft Exchange and
+ *    modern mobiles from all vendors
+ */
+ 
+const WBXMLTagEntry sv_airsync_tag_table[] = {
+    /* Code Page: "AirSync" (since v2.5 and r1.0) */
+    { "Sync",                   0x00, 0x05 }, /* since r1.0 */
+    { "Responses",              0x00, 0x06 }, /* since r1.0 */
+    { "Add",                    0x00, 0x07 }, /* since r1.0 */
+    { "Change",                 0x00, 0x08 }, /* since r1.0 */
+    { "Delete",                 0x00, 0x09 }, /* since r1.0 */
+    { "Fetch",                  0x00, 0x0a }, /* since r1.0 */
+    { "SyncKey",                0x00, 0x0b }, /* since r1.0 */
+    { "ClientId",               0x00, 0x0c }, /* since r1.0 */
+    { "ServerId",               0x00, 0x0d }, /* since r1.0 */
+    { "Status",                 0x00, 0x0e }, /* since r1.0 */
+    { "Collection",             0x00, 0x0f }, /* since r1.0 */
+    { "Class",                  0x00, 0x10 }, /* since r1.0 */
+    { "Version",                0x00, 0x11 }, /* not defined in r8.0 but in r1.0 */
+    { "CollectionId",           0x00, 0x12 }, /* since r1.0 */
+    { "GetChanges",             0x00, 0x13 }, /* since r1.0 */
+    { "MoreAvailable",          0x00, 0x14 }, /* since r1.0 */
+    { "WindowSize",             0x00, 0x15 }, /* since r1.0 */
+    { "Commands",               0x00, 0x16 }, /* since r1.0 */
+    { "Options",                0x00, 0x17 }, /* since r1.0 */
+    { "FilterType",             0x00, 0x18 }, /* since r1.0 */
+    { "Truncation",             0x00, 0x19 }, /* not defined in r8.0 but in r1.0 */
+    { "RTFTruncation",          0x00, 0x1a }, /* corrected in libwbxml 0.11.0, not defined in r8.0 but in r1.0 */
+    { "Conflict",               0x00, 0x1b }, /* since r1.0 */
+    { "Collections",            0x00, 0x1c }, /* since r1.0 */
+    { "ApplicationData",        0x00, 0x1d }, /* since r1.0 */
+    { "DeletesAsMoves",         0x00, 0x1e }, /* since r1.0 */
+    { "NotifyGUID",             0x00, 0x1f }, /* not defined in r8.0 but in r1.0 */
+    { "Supported",              0x00, 0x20 }, /* since r1.0 */
+    { "SoftDelete",             0x00, 0x21 }, /* since r1.0 */
+    { "MIMESupport",            0x00, 0x22 }, /* since r1.0 */
+    { "MIMETruncation",         0x00, 0x23 }, /* since r1.0 */
+    { "Wait",                   0x00, 0x24 }, /* since r1.0 */
+    { "Limit",                  0x00, 0x25 }, /* since r1.0 */
+    { "Partial",                0x00, 0x26 }, /* since r1.0 */
+    { "ConversationMode",       0x00, 0x27 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "MaxItems",               0x00, 0x28 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "HeartbeatInterval",      0x00, 0x29 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+
+    /* Code Page: Contacts (since v2.5 and r1.0) */
+    { "Anniversary",            0x01, 0x05 }, /* since r1.0 */
+    { "AssistantName",          0x01, 0x06 }, /* since r1.0 */
+    { "AssistantTelephoneNumber", 0x01, 0x07 }, /* corrected in libwbxml 0.11.0 */
+    { "Birthday",               0x01, 0x08 }, /* since r1.0 */
+    { "Body",                   0x01, 0x09 }, /* not defined in r8.0 but in r1.0 */
+    { "BodySize",               0x01, 0x0a }, /* not defined in r8.0 but in r1.0 */
+    { "BodyTruncated",          0x01, 0x0b }, /* not defined in r8.0 but in r1.0 */
+    { "Business2PhoneNumber",   0x01, 0x0c }, /* changed in r8.0, r1.0: Business2TelephoneNumber */
+    { "BusinessCity",           0x01, 0x0d }, /* since r1.0 */
+    { "BusinessCountry",        0x01, 0x0e }, /* since r1.0 */
+    { "BusinessPostalCode",     0x01, 0x0f }, /* since r1.0 */
+    { "BusinessState",          0x01, 0x10 }, /* since r1.0 */
+    { "BusinessStreet",         0x01, 0x11 }, /* since r1.0 */
+    { "BusinessFaxNumber",      0x01, 0x12 }, /* since r1.0 */
+    { "BusinessPhoneNumber",    0x01, 0x13 }, /* changed in r8.0, r1.0: BusinessTelephoneNumber */
+    { "CarPhoneNumber",         0x01, 0x14 }, /* since r1.0 */
+    { "Categories",             0x01, 0x15 }, /* since r1.0 */
+    { "Category",               0x01, 0x16 }, /* since r1.0 */
+    { "Children",               0x01, 0x17 }, /* since r1.0 */
+    { "Child",                  0x01, 0x18 }, /* since r1.0 */
+    { "CompanyName",            0x01, 0x19 }, /* since r1.0 */
+    { "Department",             0x01, 0x1a }, /* since r1.0 */
+    { "Email1Address",          0x01, 0x1b }, /* since r1.0 */
+    { "Email2Address",          0x01, 0x1c }, /* since r1.0 */
+    { "Email3Address",          0x01, 0x1d }, /* since r1.0 */
+    { "FileAs",                 0x01, 0x1e }, /* since r1.0 */
+    { "FirstName",              0x01, 0x1f }, /* since r1.0 */
+    { "Home2PhoneNumber",       0x01, 0x20 }, /* changed in r8.0, r1.0: BusinessTelephoneNumber */
+    { "HomeCity",               0x01, 0x21 }, /* since r1.0 */
+    { "HomeCountry",            0x01, 0x22 }, /* since r1.0 */
+    { "HomePostalCode",         0x01, 0x23 }, /* since r1.0 */
+    { "HomeState",              0x01, 0x24 }, /* since r1.0 */
+    { "HomeStreet",             0x01, 0x25 }, /* since r1.0 */
+    { "HomeFaxNumber",          0x01, 0x26 }, /* since r1.0 */
+    { "HomePhoneNumber",        0x01, 0x27 }, /* changed in r8.0, r1.0: BusinessTelephoneNumber */
+    { "JobTitle",               0x01, 0x28 }, /* since r1.0 */
+    { "LastName",               0x01, 0x29 }, /* since r1.0 */
+    { "MiddleName",             0x01, 0x2a }, /* since r1.0 */
+    { "MobilePhoneNumber",      0x01, 0x2b }, /* changed in r8.0, r1.0: BusinessTelephoneNumber */
+    { "OfficeLocation",         0x01, 0x2c }, /* since r1.0 */
+    { "OtherCity",              0x01, 0x2d }, /* since r1.0 */
+    { "OtherCountry",           0x01, 0x2e }, /* since r1.0 */
+    { "OtherPostalCode",        0x01, 0x2f }, /* since r1.0 */
+    { "OtherState",             0x01, 0x30 }, /* since r1.0 */
+    { "OtherStreet",            0x01, 0x31 }, /* since r1.0 */
+    { "PagerNumber",            0x01, 0x32 }, /* since r1.0 */
+    { "RadioPhoneNumber",       0x01, 0x33 }, /* changed in r8.0, r1.0: BusinessTelephoneNumber */
+    { "Spouse",                 0x01, 0x34 }, /* since r1.0 */
+    { "Suffix",                 0x01, 0x35 }, /* since r1.0 */
+    { "Title",                  0x01, 0x36 }, /* since r1.0 */
+    { "WebPage",                0x01, 0x37 }, /* since r1.0 */
+    { "YomiCompanyName",        0x01, 0x38 }, /* since r1.0 */
+    { "YomiFirstName",          0x01, 0x39 }, /* since r1.0 */
+    { "YomiLastName",           0x01, 0x3a }, /* since r1.0 */
+    { "CompressedRTF",          0x01, 0x3b }, /* corrected in libwbxml 0.11.0, not defined in r8.0 but in r1.0 */
+    { "Picture",                0x01, 0x3c }, /* since r1.0 */
+    { "Alias",                  0x01, 0x3d }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "WeightedRank",           0x01, 0x3e }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+
+    /* Code Page: Email (since v2.5 and r1.0) */
+    { "Attachment",             0x02, 0x05 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Attachments",            0x02, 0x06 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "AttName",                0x02, 0x07 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "AttSize",                0x02, 0x08 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "AttOId",                 0x02, 0x09 }, /* corrected in libwbxml 0.11.0, not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "AttMethod",              0x02, 0x0a }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "AttRemoved",             0x02, 0x0b }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Body",                   0x02, 0x0c }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "BodySize",               0x02, 0x0d }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "BodyTruncated",          0x02, 0x0e }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "DateReceived",           0x02, 0x0f }, /* supported since v2.5 */
+    { "DisplayName",            0x02, 0x10 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "DisplayTo",              0x02, 0x11 }, /* supported since v2.5 */
+    { "Importance",             0x02, 0x12 }, /* supported since v2.5 */
+    { "MessageClass",           0x02, 0x13 }, /* supported since v2.5 */
+    { "Subject",                0x02, 0x14 }, /* supported since v2.5 */
+    { "Read",                   0x02, 0x15 }, /* supported since v2.5 */
+    { "To",                     0x02, 0x16 }, /* supported since v2.5 */
+    { "Cc",                     0x02, 0x17 }, /* supported since v2.5 */
+    { "From",                   0x02, 0x18 }, /* supported since v2.5 */
+    { "Reply-To",               0x02, 0x19 }, /* supported since v2.5 */
+    { "AllDayEvent",            0x02, 0x1a }, /* supported since v2.5 */
+    { "Categories",             0x02, 0x1b }, /* r1.0: supported by v2.5, v12.0 and 12.1; BUT r8.0: not supported by 12.1 */
+    { "Category",               0x02, 0x1c }, /* r1.0: supported by v2.5, v12.0 and 12.1; BUT r8.0: not supported by 12.1 */
+    { "DTStamp",                0x02, 0x1d }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "EndTime",                0x02, 0x1e }, /* supported since v2.5 */
+    { "InstanceType",           0x02, 0x1f }, /* supported since v2.5 */
+    { "BusyStatus",             0x02, 0x20 }, /* supported since v2.5 */
+    { "Location",               0x02, 0x21 }, /* supported since v2.5 */
+    { "MeetingRequest",         0x02, 0x22 }, /* supported since v2.5 */
+    { "Organizer",              0x02, 0x23 }, /* supported since v2.5 */
+    { "RecurrenceId",           0x02, 0x24 }, /* supported since v2.5 */
+    { "Reminder",               0x02, 0x25 }, /* supported since v2.5 */
+    { "ResponseRequested",      0x02, 0x26 }, /* supported since v2.5 */
+    { "Recurrences",            0x02, 0x27 }, /* supported since v2.5 */
+    { "Recurrence",             0x02, 0x28 }, /* supported since v2.5 */
+    { "Recurrence_Type",        0x02, 0x29 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_Until",       0x02, 0x2a }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_Occurrences", 0x02, 0x2b }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_Interval",    0x02, 0x2c }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_DayOfWeek",   0x02, 0x2d }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_DayOfMonth",  0x02, 0x2e }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_WeekOfMonth", 0x02, 0x2f }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_MonthOfYear", 0x02, 0x30 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "StartTime",              0x02, 0x31 }, /* supported since v2.5 */
+    { "Sensitivity",            0x02, 0x32 }, /* supported since v2.5 */
+    { "TimeZone",               0x02, 0x33 }, /* supported since v2.5 */
+    { "GlobalObjId",            0x02, 0x34 }, /* supported since v2.5 */
+    { "ThreadTopic",            0x02, 0x35 }, /* supported since v2.5 */
+    { "MIMEData",               0x02, 0x36 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "MIMETruncated",          0x02, 0x37 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "MIMESize",               0x02, 0x38 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "InternetCPID",           0x02, 0x39 }, /* supported since v2.5 */
+    { "Flag",                   0x02, 0x3a }, /* supported since v12.0 */
+    { "FlagStatus",             0x02, 0x3b }, /* supported since v12.0 */
+    { "ContentClass",           0x02, 0x3c }, /* supported since v12.0 */
+    { "FlagType",               0x02, 0x3d }, /* supported since v12.0 */
+    { "CompleteTime",           0x02, 0x3e }, /* supported since v12.0 */
+    { "DisallowNewTimeProposal",0x02, 0x3f }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+
+    /* Code Page: AirNotify */
+
+    /* There are conflicting version informations.
+     *
+     * r1.0: supported by v2.5, v12.0 and v12.1
+     * r8.0: This code page is no longer in use.
+     * r8.0: Tokens 05 to 17 have been defined.
+     */
+
+    { "Notify",                 0x03, 0x05 }, /* not defined in r8.0 but in r1.0, only supported by v2.0 and v2.5 */
+    { "Notification",           0x03, 0x06 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Version",                0x03, 0x07 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "LifeTime",               0x03, 0x08 }, /* corrected in libwbxml 0.11.0, not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "DeviceInfo",             0x03, 0x09 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Enable",                 0x03, 0x0a }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Folder",                 0x03, 0x0b }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "ServerId",               0x03, 0x0c }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "DeviceAddress",          0x03, 0x0d }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "ValidCarrierProfiles",   0x03, 0x0e }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "CarrierProfile",         0x03, 0x0f }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Status",                 0x03, 0x10 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Responses",              0x03, 0x11 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Devices",                0x03, 0x12 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Device",                 0x03, 0x13 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Id",                     0x03, 0x14 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Expiry",                 0x03, 0x15 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "NotifyGUID",             0x03, 0x16 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "DeviceFriendlyName",     0x03, 0x17 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+
+    /* Code Page: Calendar (since v2.5 and r1.0) */
+    { "TimeZone",               0x04, 0x05 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "AllDayEvent",            0x04, 0x06 }, /* supported since v2.5 */
+    { "Attendees",              0x04, 0x07 }, /* supported since v2.5 */
+    { "Attendee",               0x04, 0x08 }, /* supported since v2.5 */
+    { "Attendee_Email",         0x04, 0x09 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Attendee_Name",          0x04, 0x0a }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Body",                   0x04, 0x0b }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "BodyTruncated",          0x04, 0x0c }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "BusyStatus",             0x04, 0x0d }, /* supported since v2.5 */
+    { "Categories",             0x04, 0x0e }, /* supported since v2.5 */
+    { "Category",               0x04, 0x0f }, /* supported since v2.5 */
+    { "Compressed_RTF",         0x04, 0x10 }, /* corrected in libwbxml 0.11.0, not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "DTStamp",                0x04, 0x11 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "EndTime",                0x04, 0x12 }, /* supported since v2.5 */
+    { "Exception",              0x04, 0x13 }, /* supported since v2.5 */
+    { "Exceptions",             0x04, 0x14 }, /* supported since v2.5 */
+    { "Exception_Deleted",      0x04, 0x15 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: Exception_IsDeleted */
+    { "Exception_StartTime",    0x04, 0x16 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Location",               0x04, 0x17 }, /* supported since v2.5 */
+    { "MeetingStatus",          0x04, 0x18 }, /* supported since v2.5 */
+    { "Organizer_Email",        0x04, 0x19 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Organizer_Name",         0x04, 0x1a }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence",             0x04, 0x1b }, /* supported since v2.5 */
+    { "Recurrence_Type",        0x04, 0x1c }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_Until",       0x04, 0x1d }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_Occurrences", 0x04, 0x1e }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_Interval",    0x04, 0x1f }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_DayOfWeek",   0x04, 0x20 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_DayOfMonth",  0x04, 0x21 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_WeekOfMonth", 0x04, 0x22 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Recurrence_MonthOfYear", 0x04, 0x23 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Reminder",               0x04, 0x24 }, /* supported since v2.5 */
+    { "Sensitivity",            0x04, 0x25 }, /* supported since v2.5 */
+    { "Subject",                0x04, 0x26 }, /* supported since v2.5 */
+    { "StartTime",              0x04, 0x27 }, /* supported since v2.5 */
+    { "UID",                    0x04, 0x28 }, /* supported since v2.5 */
+    { "Attendee_Status",        0x04, 0x29 }, /* corrected in libwbxml 0.11.0, supported since v12.0 */
+    { "Attendee_Type",          0x04, 0x2a }, /* corrected in libwbxml 0.11.0, supported since v12.0 */
+    { "DisallowNewTimeProposal",0x04, 0x33 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "ResponseRequested",      0x04, 0x34 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "AppointmentReplyTime",   0x04, 0x35 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "ResponseType",           0x04, 0x36 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "CalendarType",           0x04, 0x37 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "IsLeapMonth",            0x04, 0x38 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "FirstDayOfWeek",         0x04, 0x39 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "OnlineMeetingConfLink",  0x04, 0x3a }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "OnlineMeetingExternalLink",0x04, 0x3b }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "ClientUid",              0x04, 0x3c }, /* since 16.0 */
+
+    /* Code Page: Move (since v2.5 and r1.0) */
+    { "MoveItems",              0x05, 0x05 }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Move",                   0x05, 0x06 }, /* since r1.0 */
+    { "SrcMsgId",               0x05, 0x07 }, /* since r1.0 */
+    { "SrcFldId",               0x05, 0x08 }, /* since r1.0 */
+    { "DstFldId",               0x05, 0x09 }, /* since r1.0 */
+    { "Response",               0x05, 0x0a }, /* since r1.0 */
+    { "Status",                 0x05, 0x0b }, /* since r1.0 */
+    { "DstMsgId",               0x05, 0x0c }, /* since r1.0 */
+
+    /* Code Page: ItemEstimate (since v2.5 and r1.0) */
+    { "GetItemEstimate",        0x06, 0x05 }, /* since r1.0 */
+    { "Version",                0x06, 0x06 }, /* r8.0: only supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "Collections",            0x06, 0x07 }, /* since r1.0 */
+    { "Collection",             0x06, 0x08 }, /* since r1.0 */
+    { "Class",                  0x06, 0x09 }, /* r8.0: only supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "CollectionId",           0x06, 0x0a }, /* since r1.0 */
+    { "DateTime",               0x06, 0x0b }, /* r8.0: only supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "Estimate",               0x06, 0x0c }, /* since r1.0 */
+    { "Response",               0x06, 0x0d }, /* since r1.0 */
+    { "Status",                 0x06, 0x0e }, /* since r1.0 */
+
+    /* Code Page: FolderHierarchy (since v2.5 and r1.0) */
+    { "Folders",                0x07, 0x05 }, /* not defined in r8.0 but in r1.0 */
+    { "Folder",                 0x07, 0x06 }, /* not defined in r8.0 but in r1.0 */
+    { "DisplayName",            0x07, 0x07 }, /* since r1.0 */
+    { "ServerId",               0x07, 0x08 }, /* since r1.0 */
+    { "ParentId",               0x07, 0x09 }, /* since r1.0 */
+    { "Type",                   0x07, 0x0a }, /* since r1.0 */
+    { "Response",               0x07, 0x0b }, /* not defined in r8.0 but in r1.0 */
+    { "Status",                 0x07, 0x0c }, /* since r1.0 */
+    { "ContentClass",           0x07, 0x0d }, /* not defined in r8.0 but in r1.0 */
+    { "Changes",                0x07, 0x0e }, /* since r1.0 */
+    { "Add",                    0x07, 0x0f }, /* since r1.0 */
+    { "Delete",                 0x07, 0x10 }, /* since r1.0 */
+    { "Update",                 0x07, 0x11 }, /* since r1.0 */
+    { "SyncKey",                0x07, 0x12 }, /* since r1.0 */
+    { "FolderCreate",           0x07, 0x13 }, /* since r1.0 */
+    { "FolderDelete",           0x07, 0x14 }, /* since r1.0 */
+    { "FolderUpdate",           0x07, 0x15 }, /* since r1.0 */
+    { "FolderSync",             0x07, 0x16 }, /* since r1.0 */
+    { "Count",                  0x07, 0x17 }, /* since r1.0 */
+    { "Version",                0x07, 0x18 }, /* not defined in r8.0 but in r1.0 */
+
+    /* Code Page: MeetingResponse (since v2.5 and r1.0) */
+    { "CalendarId",             0x08, 0x05 }, /* changed in r8.0, r1.0: CallID */
+    { "CollectionId",           0x08, 0x06 }, /* since r1.0 */
+    { "MeetingResponse",        0x08, 0x07 }, /* since r1.0 */
+    { "RequestId",              0x08, 0x08 }, /* changed in r8.0, r1.0: ReqId */
+    { "Request",                0x08, 0x09 }, /* since r1.0 */
+    { "Result",                 0x08, 0x0a }, /* since r1.0 */
+    { "Status",                 0x08, 0x0b }, /* since r1.0 */
+    { "UserResponse",           0x08, 0x0c }, /* since r1.0 */
+    { "Version",                0x08, 0x0d }, /* not defined in r8.0 but in r1.0 */
+    { "InstanceId",             0x08, 0x0e }, /* since r8.0? */
+    { "SendResponse",           0x08, 0x12 }, /* since 16.0 */
+
+    /* Code Page: Tasks (since v2.5 and r1.0) */
+    { "Body",                   0x09, 0x05 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "BodySize",               0x09, 0x06 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "BodyTruncated",          0x09, 0x07 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "Categories",             0x09, 0x08 }, /* supported since v2.5 */
+    { "Category",               0x09, 0x09 }, /* supported since v2.5 */
+    { "Complete",               0x09, 0x0a }, /* supported since v2.5 */
+    { "DateCompleted",          0x09, 0x0b }, /* supported since v2.5 */
+    { "DueDate",                0x09, 0x0c }, /* supported since v2.5 */
+    { "UTCDueDate",             0x09, 0x0d }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Importance",             0x09, 0x0e }, /* supported since v2.5 */
+    { "Recurrence",             0x09, 0x0f }, /* supported since v2.5 */
+    { "Recurrence_Type",        0x09, 0x10 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceType */
+    { "Recurrence_Start",       0x09, 0x11 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceStart */
+    { "Recurrence_Until",       0x09, 0x12 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceUntil */
+    { "Recurrence_Occurrences", 0x09, 0x13 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceOccurrences */
+    { "Recurrence_Interval",    0x09, 0x14 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceInterval */
+    { "Recurrence_DayOfMonth",  0x09, 0x15 }, /* supported since v2.5, changed in r8.0, r1.0: RecurrenceDayOfMonth */
+    { "Recurrence_DayOfWeek",   0x09, 0x16 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceDayOfWeek */
+    { "Recurrence_DayOfMonth",  0x09, 0x15 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceDayOfMonth */
+    { "Recurrence_WeekOfMonth", 0x09, 0x17 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceWeekOfMonth */
+    { "Recurrence_MonthOfYear", 0x09, 0x18 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceMonthOfYear */
+    { "Recurrence_Regenerate",  0x09, 0x19 }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceRegenerate */
+    { "Recurrence_DeadOccur",   0x09, 0x1a }, /* corrected in libwbxml 0.11.0, supported since v2.5, changed in r8.0, r1.0: RecurrenceDeadOccour */
+    { "ReminderSet",            0x09, 0x1b }, /* supported since v2.5 */
+    { "ReminderTime",           0x09, 0x1c }, /* supported since v2.5 */
+    { "Sensitivity",            0x09, 0x1d }, /* supported since v2.5 */
+    { "StartDate",              0x09, 0x1e }, /* supported since v2.5 */
+    { "UTCStartDate",           0x09, 0x1f }, /* corrected in libwbxml 0.11.0, supported since v2.5 */
+    { "Subject",                0x09, 0x20 }, /* supported since v2.5 */
+    { "CompressedRTF",          0x09, 0x21 }, /* corrected in libwbxml 0.11.0, not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { "OrdinalDate",            0x09, 0x22 }, /* supported since v12.0 */
+    { "SubOrdinalDate",         0x09, 0x23 }, /* supported since v12.0 */
+    { "CalendarType",           0x09, 0x24 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "IsLeapMonth",            0x09, 0x25 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "FirstDayOfWeek",         0x09, 0x26 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+
+    /* Code Page: ResolveRecipients (since v2.5 and r1.0) */
+    { "ResolveRecipients",      0x0a, 0x05 }, /* since r1.0 */
+    { "Response",               0x0a, 0x06 }, /* since r1.0 */
+    { "Status",                 0x0a, 0x07 }, /* since r1.0 */
+    { "Type",                   0x0a, 0x08 }, /* since r1.0 */
+    { "Recipient",              0x0a, 0x09 }, /* since r1.0 */
+    { "DisplayName",            0x0a, 0x0a }, /* since r1.0 */
+    { "EmailAddress",           0x0a, 0x0b }, /* since r1.0 */
+    { "Certificates",           0x0a, 0x0c }, /* since r1.0 */
+    { "Certificate",            0x0a, 0x0d }, /* since r1.0 */
+    { "MiniCertificate",        0x0a, 0x0e }, /* since r1.0 */
+    { "Options",                0x0a, 0x0f }, /* since r1.0 */
+    { "To",                     0x0a, 0x10 }, /* since r1.0 */
+    { "CertificateRetrieval",   0x0a, 0x11 }, /* since r1.0 */
+    { "RecipientCount",         0x0a, 0x12 }, /* since r1.0 */
+    { "MaxCertificates",        0x0a, 0x13 }, /* since r1.0 */
+    { "MaxAmbiguousRecipients", 0x0a, 0x14 }, /* since r1.0 */
+    { "CertificateCount",       0x0a, 0x15 }, /* since r1.0 */
+    { "Availability",           0x0a, 0x16 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "StartTime",              0x0a, 0x17 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "EndTime",                0x0a, 0x18 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "MergedFreeBusy",         0x0a, 0x19 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "Picture",                0x0a, 0x1a }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "MaxSize",                0x0a, 0x1b }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "Data",                   0x0a, 0x1c, WBXML_TAG_OPTION_BINARY }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "MaxPictures",            0x0a, 0x1d }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+
+    /* Code Page: ValidateCert (since v2.5 and r1.0) */
+    { "ValidateCert",           0x0b, 0x05 }, /* since r1.0 */
+    { "Certificates",           0x0b, 0x06 }, /* since r1.0 */
+    { "Certificate",            0x0b, 0x07 }, /* since r1.0 */
+    { "CertificateChain",       0x0b, 0x08 }, /* since r1.0 */
+    { "CheckCRL",               0x0b, 0x09 }, /* since r1.0 */
+    { "Status",                 0x0b, 0x0a }, /* since r1.0 */
+
+    /* Code Page: Contacts2 (since v2.5 and r1.0) */
+    { "CustomerId",             0x0c, 0x05 }, /* since r1.0 */
+    { "GovernmentId",           0x0c, 0x06 }, /* since r1.0 */
+    { "IMAddress",              0x0c, 0x07 }, /* since r1.0 */
+    { "IMAddress2",             0x0c, 0x08 }, /* since r1.0 */
+    { "IMAddress3",             0x0c, 0x09 }, /* since r1.0 */
+    { "ManagerName",            0x0c, 0x0a }, /* since r1.0 */
+    { "CompanyMainPhone",       0x0c, 0x0b }, /* since r1.0 */
+    { "AccountName",            0x0c, 0x0c }, /* since r1.0 */
+    { "NickName",               0x0c, 0x0d }, /* since r1.0 */
+    { "MMS",                    0x0c, 0x0e }, /* since r1.0 */
+
+    /* Code Page: Ping (since v2.5 and r1.0) */
+    { "Ping",                   0x0d, 0x05 }, /* since r1.0 */
+    { "AutdState",              0x0d, 0x06 }, /* not used by protocol */
+    { "Status",                 0x0d, 0x07 }, /* since r1.0 */
+    { "HeartbeatInterval",      0x0d, 0x08 }, /* since r1.0 */
+    { "Folders",                0x0d, 0x09 }, /* since r1.0 */
+    { "Folder",                 0x0d, 0x0a }, /* since r1.0 */
+    { "Id",                     0x0d, 0x0b }, /* since r1.0 */
+    { "Class",                  0x0d, 0x0c }, /* since r1.0 */
+    { "MaxFolders",             0x0d, 0x0d }, /* since r1.0 */
+
+    /* Code Page: Provision (since v2.5 and r1.0) */
+    { "Provision",                                0x0e, 0x05 }, /* supported since v2.5 */
+    { "Policies",                                 0x0e, 0x06 }, /* supported since v2.5 */
+    { "Policy",                                   0x0e, 0x07 }, /* supported since v2.5 */
+    { "PolicyType",                               0x0e, 0x08 }, /* supported since v2.5 */
+    { "PolicyKey",                                0x0e, 0x09 }, /* supported since v2.5 */
+    { "Data",                                     0x0e, 0x0a }, /* supported since v2.5 */
+    { "Status",                                   0x0e, 0x0b }, /* supported since v2.5 */
+    { "RemoteWipe",                               0x0e, 0x0c }, /* supported since v2.5 */
+    { "EASProvisionDoc",                          0x0e, 0x0d }, /* supported since v12.0 */
+    { "DevicePasswordEnabled",                    0x0e, 0x0e }, /* supported since v12.0 */
+    { "AlphanumericDevicePasswordRequired",       0x0e, 0x0f }, /* supported since v12.0 */
+    { "DeviceEncryptionEnabled",                  0x0e, 0x10 }, /* r1.0: supported since v12.0 */
+    { "RequireStorageCardEncryption",             0x0e, 0x10 }, /* r1.0: supported by v2.0 and v2.5 */
+    { "PasswordRecoveryEnabled",                  0x0e, 0x11 }, /* supported since v12.0 */
+    { "DocumentBrowseEnabled",                    0x0e, 0x12 }, /* supported since v12.0, not defined in r8.0 but in r1.0 */
+    { "AttachmentsEnabled",                       0x0e, 0x13 }, /* supported since v12.0 */
+    { "MinDevicePasswordLength",                  0x0e, 0x14 }, /* supported since v12.0 */
+    { "MaxInactivityTimeDeviceLock",              0x0e, 0x15 }, /* supported since v12.0 */
+    { "MaxDevicePasswordFailedAttempts",          0x0e, 0x16 }, /* supported since v12.0 */
+    { "MaxAttachmentSize",                        0x0e, 0x17 }, /* supported since v12.0 */
+    { "AllowSimpleDevicePassword",                0x0e, 0x18 }, /* supported since v12.0 */
+    { "DevicePasswordExpiration",                 0x0e, 0x19 }, /* supported since v12.0 */
+    { "DevicePasswordHistory",                    0x0e, 0x1a }, /* supported since v12.0 */
+    { "AllowStorageCard",                         0x0e, 0x1b }, /* supported since v12.1 */
+    { "AllowCamera",                              0x0e, 0x1c }, /* supported by v2.0 and v2.5 */
+    { "RequireDeviceEncryption",                  0x0e, 0x1d }, /* supported by v2.0 and v2.5 */
+    { "AllowUnsignedApplications",                0x0e, 0x1e }, /* supported by v2.0 and v2.5 */
+    { "AllowUnsignedInstallationPackages",        0x0e, 0x1f }, /* supported by v2.0 and v2.5 */
+    { "MinDevicePasswordComplexCharacters",       0x0e, 0x20 }, /* supported by v2.0 and v2.5 */
+    { "AllowWiFi",                                0x0e, 0x21 }, /* supported by v2.0 and v2.5 */
+    { "AllowTextMessaging",                       0x0e, 0x22 }, /* supported by v2.0 and v2.5 */
+    { "AllowPOPIMAPEmail",                        0x0e, 0x23 }, /* supported by v2.0 and v2.5 */
+    { "AllowBluetooth",                           0x0e, 0x24 }, /* supported by v2.0 and v2.5 */
+    { "AllowIrDA",                                0x0e, 0x25 }, /* supported by v2.0 and v2.5 */
+    { "RequireManualSyncWhenRoaming",             0x0e, 0x26 }, /* supported by v2.0 and v2.5 */
+    { "AllowDesktopSync",                         0x0e, 0x27 }, /* supported by v2.0 and v2.5 */
+    { "MaxCalendarAgeFilter",                     0x0e, 0x28 }, /* supported by v2.0 and v2.5 */
+    { "AllowHTMLEmail",                           0x0e, 0x29 }, /* supported by v2.0 and v2.5 */
+    { "MaxEmailAgeFilter",                        0x0e, 0x2a }, /* supported by v2.0 and v2.5 */
+    { "MaxEmailBodyTruncationSize",               0x0e, 0x2b }, /* supported by v2.0 and v2.5 */
+    { "MaxEmailHTMLBodyTruncationSize",           0x0e, 0x2c }, /* supported by v2.0 and v2.5 */
+    { "RequireSignedSMIMEMessages",               0x0e, 0x2d }, /* supported by v2.0 and v2.5 */
+    { "RequireEncryptedSMIMEMessages",            0x0e, 0x2e }, /* supported by v2.0 and v2.5 */
+    { "RequireSignedSMIMEAlgorithm",              0x0e, 0x2f }, /* supported by v2.0 and v2.5 */
+    { "RequireEncryptionSMIMEAlgorithm",          0x0e, 0x30 }, /* supported by v2.0 and v2.5 */
+    { "AllowSMIMEEncryptionAlgorithmNegotiation", 0x0e, 0x31 }, /* supported by v2.0 and v2.5 */
+    { "AllowSMIMESoftCerts",                      0x0e, 0x32 }, /* supported by v2.0 and v2.5 */
+    { "AllowBrowser",                             0x0e, 0x33 }, /* supported by v2.0 and v2.5 */
+    { "AllowConsumerEmail",                       0x0e, 0x34 }, /* supported by v2.0 and v2.5 */
+    { "AllowRemoteDesktop",                       0x0e, 0x35 }, /* supported by v2.0 and v2.5 */
+    { "AllowInternetSharing",                     0x0e, 0x36 }, /* supported by v2.0 and v2.5 */
+    { "UnapprovedInROMApplicationList",           0x0e, 0x37 }, /* supported by v2.0 and v2.5 */
+    { "ApplicationName",                          0x0e, 0x38 }, /* supported by v2.0 and v2.5 */
+    { "ApprovedApplicationList",                  0x0e, 0x39 }, /* supported by v2.0 and v2.5 */
+    { "Hash",                                     0x0e, 0x3a }, /* supported by v2.0 and v2.5 */
+
+    /* Code Page: Search (since v2.5 and r1.0) */
+    /* Token 0x06 and 0x16 are not supported. */
+    { "Search",                 0x0f, 0x05 }, /* supported since v2.5 */
+    { "Store",                  0x0f, 0x07 }, /* supported since v2.5 */
+    { "Name",                   0x0f, 0x08 }, /* supported since v2.5 */
+    { "Query",                  0x0f, 0x09 }, /* supported since v2.5 */
+    { "Options",                0x0f, 0x0a }, /* supported since v2.5 */
+    { "Range",                  0x0f, 0x0b }, /* supported since v2.5 */
+    { "Status",                 0x0f, 0x0c }, /* supported since v2.5 */
+    { "Response",               0x0f, 0x0d }, /* supported since v2.5 */
+    { "Result",                 0x0f, 0x0e }, /* supported since v2.5 */
+    { "Properties",             0x0f, 0x0f }, /* supported since v2.5 */
+    { "Total",                  0x0f, 0x10 }, /* supported since v2.5 */
+    { "EqualTo",                0x0f, 0x11 }, /* supported since v12.0 */
+    { "Value",                  0x0f, 0x12 }, /* supported since v12.0 */
+    { "And",                    0x0f, 0x13 }, /* supported since v12.0 */
+    { "Or",                     0x0f, 0x14 }, /* supported since v12.0, r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "FreeText",               0x0f, 0x15 }, /* supported since v12.0 */
+    { "DeepTraversal",          0x0f, 0x17 }, /* supported since v12.0 */
+    { "LongId",                 0x0f, 0x18 }, /* supported since v12.0 */
+    { "RebuildResults",         0x0f, 0x19 }, /* supported since v12.0 */
+    { "LessThan",               0x0f, 0x1a }, /* supported since v12.0 */
+    { "GreaterThan",            0x0f, 0x1b }, /* supported since v12.0 */
+    { "Schema",                 0x0f, 0x1c }, /* supported since v12.0, r8.0: not defined in r8.0 but in r1.0 */
+    { "Supported",              0x0f, 0x1d }, /* supported since v12.0, r8.0: not defined in r8.0 but in r1.0 */
+    { "UserName",               0x0f, 0x1e }, /* since 8.0? */
+    { "Password",               0x0f, 0x1f }, /* since 8.0? */
+    { "ConversationId",         0x0f, 0x20, WBXML_TAG_OPTION_BINARY }, /* since 8.0? */
+    { "Picture",                0x0f, 0x21 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "MaxSize",                0x0f, 0x22 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "MaxPictures",            0x0f, 0x23 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+
+    /* Code Page: GAL (since v2.5 and r1.0) */
+    { "DisplayName",            0x10, 0x05 }, /* since r1.0 */
+    { "Phone",                  0x10, 0x06 }, /* since r1.0 */
+    { "Office",                 0x10, 0x07 }, /* since r1.0 */
+    { "Title",                  0x10, 0x08 }, /* since r1.0 */
+    { "Company",                0x10, 0x09 }, /* since r1.0 */
+    { "Alias",                  0x10, 0x0a }, /* since r1.0 */
+    { "FirstName",              0x10, 0x0b }, /* since r1.0 */
+    { "LastName",               0x10, 0x0c }, /* since r1.0 */
+    { "HomePhone",              0x10, 0x0d }, /* since r1.0 */
+    { "MobilePhone",            0x10, 0x0e }, /* since r1.0 */
+    { "EmailAddress",           0x10, 0x0f }, /* since r1.0 */
+    { "Picture",                0x10, 0x10 }, /* not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "Status",                 0x10, 0x11 }, /* not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "Data",                   0x10, 0x12, WBXML_TAG_OPTION_BINARY }, /* not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+
+    /* Code Page: AirSyncBase (since v12.0 and r1.0) */
+    { "BodyPreference",         0x11, 0x05 }, /* since r1.0 */
+    { "Type",                   0x11, 0x06 }, /* since r1.0 */
+    { "TruncationSize",         0x11, 0x07 }, /* since r1.0 */
+    { "AllOrNone",              0x11, 0x08 }, /* since r1.0 */
+    { "Body",                   0x11, 0x0a }, /* since r1.0 */
+    { "Data",                   0x11, 0x0b }, /* since r1.0 */
+    { "EstimatedDataSize",      0x11, 0x0c }, /* since r1.0 */
+    { "Truncated",              0x11, 0x0d }, /* since r1.0 */
+    { "Attachments",            0x11, 0x0e }, /* since r1.0 */
+    { "Attachment",             0x11, 0x0f }, /* since r1.0 */
+    { "DisplayName",            0x11, 0x10 }, /* since r1.0 */
+    { "FileReference",          0x11, 0x11 }, /* since r1.0 */
+    { "Method",                 0x11, 0x12 }, /* since r1.0 */
+    { "ContentId",              0x11, 0x13 }, /* since r1.0 */
+    { "ContentLocation",        0x11, 0x14 }, /* r8.0: not used */
+    { "IsInline",               0x11, 0x15 }, /* since r1.0 */
+    { "NativeBodyType",         0x11, 0x16 }, /* since r1.0 */
+    { "ContentType",            0x11, 0x17 }, /* since r1.0 */
+    { "Preview",                0x11, 0x18 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "BodyPartPreference",     0x11, 0x19 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 or 14 */
+    { "BodyPart",               0x11, 0x1a }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 or 14 */
+    { "Status",                 0x11, 0x1b }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 or 14 */
+    { "Add",                    0x11, 0x1c }, /* since 16.0 */
+    { "Delete",                 0x11, 0x1d }, /* since 16.0 */
+    { "ClientId",               0x11, 0x1e }, /* since 16.0 */
+    { "Content",                0x11, 0x1f }, /* since 16.0 */
+    { "Location",               0x11, 0x20 }, /* since 16.0 */
+    { "Annotation",             0x11, 0x21 }, /* since 16.0 */
+    { "Street",                 0x11, 0x22 }, /* since 16.0 */
+    { "City",                   0x11, 0x23 }, /* since 16.0 */
+    { "State",                  0x11, 0x24 }, /* since 16.0 */
+    { "Country",                0x11, 0x25 }, /* since 16.0 */
+    { "PostalCode",             0x11, 0x26 }, /* since 16.0 */
+    { "Latitude",               0x11, 0x27 }, /* since 16.0 */
+    { "Longitude",              0x11, 0x28 }, /* since 16.0 */
+    { "Accuracy",               0x11, 0x29 }, /* since 16.0 */
+    { "Altitude",               0x11, 0x2a }, /* since 16.0 */
+    { "AltitudeAccuracy",       0x11, 0x2b }, /* since 16.0 */
+    { "LocationUri",            0x11, 0x2c }, /* since 16.0 */
+    { "InstanceId",             0x11, 0x2d }, /* since 16.0 */
+
+    /* Code Page: Settings (since v12.1 and r1.0) */
+    { "Settings",                   0x12, 0x05 }, /* since r1.0 */
+    { "Status",                     0x12, 0x06 }, /* since r1.0 */
+    { "Get",                        0x12, 0x07 }, /* since r1.0 */
+    { "Set",                        0x12, 0x08 }, /* since r1.0 */
+    { "Oof",                        0x12, 0x09 }, /* since r1.0 */
+    { "OofState",                   0x12, 0x0a }, /* since r1.0 */
+    { "StartTime",                  0x12, 0x0b }, /* since r1.0 */
+    { "EndTime",                    0x12, 0x0c }, /* since r1.0 */
+    { "OofMessage",                 0x12, 0x0d }, /* since r1.0 */
+    { "AppliesToInternal",          0x12, 0x0e }, /* since r1.0 */
+    { "AppliesToExternalKnown",     0x12, 0x0f }, /* since r1.0 */
+    { "AppliesToExternalUnknown",   0x12, 0x10 }, /* since r1.0 */
+    { "Enabled",                    0x12, 0x11 }, /* since r1.0 */
+    { "ReplyMessage",               0x12, 0x12 }, /* since r1.0 */
+    { "BodyType",                   0x12, 0x13 }, /* since r1.0 */
+    { "DevicePassword",             0x12, 0x14 }, /* since r1.0 */
+    { "Password",                   0x12, 0x15 }, /* since r1.0 */
+    { "DeviceInformation",          0x12, 0x16 }, /* since r1.0 */
+    { "Model",                      0x12, 0x17 }, /* since r1.0 */
+    { "IMEI",                       0x12, 0x18 }, /* since r1.0 */
+    { "FriendlyName",               0x12, 0x19 }, /* since r1.0 */
+    { "OS",                         0x12, 0x1a }, /* since r1.0 */
+    { "OSLanguage",                 0x12, 0x1b }, /* since r1.0 */
+    { "PhoneNumber",                0x12, 0x1c }, /* since r1.0 */
+    { "UserInformation",            0x12, 0x1d }, /* since r1.0 */
+    { "EmailAddresses",             0x12, 0x1e }, /* since r1.0 */
+    { "SmtpAddress",                0x12, 0x1f }, /* since r1.0 */
+    { "UserAgent",                  0x12, 0x20 }, /* since r8.0? */
+    { "EnableOutboundSMS",          0x12, 0x21 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "MobileOperator",             0x12, 0x22 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "PrimarySmtpAddress",         0x12, 0x23 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "Accounts",                   0x12, 0x24 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "Account",                    0x12, 0x25 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "AccountId",                  0x12, 0x26 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "AccountName",                0x12, 0x27 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "UserDisplayName",            0x12, 0x28 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "SendDisabled",               0x12, 0x29 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "ihsManagementInformation",   0x12, 0x2b }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+
+    /* Code Page: DocumentLibrary (since v12.1 and r1.0) */
+    { "LinkId",             0x13, 0x05 }, /* since r1.0 */
+    { "DisplayName",        0x13, 0x06 }, /* since r1.0 */
+    { "IsFolder",           0x13, 0x07 }, /* since r1.0 */
+    { "CreationDate",       0x13, 0x08 }, /* since r1.0 */
+    { "LastModifiedDate",   0x13, 0x09 }, /* since r1.0 */
+    { "IsHidden",           0x13, 0x0a }, /* since r1.0 */
+    { "ContentLength",      0x13, 0x0b }, /* since r1.0 */
+    { "ContentType",        0x13, 0x0c }, /* since r1.0 */
+
+    /* Code Page: ItemOperations (since v12.1 and r1.0) */
+    { "ItemOperations",      0x14, 0x05 }, /* since r1.0 */
+    { "Fetch",               0x14, 0x06 }, /* since r1.0 */
+    { "Store",               0x14, 0x07 }, /* since r1.0 */
+    { "Options",             0x14, 0x08 }, /* since r1.0 */
+    { "Range",               0x14, 0x09 }, /* since r1.0 */
+    { "Total",               0x14, 0x0a }, /* since r1.0 */
+    { "Properties",          0x14, 0x0b }, /* since r1.0 */
+    { "Data",                0x14, 0x0c }, /* since r1.0 */
+    { "Status",              0x14, 0x0d }, /* since r1.0 */
+    { "Response",            0x14, 0x0e }, /* since r1.0 */
+    { "Version",             0x14, 0x0f }, /* since r1.0 */
+    { "Schema",              0x14, 0x10 }, /* since r1.0 */
+    { "Part",                0x14, 0x11 }, /* since r1.0 */
+    { "EmptyFolderContents", 0x14, 0x12 }, /* since r1.0 */
+    { "DeleteSubFolders",    0x14, 0x13 }, /* since r1.0 */
+    { "UserName",            0x14, 0x14 }, /* since r8.0? */
+    { "Password",            0x14, 0x15 }, /* since r8.0? */
+    { "Move",                0x14, 0x16 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "DstFldId",            0x14, 0x17 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "ConversationId",      0x14, 0x18, WBXML_TAG_OPTION_BINARY }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "MoveAlways",          0x14, 0x19 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+
+    /* Code Page: ComposeMail (since v14.0 and r8.0?) */
+    /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "SendMail",               0x15, 0x05 }, /* since r8.0? */
+    { "SmartForward",           0x15, 0x06 }, /* since r8.0? */
+    { "SmartReply",             0x15, 0x07 }, /* since r8.0? */
+    { "SaveInSentItems",        0x15, 0x08 }, /* since r8.0? */
+    { "ReplaceMime",            0x15, 0x09 }, /* since r8.0? */
+    { "Source",                 0x15, 0x0b }, /* since r8.0? */
+    { "FolderId",               0x15, 0x0c }, /* since r8.0? */
+    { "ItemId",                 0x15, 0x0d }, /* since r8.0? */
+    { "LongId",                 0x15, 0x0e }, /* since r8.0? */
+    { "InstanceId",             0x15, 0x0f }, /* since r8.0? */
+    { "MIME",                   0x15, 0x10, WBXML_TAG_OPTION_BINARY }, /* since r8.0? */
+    { "ClientId",               0x15, 0x11 }, /* since r8.0? */
+    { "Status",                 0x15, 0x12 }, /* since r8.0? */
+    { "AccountId",              0x15, 0x13 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "Forwardees",             0x15, 0x15 }, /* since 16.0 */
+    { "Forwardee",              0x15, 0x16 }, /* since 16.0 */
+    { "ForwardeeName",          0x15, 0x17 }, /* since 16.0 */
+    { "ForwardeeEmail",         0x15, 0x18 }, /* since 16.0 */
+
+    /* Code Page: Email2 (since v14.0 and r8.0?) */
+    /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "UmCallerID",             0x16, 0x05 }, /* since r8.0? */
+    { "UmUserNotes",            0x16, 0x06 }, /* since r8.0? */
+    { "UmAttDuration",          0x16, 0x07 }, /* since r8.0? */
+    { "UmAttOrder",             0x16, 0x08 }, /* since r8.0? */
+    { "ConversationId",         0x16, 0x09, WBXML_TAG_OPTION_BINARY }, /* since r8.0? */
+    { "ConversationIndex",      0x16, 0x0a, WBXML_TAG_OPTION_BINARY }, /* since r8.0? */
+    { "LastVerbExecuted",       0x16, 0x0b }, /* since r8.0? */
+    { "LastVerbExecutionTime",  0x16, 0x0c }, /* since r8.0? */
+    { "ReceivedAsBcc",          0x16, 0x0d }, /* since r8.0? */
+    { "Sender",                 0x16, 0x0e }, /* since r8.0? */
+    { "CalendarType",           0x16, 0x0f }, /* since r8.0? */
+    { "IsLeapMonth",            0x16, 0x10 }, /* since r8.0? */
+    { "AccountId",              0x16, 0x11 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "FirstDayOfWeek",         0x16, 0x12 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "MeetingMessageType",     0x16, 0x13 }, /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "IsDraft",                0x16, 0x15 }, /* since 16.0 */
+    { "Bcc",                    0x16, 0x16 }, /* since 16.0 */
+    { "Send",                   0x16, 0x17 }, /* since 16.0 */
+
+    /* Code Page: Notes (since v14.0 and r8.0?) */
+    /* r8.0: not supported when the MS-ASProtocolVersion header is set to 12.1 */
+    { "Subject",                0x17, 0x05 }, /* since r8.0? */
+    { "MessageClass",           0x17, 0x06 }, /* since r8.0? */
+    { "LastModifiedDate",       0x17, 0x07 }, /* since r8.0? */
+    { "Categories",             0x17, 0x08 }, /* since r8.0? */
+    { "Category",               0x17, 0x09 }, /* since r8.0? */
+
+    /* Code Page: RightsManagement (since r8.0?) */
+    /* r8.0: not supported when the MS-ASProtocolVersion header is set to 14.0 or 12.1 */
+    { "RightsManagementSupport",0x18, 0x05 }, /* since r8.0? */
+    { "RightsManagementTemplates",0x18, 0x06 }, /* since r8.0? */
+    { "RightsManagementTemplate",0x18, 0x07 }, /* since r8.0? */
+    { "RightsManagementLicense",0x18, 0x08 }, /* since r8.0? */
+    { "EditAllowed",            0x18, 0x09 }, /* since r8.0? */
+    { "ReplyAllowed",           0x18, 0x0a }, /* since r8.0? */
+    { "ReplyAllAllowed",        0x18, 0x0b }, /* since r8.0? */
+    { "ForwardAllowed",         0x18, 0x0c }, /* since r8.0? */
+    { "ModifyRecipientsAllowed",0x18, 0x0d }, /* since r8.0? */
+    { "ExtractAllowed",         0x18, 0x0e }, /* since r8.0? */
+    { "PrintAllowed",           0x18, 0x0f }, /* since r8.0? */
+    { "ExportAllowed",          0x18, 0x10 }, /* since r8.0? */
+    { "ProgrammaticAccessAllowed",0x18, 0x11 }, /* since r8.0? */
+    { "RMOwner",                0x18, 0x12 }, /* since r8.0? */
+    { "ContentExpiryDate",      0x18, 0x13 }, /* since r8.0? */
+    { "TemplateID",             0x18, 0x14 }, /* since r8.0? */
+    { "TemplateName",           0x18, 0x15 }, /* since r8.0? */
+    { "TemplateDescription",    0x18, 0x16 }, /* since r8.0? */
+    { "ContentOwner",           0x18, 0x17 }, /* since r8.0? */
+    { "RemoveRightsManagementDistribution",0x18, 0x18 }, /* since r8.0? */
+
+    { NULL,                  0x00, 0x00 }
+};
+
+const WBXMLAttrEntry sv_airsync_attr_table[] = {
+    { "Version", "1.1", 0x03, 0x05 }, /* not defined in r8.0 but in r1.0, supported by v2.5, v12.0 and v12.1 */
+    { NULL,      NULL,  0x00, 0x00 }
+};
+
+/* NOTE:
+ * These namespace names differ from the Microsoft-assigned namespaces.  The
+ * reason for the difference is that the Microsoft-assigned names are not
+ * valid URI's and hence produce warning messages when processed by some
+ * libraries.  The mapping is as follows:
+ * 
+ *   Microsoft	          Ours
+ *   ---------            ----
+ *   AirSync:             http://synce.org/formats/airsync_wm5/airsync
+ *   Contacts:            http://synce.org/formats/airsync_wm5/contacts
+ *   Email:               http://synce.org/formats/airsync_wm5/email
+ *   AirNotify:           http://synce.org/formats/airsync_wm5/airnotify
+ *   Calendar:            http://synce.org/formats/airsync_wm5/calendar
+ *   Move:                http://synce.org/formats/airsync_wm5/move
+ *   ItemEstimate:        http://synce.org/formats/airsync_wm5/itemestimate
+ *   FolderHierarchy:     http://synce.org/formats/airsync_wm5/folderhierarchy
+ *   MeetingResponse:     http://synce.org/formats/airsync_wm5/meetingresponse
+ *   Tasks:               http://synce.org/formats/airsync_wm5/tasks
+ *   ResolveRecipients:   http://synce.org/formats/airsync_wm5/resolverecipients
+ *   ValidateCert:        http://synce.org/formats/airsync_wm5/validatecert
+ *   Contacts2:           http://synce.org/formats/airsync_wm5/contacts2
+ *   Ping:                http://synce.org/formats/airsync_wm5/ping
+ *   Provision:           http://synce.org/formats/airsync_wm5/provision
+ *   Search:              http://synce.org/formats/airsync_wm5/search
+ *   Gal:                 http://synce.org/formats/airsync_wm5/gal
+ *   AirSyncBase:         http://synce.org/formats/airsync_wm5/airsyncbase
+ *   Settings:            http://synce.org/formats/airsync_wm5/settings
+ *   DocumentLibrary:     http://synce.org/formats/airsync_wm5/documentlibrary
+ *   ItemOperations:      http://synce.org/formats/airsync_wm5/itemoperations
+ *   ComposeMail:         http://synce.org/formats/airsync_wm5/composemail
+ *   Email2:              http://synce.org/formats/airsync_wm5/email2
+ *   Notes:               http://synce.org/formats/airsync_wm5/notes
+ *   RightsManagement:    http://synce.org/formats/airsync_wm5/rightsmanagement
+ *
+ */
+const WBXMLNameSpaceEntry sv_airsync_ns_table[] = {
+    { "http://synce.org/formats/airsync_wm5/airsync",           0x00 },     /**< Code Page 0 */
+    { "http://synce.org/formats/airsync_wm5/contacts",          0x01 },     /**< Code Page 1 */
+    { "http://synce.org/formats/airsync_wm5/email",             0x02 },     /**< Code Page 2 */
+    { "http://synce.org/formats/airsync_wm5/airnotify",         0x03 },     /**< Code Page 3 */
+    { "http://synce.org/formats/airsync_wm5/calendar",          0x04 },     /**< Code Page 4 */
+    { "http://synce.org/formats/airsync_wm5/move",              0x05 },     /**< Code Page 5 */
+    { "http://synce.org/formats/airsync_wm5/itemestimate",      0x06 },     /**< Code Page 6 */
+    { "http://synce.org/formats/airsync_wm5/folderhierarchy",   0x07 },     /**< Code Page 7 */
+    { "http://synce.org/formats/airsync_wm5/meetingresponse",   0x08 },     /**< Code Page 8 */
+    { "http://synce.org/formats/airsync_wm5/tasks",             0x09 },     /**< Code Page 9 */
+    { "http://synce.org/formats/airsync_wm5/resolverecipients", 0x0a },     /**< Code Page 10 */
+    { "http://synce.org/formats/airsync_wm5/validatecert",      0x0b },     /**< Code Page 11 */
+    { "http://synce.org/formats/airsync_wm5/contacts2",         0x0c },     /**< Code Page 12 */
+    { "http://synce.org/formats/airsync_wm5/ping",              0x0d },     /**< Code Page 13 */
+    { "http://synce.org/formats/airsync_wm5/provision",         0x0e },     /**< Code Page 14 */
+    { "http://synce.org/formats/airsync_wm5/search",            0x0f },     /**< Code Page 15 */
+    { "http://synce.org/formats/airsync_wm5/gal",               0x10 },     /**< Code Page 16 */
+    { "http://synce.org/formats/airsync_wm5/airsyncbase",       0x11 },     /**< Code Page 17 */
+    { "http://synce.org/formats/airsync_wm5/settings",          0x12 },     /**< Code Page 18 */
+    { "http://synce.org/formats/airsync_wm5/documentlibrary",   0x13 },     /**< Code Page 19 */
+    { "http://synce.org/formats/airsync_wm5/itemoperations",    0x14 },     /**< Code Page 20 */
+    { "http://synce.org/formats/airsync_wm5/composemail",       0x15 },     /**< Code Page 21 */
+    { "http://synce.org/formats/airsync_wm5/email2",            0x16 },     /**< Code Page 22 */
+    { "http://synce.org/formats/airsync_wm5/notes",             0x17 },     /**< Code Page 23 */
+    { "http://synce.org/formats/airsync_wm5/rightsmanagement",  0x18 },     /**< Code Page 24 */
+    { NULL,                                                     0x00 }
+};
+
+const WBXMLNameSpaceEntry sv_activesync_ns_table[] = {
+    { "AirSync:",           0x00 },     /**< Code Page 0 */
+    { "Contacts:",          0x01 },     /**< Code Page 1 */
+    { "Email:",             0x02 },     /**< Code Page 2 */
+    { "AirNotify:",         0x03 },     /**< Code Page 3 */
+    { "Calendar:",          0x04 },     /**< Code Page 4 */
+    { "Move:",              0x05 },     /**< Code Page 5 */
+    { "GetItemEstimate:",   0x06 },     /**< Code Page 6 */
+    { "FolderHierarchy:",   0x07 },     /**< Code Page 7 */
+    { "MeetingResponse:",   0x08 },     /**< Code Page 8 */
+    { "Tasks:",             0x09 },     /**< Code Page 9 */
+    { "ResolveRecipients:", 0x0a },     /**< Code Page 10 */
+    { "ValidateCert:",      0x0b },     /**< Code Page 11 */
+    { "Contacts2:",         0x0c },     /**< Code Page 12 */
+    { "Ping:",              0x0d },     /**< Code Page 13 */
+    { "Provision:",         0x0e },     /**< Code Page 14 */
+    { "Search:",            0x0f },     /**< Code Page 15 */
+    { "Gal:",               0x10 },     /**< Code Page 16 */
+    { "AirSyncBase:",       0x11 },     /**< Code Page 17 */
+    { "Settings:",          0x12 },     /**< Code Page 18 */
+    { "DocumentLibrary:",   0x13 },     /**< Code Page 19 */
+    { "ItemOperations:",    0x14 },     /**< Code Page 20 */
+    { "ComposeMail:",       0x15 },     /**< Code Page 21 */
+    { "Email2:",            0x16 },     /**< Code Page 22 */
+    { "Notes:",             0x17 },     /**< Code Page 23 */
+    { "RightsManagement:",  0x18 },     /**< Code Page 24 */
+    { NULL,                 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_AIRSYNC */
+
+
+#if defined( WBXML_SUPPORT_CONML )
+
+/*************************************************
+ *    Nokia ConML
+ *
+ *    This is no official markup language from Nokia.
+ *    It is used for example by Nokia PC Suite to install software.
+ */
+ 
+const WBXMLTagEntry sv_conml_tag_table[] = {
+    /* Code Page: "ConML" */
+    { "All",                  0x00, 0x05 },
+    { "Application",          0x00, 0x06 },
+    { "Applications",         0x00, 0x07 },
+    { "Unknown_0x08",         0x00, 0x08 },
+    { "Cancel",               0x00, 0x09 },
+    { "Complete",             0x00, 0x0a },
+    { "ConML",                0x00, 0x0b },
+    { "Data",                 0x00, 0x0c },
+    /* Candidates from SyncML:
+         DataType     *
+         DefaultValue
+         Delete
+         Description  *
+         DevID        *
+     */
+    { "Unknown_0x0d",         0x00, 0x0d },
+    { "Unknown_0x0e",         0x00, 0x0e },
+    { "Unknown_0x0f",         0x00, 0x0f },
+    { "DeviceInfo",           0x00, 0x10 },
+    /* Candidates from SyncML:
+         DevTyp
+     */
+    { "Unknown_0x11",         0x00, 0x11 },
+    { "Drives",               0x00, 0x12 },
+    { "Execute",              0x00, 0x13 },
+    /* Candidates from SyncML:
+         Final
+     */
+    { "Unknown_0x14",         0x00, 0x14 },
+    { "Unknown_0x15",         0x00, 0x15 },
+    { "Unknown_0x16",         0x00, 0x16 },
+    { "GetDataSize",          0x00, 0x17 },
+    { "GetStatus",            0x00, 0x18 },
+    { "HasFiles",             0x00, 0x19 },
+    { "ID",                   0x00, 0x1a },
+    { "IncType",              0x00, 0x1b },
+    { "Install",              0x00, 0x1c },
+    { "InstParams",           0x00, 0x1d },
+    { "ListInstalledApps",    0x00, 0x1f },
+    /* Candidates from SyncML:
+         MaxMsgSize
+     */
+    { "Unknown_0x20",         0x00, 0x20 },
+    { "MaxObjectSize",        0x00, 0x21 },
+    { "Modified",             0x00, 0x22 },
+    { "MoreData",             0x00, 0x23 },
+    /* The content of the element Name is originally encoded as opaque data.
+       The mobiles accepts the element data also as a normal string.
+       Therefore the data will be encoded as a string.
+       If there is a requirement for the original behavior
+       then it is necessary to add some code to wbxml_encoder.c.
+     */
+    { "Name",                 0x00, 0x24 },
+    { "PackageInfo",          0x00, 0x25 },
+    { "Param",                0x00, 0x26 },
+    { "PartialType",          0x00, 0x27 },
+    { "Progress",             0x00, 0x28 },
+    { "Reboot",               0x00, 0x29 },
+    /* Candidates from SyncML:
+         Replace
+         RespURI
+     */
+    { "Unknown_0x2a",         0x00, 0x2a },
+    { "Unknown_0x2b",         0x00, 0x2b },
+    { "Results",              0x00, 0x2c },
+    /* Candidates from SyncML:
+         Search
+         Sequence
+         SessionID
+         SftDel
+         Source
+         SourceRef
+     */
+    { "Unknown_0x2d",         0x00, 0x2d },
+    { "Unknown_0x2e",         0x00, 0x2e },
+    { "Unknown_0x2f",         0x00, 0x2f },
+    { "Unknown_0x30",         0x00, 0x30 },
+    { "Status",               0x00, 0x31 },
+    /* Candidates from SyncML:
+         Target
+         TargetRef
+     */
+    { "Unknown_0x32",         0x00, 0x32 },
+    { "Unknown_0x33",         0x00, 0x33 },
+    { "Unknown_0x34",         0x00, 0x34 },
+    { "Task",                 0x00, 0x35 },
+    /* Candidates from SyncML:
+         Time
+         TStamp
+         Title
+     */
+    { "Unknown_0x36",         0x00, 0x36 },
+    { "Type",                 0x00, 0x37 },
+    { "UID",                  0x00, 0x38 },
+    { "UnInstall",            0x00, 0x39 },
+    /* Candidates from SyncML:
+         ValEnum
+     */
+    { "Unknown_0x3a",         0x00, 0x3a },
+    { "Unknown_0x3b",         0x00, 0x3b },
+    { "Value",                0x00, 0x3c },
+    { "Version",              0x00, 0x3d },
+    { NULL,                   0x00, 0x00 }
+};
+
+#endif /* WBXML_SUPPORT_CONML */
+
+
+/******************************
+ *    Main Table
+ */
+
+const WBXMLLangEntry sv_table_entry[] = {
+#if defined( WBXML_SUPPORT_WML )
+#ifdef WBXML_TABLES_SEPARATE_WML_VERSIONS    
+    { WBXML_LANG_WML10,             &sv_wml10_public_id,            sv_wml10_tag_table,             NULL,                           sv_wml10_attr_table,        sv_wml10_attr_value_table,      NULL },
+    { WBXML_LANG_WML11,             &sv_wml11_public_id,            sv_wml11_tag_table,             NULL,                           sv_wml11_attr_table,        sv_wml11_attr_value_table,      NULL },
+    { WBXML_LANG_WML12,             &sv_wml12_public_id,            sv_wml12_tag_table,             NULL,                           sv_wml12_attr_table,        sv_wml12_attr_value_table,      NULL },
+#else /* WBXML_TABLES_SEPARATE_WML_VERSIONS */
+    { WBXML_LANG_WML10,             &sv_wml10_public_id,            sv_wml13_tag_table,             NULL,                           sv_wml13_attr_table,        sv_wml13_attr_value_table,      NULL },
+    { WBXML_LANG_WML11,             &sv_wml11_public_id,            sv_wml13_tag_table,             NULL,                           sv_wml13_attr_table,        sv_wml13_attr_value_table,      NULL },
+    { WBXML_LANG_WML12,             &sv_wml12_public_id,            sv_wml13_tag_table,             NULL,                           sv_wml13_attr_table,        sv_wml13_attr_value_table,      NULL },
+#endif /* WBXML_TABLES_SEPARATE_WML_VERSIONS */
+    { WBXML_LANG_WML13,             &sv_wml13_public_id,            sv_wml13_tag_table,             NULL,                           sv_wml13_attr_table,        sv_wml13_attr_value_table,      NULL },
+#endif /* WBXML_SUPPORT_WML */
+
+#if defined( WBXML_SUPPORT_WTA )
+    { WBXML_LANG_WTA10,             &sv_wta10_public_id,            sv_wta10_tag_table,             NULL,                           sv_wta10_attr_table,        NULL,                           NULL },
+    { WBXML_LANG_WTAWML12,          &sv_wtawml12_public_id,         sv_wtawml12_tag_table,          NULL,                           sv_wtawml12_attr_table,     sv_wtawml12_attr_value_table,   NULL },
+    { WBXML_LANG_CHANNEL11,         &sv_channel11_public_id,        sv_channel11_tag_table,         NULL,                           sv_channel11_attr_table,    NULL,                           NULL },
+    { WBXML_LANG_CHANNEL12,         &sv_channel12_public_id,        sv_channel12_tag_table,         NULL,                           sv_channel12_attr_table,    NULL,                           NULL },
+#endif /* WBXML_SUPPORT_WTA */
+
+#if defined( WBXML_SUPPORT_SI )
+    { WBXML_LANG_SI10,              &sv_si10_public_id,             sv_si10_tag_table,              NULL,                           sv_si10_attr_table,         sv_si10_attr_value_table,       NULL },
+#endif /* WBXML_SUPPORT_SI */
+
+#if defined( WBXML_SUPPORT_SL )
+    { WBXML_LANG_SL10,              &sv_sl10_public_id,             sv_sl10_tag_table,              NULL,                           sv_sl10_attr_table,         sv_sl10_attr_value_table,       NULL },
+#endif /* WBXML_SUPPORT_SL */
+
+#if defined( WBXML_SUPPORT_CO )
+    { WBXML_LANG_CO10,              &sv_co10_public_id,             sv_co10_tag_table,              NULL,                           sv_co10_attr_table,         sv_co10_attr_value_table,       NULL },
+#endif /* WBXML_SUPPORT_CO */
+
+#if defined( WBXML_SUPPORT_PROV )
+    { WBXML_LANG_PROV10,            &sv_prov10_public_id,           sv_prov10_tag_table,            NULL,                           sv_prov10_attr_table,       sv_prov10_attr_value_table,     NULL }, 
+#endif /* WBXML_SUPPORT_PROV */
+
+#if defined( WBXML_SUPPORT_EMN )
+    { WBXML_LANG_EMN10,             &sv_emn10_public_id,            sv_emn10_tag_table,             NULL,                           sv_emn10_attr_table,        sv_emn10_attr_value_table,      NULL },
+#endif /* WBXML_SUPPORT_EMN */
+
+#if defined( WBXML_SUPPORT_DRMREL )
+    { WBXML_LANG_DRMREL10,          &sv_drmrel10_public_id,         sv_drmrel10_tag_table,          NULL,                           sv_drmrel10_attr_table,     sv_drmrel10_attr_value_table,   NULL },
+#endif /* WBXML_SUPPORT_DRMREL */
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+    { WBXML_LANG_OTA_SETTINGS,      &sv_ota_settings_public_id,     sv_ota_settings_tag_table,      NULL,                           sv_ota_settings_attr_table, NULL,                           NULL },
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+#if defined( WBXML_SUPPORT_SYNCML )
+    /* SyncML 1.2 */
+    { WBXML_LANG_SYNCML_SYNCML12,   &sv_syncml_syncml12_public_id,  sv_syncml_syncml12_tag_table,   sv_syncml_syncml12_ns_table,    NULL,                       NULL,                           NULL },
+    { WBXML_LANG_SYNCML_DEVINF12,   &sv_syncml_devinf12_public_id,  sv_syncml_devinf12_tag_table,   sv_syncml_devinf12_ns_table,    NULL,                       NULL,                           NULL },
+    { WBXML_LANG_SYNCML_METINF12,   &sv_syncml_metinf12_public_id,  sv_syncml_metinf12_tag_table,   NULL,                           NULL,                       NULL,                           NULL },
+    { WBXML_LANG_SYNCML_DMDDF12,    &sv_syncml_dmddf12_public_id,   sv_syncml_dmddf12_tag_table,    sv_syncml_dmddf12_ns_table,     NULL,                       NULL,                           NULL },
+
+    /* SyncML 1.1 */
+    { WBXML_LANG_SYNCML_SYNCML11,   &sv_syncml_syncml11_public_id,  sv_syncml_syncml11_tag_table,   sv_syncml_syncml11_ns_table,    NULL,                       NULL,                           NULL },
+    { WBXML_LANG_SYNCML_DEVINF11,   &sv_syncml_devinf11_public_id,  sv_syncml_devinf11_tag_table,   sv_syncml_devinf11_ns_table,    NULL,                       NULL,                           NULL },
+    { WBXML_LANG_SYNCML_METINF11,   &sv_syncml_metinf11_public_id,  sv_syncml_metinf11_tag_table,   NULL,                           NULL,                       NULL,                           NULL },
+    
+    /** @todo Check if Tag Tables are exactly with SyncML 1.0 */
+    { WBXML_LANG_SYNCML_SYNCML10,   &sv_syncml_syncml10_public_id,  sv_syncml_syncml11_tag_table,   sv_syncml_syncml10_ns_table,    NULL,                       NULL,                           NULL },
+    { WBXML_LANG_SYNCML_DEVINF10,   &sv_syncml_devinf10_public_id,  sv_syncml_devinf11_tag_table,   sv_syncml_devinf11_ns_table,    NULL,                       NULL,                           NULL },   
+#endif /* WBXML_SUPPORT_SYNCML */
+
+#if defined( WBXML_SUPPORT_WV )
+    { WBXML_LANG_WV_CSP11,          &sv_wv_csp11_public_id,         sv_wv_csp_tag_table,            NULL,                           sv_wv_csp_attr_table,       NULL,                           sv_wv_csp_ext_table },
+    { WBXML_LANG_WV_CSP12,          &sv_wv_csp12_public_id,         sv_wv_csp_tag_table,            NULL,                           sv_wv_csp_attr_table,       NULL,                           sv_wv_csp_ext_table },
+#endif /* WBXML_SUPPORT_WV */
+
+#if defined( WBXML_SUPPORT_AIRSYNC )
+    { WBXML_LANG_AIRSYNC,           &sv_airsync_public_id,          sv_airsync_tag_table,           sv_airsync_ns_table,            sv_airsync_attr_table,                       NULL,                           NULL },
+    { WBXML_LANG_ACTIVESYNC,        &sv_activesync_public_id,       sv_airsync_tag_table,           sv_activesync_ns_table,         sv_airsync_attr_table,                       NULL,                           NULL },
+#endif /* WBXML_SUPPORT_AIRSYNC */
+
+#if defined( WBXML_SUPPORT_CONML )
+    { WBXML_LANG_CONML,             &sv_conml_public_id,            sv_conml_tag_table,             NULL,                           NULL,                       NULL,                           NULL },
+#endif /* WBXML_SUPPORT_CONML */
+
+    { WBXML_LANG_UNKNOWN,           NULL,                           NULL,                           NULL,                           NULL,                       NULL,                           NULL }
+};
+
+
+/******************************
+ * Public Functions
+ */
+
+/* Exported function to return pointer to WBXML Languages Main Table */
+WBXML_DECLARE(const WBXMLLangEntry *) wbxml_tables_get_main(void)
+{
+    return sv_table_entry;
+}
+
+
+WBXML_DECLARE(const WBXMLLangEntry *) wbxml_tables_get_table(WBXMLLanguage lang)
+{
+    const WBXMLLangEntry *main_table = NULL;
+    WB_ULONG index = 0;
+    
+    /* Get main tables array*/
+    if ((lang == WBXML_LANG_UNKNOWN) || ((main_table = wbxml_tables_get_main()) == NULL))
+        return NULL;
+    
+    /* Search language table */
+    while (main_table[index].langID != WBXML_LANG_UNKNOWN) {
+        if (main_table[index].langID == lang)
+            return &main_table[index];
+        index++;
+    }
+
+    return NULL;
+}
+
+
+WBXML_DECLARE(const WBXMLLangEntry *) wbxml_tables_search_table(const WBXMLLangEntry *main_table,
+                                                                const WB_UTINY *public_id, 
+                                                                const WB_UTINY *system_id,
+                                                                const WB_UTINY *root)
+{
+    WB_ULONG index;
+    const WB_UTINY *sep = NULL;
+
+    if (main_table == NULL)
+        return NULL;
+
+    /* Search by XML Public ID  */
+    if (public_id != NULL) {
+        index = 0;
+
+        while (main_table[index].publicID != NULL) {
+            if (main_table[index].publicID->xmlPublicID && WBXML_STRCASECMP(main_table[index].publicID->xmlPublicID, public_id) == 0)
+                return &main_table[index];
+            index++;
+        }
+    }
+
+    /* Search by XML System ID  */
+    if (system_id != NULL) {
+        index = 0;
+
+        while (main_table[index].publicID != NULL) {
+            if (main_table[index].publicID->xmlDTD && WBXML_STRCMP(main_table[index].publicID->xmlDTD, system_id) == 0) 
+                return &main_table[index];
+            index++;
+        }
+    }
+
+    /* Search by XML Root Element  */
+    if (root != NULL) {
+        index = 0;
+
+        /* table scan for matching namespace element */
+        sep = (WB_UTINY *)strrchr((const WB_TINY *) root, WBXML_NAMESPACE_SEPARATOR);
+        if (sep != NULL) {
+            /* There is a namespace (from root to sep). */
+            while (main_table[index].publicID != NULL) {
+                /* It is only possible to evaluate the first entry in the table
+                 * because the second code page has often no unique name space name.
+                 * Example: SyncML Meta Information => syncml:metinf
+                 */
+                if (main_table[index].nsTable != NULL &&
+                    main_table[index].nsTable[0].xmlNameSpace && 
+                    WBXML_STRNCASECMP(main_table[index].nsTable[0].xmlNameSpace, root, WBXML_STRLEN(main_table[index].nsTable[0].xmlNameSpace)) == 0) 
+                    return &main_table[index];
+                index++;
+            }
+        }
+
+        /* table scan for matching root element */
+        while (main_table[index].publicID != NULL) {
+            if (main_table[index].publicID->xmlRootElt && WBXML_STRCMP(main_table[index].publicID->xmlRootElt, root) == 0) 
+                return &main_table[index];
+            index++;
+        }
+    }
+
+    return NULL;
+}
+
+
+WBXML_DECLARE(WB_ULONG) wbxml_tables_get_wbxml_publicid(const WBXMLLangEntry *main_table, WBXMLLanguage lang_id)
+{
+    WB_ULONG i = 0;
+
+    if (main_table == NULL)
+        return WBXML_PUBLIC_ID_UNKNOWN;
+
+    while (main_table[i].langID != WBXML_LANG_UNKNOWN) {
+        if (main_table[i].langID == lang_id) {
+            if (main_table[i].publicID != NULL)
+                return main_table[i].publicID->wbxmlPublicID;
+            else
+                return WBXML_PUBLIC_ID_UNKNOWN;
+        }
+        i++;
+    }
+
+    return WBXML_PUBLIC_ID_UNKNOWN;
+}
+
+
+WBXML_DECLARE(const WBXMLTagEntry *) wbxml_tables_get_tag_from_xml(const WBXMLLangEntry *lang_table,
+                                                                   const int cur_code_page,
+                                                                   const WB_UTINY *xml_name)
+{
+    WB_ULONG i;
+    WB_BOOL found_current = FALSE;
+
+    if ((lang_table == NULL) || (lang_table->tagTable == NULL) || (xml_name == NULL))
+        return NULL;
+
+    /* First off, try to find it in the current code page, if provided */
+    for (i = 0; cur_code_page >= 0 && lang_table->tagTable[i].xmlName != NULL; i++) {
+        const WBXMLTagEntry *entry = &lang_table->tagTable[i];
+
+        if (entry->wbxmlCodePage == cur_code_page) {
+            found_current = TRUE;
+
+            if (WBXML_STRCMP(entry->xmlName, xml_name) == 0)
+                return entry;
+        } else {
+            if (found_current)
+              break;
+        }
+    }
+
+    /* Then try all others */
+    for (i = 0; lang_table->tagTable[i].xmlName != NULL; i++) {
+        const WBXMLTagEntry *entry = &lang_table->tagTable[i];
+
+        /* We've already searched the current code page */
+        if (cur_code_page >= 0 && entry->wbxmlCodePage == cur_code_page)
+          continue;
+
+        if (WBXML_STRCMP(entry->xmlName, xml_name) == 0)
+            return entry;
+    }
+
+    return NULL;
+}
+
+
+WBXML_DECLARE(const WBXMLAttrEntry *) wbxml_tables_get_attr_from_xml(const WBXMLLangEntry *lang_table,
+                                                                     WB_UTINY *xml_name,
+                                                                     WB_UTINY *xml_value,
+                                                                     WB_UTINY **value_left)
+{
+    WB_ULONG i = 0;
+    WB_ULONG found_index = 0, found_comp = 0;
+    WB_BOOL found = FALSE;
+
+    if ((lang_table == NULL) || (lang_table->attrTable == NULL) || (xml_name == NULL))
+        return NULL;
+
+    if (value_left != NULL)
+        *value_left = xml_value;
+
+    /* Iterate in Attribute Table */
+    while (lang_table->attrTable[i].xmlName != NULL) {
+        /* Search for Attribute Name */
+        if (WBXML_STRCMP(lang_table->attrTable[i].xmlName, xml_name) == 0) 
+        {
+            if (lang_table->attrTable[i].xmlValue == NULL) {
+                /* This is the token with a NULL Attribute Value */
+                if (xml_value == NULL) {
+                    /* Well, we got it */
+                    return &(lang_table->attrTable[i]);
+                }
+                else {
+                    if (!found) {
+                        /* We haven't found yet a better Attribute Token */
+                        found = TRUE;
+                        found_index = i;
+                    }
+
+                    /* Else: We already have found a better Attribute Token, so let's forget this one */
+                }
+            }
+            else {
+                /* Check the Attribute Value */
+                if (xml_value != NULL)
+                {
+                    if (WBXML_STRCMP(lang_table->attrTable[i].xmlValue, xml_value) == 0) 
+                    {
+                        /* We have found the EXACT Attribute Name / Value pair we are searching, well done boy */
+                        if (value_left != NULL)
+                            *value_left = NULL;
+
+                        return &(lang_table->attrTable[i]);
+                    }
+                    else {
+                        if ((WBXML_STRLEN(lang_table->attrTable[i].xmlValue) < WBXML_STRLEN(xml_value)) &&
+                            (found_comp < WBXML_STRLEN(lang_table->attrTable[i].xmlValue)) &&
+                            (WBXML_STRNCMP(lang_table->attrTable[i].xmlValue, xml_value, WBXML_STRLEN(lang_table->attrTable[i].xmlValue)) == 0))
+                        {
+                            /* We have found a better Attribute Value */
+                            found = TRUE;
+                            found_index = i;
+                            found_comp = WBXML_STRLEN(lang_table->attrTable[i].xmlValue);
+                        }
+                    }
+                }
+
+                /* Else: We are searching for the Attribute Token with a NULL Attribute Value associated, so forget this one  */
+            }
+        }
+        i++;
+    }
+
+    /* Attribute Name / Value pair not found, but an entry with this Attribute Name, 
+     * and (maybe) start of this Attribute Value was found */
+    if (found) {
+        if (value_left != NULL)
+            *value_left = xml_value + found_comp;
+
+        return &(lang_table->attrTable[found_index]);
+    }
+
+    /* Attribute Name NOT found */
+    return NULL;
+}
+
+
+WBXML_DECLARE(const WBXMLExtValueEntry *) wbxml_tables_get_ext_from_xml(const WBXMLLangEntry *lang_table,
+                                                                        WB_UTINY *xml_value)
+{
+    WB_ULONG i = 0;
+
+    if ((lang_table == NULL) || (lang_table->extValueTable == NULL) || (xml_value == NULL))
+        return NULL;
+
+    while (lang_table->extValueTable[i].xmlName != NULL) {
+        if (WBXML_STRCMP(lang_table->extValueTable[i].xmlName, xml_value) == 0)
+            return &(lang_table->extValueTable[i]);
+        i++;
+    }
+
+    return NULL;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_tables_contains_attr_value_from_xml(const WBXMLLangEntry *lang_table,
+                                                                 WB_UTINY *xml_value)
+{
+    WB_ULONG i = 0;
+
+    if ((lang_table == NULL) || (lang_table->attrValueTable == NULL) || (xml_value == NULL))
+        return FALSE;
+
+    while (lang_table->attrValueTable[i].xmlName != NULL)
+    {
+        /* Is this Attribute Value contained in this XML Buffer ? */
+        if (WBXML_STRSTR(xml_value, lang_table->attrValueTable[i].xmlName) != NULL)
+            return TRUE;
+
+        i++;
+    }
+
+    return FALSE;
+}
+
+
+WBXML_DECLARE(const WB_TINY *) wbxml_tables_get_xmlns(const WBXMLNameSpaceEntry *ns_table, WB_UTINY code_page)
+{
+    WB_ULONG i = 0;
+
+    if (ns_table == NULL)
+        return NULL;
+
+    while (ns_table[i].xmlNameSpace != NULL)
+    {
+        if (ns_table[i].wbxmlCodePage == code_page)
+            return ns_table[i].xmlNameSpace;
+
+        i++;
+    }
+
+    return NULL;
+}
+
+WBXML_DECLARE(WB_UTINY) wbxml_tables_get_code_page(const WBXMLNameSpaceEntry *ns_table, const WB_TINY* xmlns)
+{
+    WB_ULONG i = 0;
+
+    if (ns_table == NULL)
+        return 0;
+
+    while (ns_table[i].xmlNameSpace != NULL)
+    {
+        if (strcmp(ns_table[i].xmlNameSpace, xmlns) == 0)
+            return ns_table[i].wbxmlCodePage;
+
+        i++;
+    }
+
+    return 0;
+}
+

--- a/src/libwbxml/wbxml_tables.h
+++ b/src/libwbxml/wbxml_tables.h
@@ -1,0 +1,346 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2009-2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tables.h
+ * @ingroup wbxml_tables
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 02/03/17
+ *
+ * @brief WBXML Tables
+ */
+
+#ifndef WBXML_TABLES_H
+#define WBXML_TABLES_H
+
+#include "wbxml.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_tables 
+ *  @{ 
+ */
+
+/****************************************************
+ *    WBXML Public IDs (http://www.wapforum.org/wina)
+ */
+
+#define WBXML_PUBLIC_ID_UNKNOWN   0x01
+
+/* WAP */
+#define WBXML_PUBLIC_ID_WML10     0x02
+#define WBXML_PUBLIC_ID_WTA10     0x03
+#define WBXML_PUBLIC_ID_WML11     0x04
+#define WBXML_PUBLIC_ID_SI10      0x05
+#define WBXML_PUBLIC_ID_SL10      0x06
+#define WBXML_PUBLIC_ID_CO10      0x07
+#define WBXML_PUBLIC_ID_CHANNEL11 0x08
+#define WBXML_PUBLIC_ID_WML12     0x09
+#define WBXML_PUBLIC_ID_WML13     0x0A
+#define WBXML_PUBLIC_ID_PROV10    0x0B
+#define WBXML_PUBLIC_ID_WTAWML12  0x0C
+#define WBXML_PUBLIC_ID_CHANNEL12 WBXML_PUBLIC_ID_UNKNOWN /**< I don't understand what is the Channel1.2 WBXML Public ID */
+#define WBXML_PUBLIC_ID_EMN10     0x0D
+#define WBXML_PUBLIC_ID_DRMREL10  0x0E
+
+#define XML_PUBLIC_ID_WML10     "-//WAPFORUM//DTD WML 1.0//EN"
+#define XML_PUBLIC_ID_WTA10     "-//WAPFORUM//DTD WTA 1.0//EN"
+#define XML_PUBLIC_ID_WML11     "-//WAPFORUM//DTD WML 1.1//EN"
+#define XML_PUBLIC_ID_SI10      "-//WAPFORUM//DTD SI 1.0//EN"
+#define XML_PUBLIC_ID_SL10      "-//WAPFORUM//DTD SL 1.0//EN"
+#define XML_PUBLIC_ID_CO10      "-//WAPFORUM//DTD CO 1.0//EN"
+#define XML_PUBLIC_ID_CHANNEL11 "-//WAPFORUM//DTD CHANNEL 1.1//EN"
+#define XML_PUBLIC_ID_WML12     "-//WAPFORUM//DTD WML 1.2//EN"
+#define XML_PUBLIC_ID_WML13     "-//WAPFORUM//DTD WML 1.3//EN"
+#define XML_PUBLIC_ID_PROV10    "-//WAPFORUM//DTD PROV 1.0//EN"
+#define XML_PUBLIC_ID_WTAWML12  "-//WAPFORUM//DTD WTA-WML 1.2//EN"
+#define XML_PUBLIC_ID_CHANNEL12 "-//WAPFORUM//DTD CHANNEL 1.2//EN"
+#define XML_PUBLIC_ID_EMN10     "-//WAPFORUM//DTD EMN 1.0//EN"
+#define XML_PUBLIC_ID_DRMREL10  "-//OMA//DTD DRMREL 1.0//EN"
+
+/* Ericsson/Nokia OTA Settings v7.0 */
+#define WBXML_PUBLIC_ID_OTA_SETTINGS WBXML_PUBLIC_ID_UNKNOWN
+#define XML_PUBLIC_ID_OTA_SETTINGS   NULL                    /* No XML Public ID defined */
+
+/* SyncML 1.0 */
+#define WBXML_PUBLIC_ID_SYNCML_SYNCML10 0x0FD1
+#define WBXML_PUBLIC_ID_SYNCML_DEVINF10 0x0FD2
+#define WBXML_PUBLIC_ID_SYNCML_METINF10 WBXML_PUBLIC_ID_UNKNOWN /* No WBXML PublicID defined for SyncML Meta Info */
+
+#define XML_PUBLIC_ID_SYNCML_SYNCML10 "-//SYNCML//DTD SyncML 1.0//EN"
+#define XML_PUBLIC_ID_SYNCML_DEVINF10 "-//SYNCML//DTD DevInf 1.0//EN"
+#define XML_PUBLIC_ID_SYNCML_METINF10 "-//SYNCML//DTD MetInf 1.0//EN"
+
+/* SyncML 1.1 */
+#define WBXML_PUBLIC_ID_SYNCML_SYNCML11 0x0FD3
+#define WBXML_PUBLIC_ID_SYNCML_DEVINF11 0x0FD4
+#define WBXML_PUBLIC_ID_SYNCML_METINF11 WBXML_PUBLIC_ID_UNKNOWN /* No WBXML PublicID defined for SyncML Meta Info */
+
+#define XML_PUBLIC_ID_SYNCML_SYNCML11 "-//SYNCML//DTD SyncML 1.1//EN"
+#define XML_PUBLIC_ID_SYNCML_DEVINF11 "-//SYNCML//DTD DevInf 1.1//EN"
+#define XML_PUBLIC_ID_SYNCML_METINF11 "-//SYNCML//DTD MetInf 1.1//EN"
+
+/* SyncML 1.2 */
+#define WBXML_PUBLIC_ID_SYNCML_SYNCML12 0x1201
+#define WBXML_PUBLIC_ID_SYNCML_METINF12 0x1202
+#define WBXML_PUBLIC_ID_SYNCML_DEVINF12 0x1203
+#define WBXML_PUBLIC_ID_SYNCML_DMDDF12 WBXML_PUBLIC_ID_UNKNOWN /* No WBXML PublicID defined for OMA DM DDF */
+
+#define XML_PUBLIC_ID_SYNCML_SYNCML12 "-//SYNCML//DTD SyncML 1.2//EN"
+#define XML_PUBLIC_ID_SYNCML_DEVINF12 "-//SYNCML//DTD DevInf 1.2//EN"
+#define XML_PUBLIC_ID_SYNCML_METINF12 "-//SYNCML//DTD MetInf 1.2//EN"
+#define XML_PUBLIC_ID_SYNCML_DMDDF12  "-//OMA//DTD-DM-DDF 1.2//EN"
+
+/* OMA Wireless Village CSP 1.1 / 1.2 - @todo Check for CSP 1.0 */
+#define WBXML_PUBLIC_ID_WV_CSP11 0x10
+#define WBXML_PUBLIC_ID_WV_CSP12 WBXML_PUBLIC_ID_UNKNOWN
+    
+#define XML_PUBLIC_ID_WV_CSP11 "-//OMA//DTD WV-CSP 1.1//EN" /**< @todo Also defined as "-//WIRELESSVILLAGE//DTD CSP 1.1//EN" (so choose one) */
+#define XML_PUBLIC_ID_WV_CSP12 "-//OMA//DTD WV-CSP 1.2//EN"
+
+/* Microsoft AirSync */
+#define WBXML_PUBLIC_ID_AIRSYNC WBXML_PUBLIC_ID_UNKNOWN
+#define XML_PUBLIC_ID_AIRSYNC "-//AIRSYNC//DTD AirSync//EN"
+
+#define WBXML_PUBLIC_ID_ACTIVESYNC WBXML_PUBLIC_ID_UNKNOWN
+#define XML_PUBLIC_ID_ACTIVESYNC "-//MICROSOFT//DTD ActiveSync//EN"
+
+/* Nokia ConML */
+#define WBXML_PUBLIC_ID_CONML 0x8F
+#define XML_PUBLIC_ID_CONML "-//CONML//DTD ConML//EN"
+
+/****************************************************
+ *    WBXML Encoding options
+ */
+
+#define WBXML_TAG_OPTION_UNKNOWN 0x0
+#define WBXML_TAG_OPTION_BINARY  0x1
+#define WBXML_TAG_OPTION_OPAQUE  0x2
+#define WBXML_TAG_OPTION_CDATA   0x4
+
+/* Example: CDATA|OPAQUE
+ *   => XML:   <![CDATA ... ]]>
+ *   => WBXML: create opaque encoding
+ */
+
+/****************************************************
+ *    WBXML Tables Structures
+ */
+
+/**
+ * @brief WBXML Public ID structure
+ */
+typedef struct WBXMLPublicIDEntry_s
+{
+    WB_ULONG       wbxmlPublicID; /**< WBXML Public ID */
+    const WB_TINY *xmlPublicID;   /**< XML Public ID */
+    const WB_TINY *xmlRootElt;    /**< XML Root Element */
+    const WB_TINY *xmlDTD;        /**< XML DTD */
+
+} WBXMLPublicIDEntry;
+
+
+/**
+ * @brief WBXML Application Token structure: Tag token
+ *        The options are used to optionally define the
+ *        handling of content.
+ */
+typedef struct WBXMLTagEntry_s
+{    
+    const WB_TINY *xmlName;       /**< XML Tag Name */    
+    WB_UTINY       wbxmlCodePage; /**< WBXML Code Page */
+    WB_UTINY       wbxmlToken;    /**< WBXML Tag Token */
+    WB_ULONG       options;       /**< (WB)XML (Encoding) Options (optional bit mask)*/
+} WBXMLTagEntry;
+
+
+/**
+ * @brief Name Space
+ * @note For SyncML, where a WBXML Code Page is associated to an XML Name Space
+ */
+typedef struct WBXMLNameSpaceEntry_s
+{    
+    const WB_TINY *xmlNameSpace;  /**< XML Name Space */   
+    WB_UTINY       wbxmlCodePage; /**< WBXML Code Page */
+} WBXMLNameSpaceEntry;
+
+
+/**
+ * @brief WBXML Application Token structure: Attribute token
+ */
+typedef struct WBXMLAttrEntry_s
+{
+    const WB_TINY *xmlName;       /**< XML Attribute Name */
+    const WB_TINY *xmlValue;      /**< XML Attribute Value (may be NULL) */
+    WB_UTINY       wbxmlCodePage; /**< WBXML Code Page */
+    WB_UTINY       wbxmlToken;    /**< WBXML Attribute Token */
+} WBXMLAttrEntry;
+
+
+/**
+ * @brief WBXML Application Token structure: Attribute Value token
+ */
+typedef struct WBXMLAttrValueEntry_s
+{
+    const WB_TINY *xmlName;       /**< XML Attribute Value */
+    WB_UTINY       wbxmlCodePage; /**< WBXML Code Page */
+    WB_UTINY       wbxmlToken;    /**< WBXML Attribute Value Token */
+} WBXMLAttrValueEntry;
+
+
+/**
+ * @brief WBXML Application Token structure: Extension Value token
+ * @note For Wireless-Village, the content can be tokenized with Extension Tokens
+ */
+typedef struct WBXMLExtValueEntry_s
+{
+    const WB_TINY *xmlName;    /**< XML Extension Value */
+    WB_UTINY       wbxmlToken; /**< WBXML Extension Value Token */
+} WBXMLExtValueEntry;
+
+
+/**
+ * @brief Language structure
+ */
+typedef struct WBXMLLangEntry_s
+{
+    WBXMLLanguage              langID;         /**< Language ID */
+    const WBXMLPublicIDEntry  *publicID;       /**< Public ID */
+    const WBXMLTagEntry       *tagTable;       /**< Tags Table */
+    const WBXMLNameSpaceEntry *nsTable;        /**< NameSpaces Table */
+    const WBXMLAttrEntry      *attrTable;      /**< Attributes Table*/
+    const WBXMLAttrValueEntry *attrValueTable; /**< Attributes Values Table */
+    const WBXMLExtValueEntry  *extValueTable;  /**< Extensions Values Table */
+} WBXMLLangEntry;
+
+
+/**
+ * @brief Get Main Table
+ * @return The main array of WBXML Language Tables
+ */
+WBXML_DECLARE(const WBXMLLangEntry *) wbxml_tables_get_main(void);
+
+/**
+ * @brief Get a Language Table
+ * @param lang Language to get
+ * @return The Language Table, or NULL if unknown Language
+ */
+WBXML_DECLARE(const WBXMLLangEntry *) wbxml_tables_get_table(WBXMLLanguage lang);
+
+/**
+ * @brief Search for a Language Table
+ * @param main_table Main Table Array to search in
+ * @param public_id The Public ID to search [can be NULL]
+ * @param system_id The System ID to search [can be NULL]
+ * @param root The Root Element to search [can be NULL]
+ * @return The Language Table found, or NULL if none found
+ * @note This function try to find the correct Language Table thanks to the XML Public ID, then (if not found) by
+ *       the XML System ID, and finally (if not found) by the Root XML Element
+ */
+WBXML_DECLARE(const WBXMLLangEntry *) wbxml_tables_search_table(const WBXMLLangEntry *main_table,
+                                                                const WB_UTINY *public_id, 
+                                                                const WB_UTINY *system_id,
+                                                                const WB_UTINY *root);
+
+/**
+ * @brief Get the WBXML Public ID corresponding to given WBXML Language
+ * @param main_table The Main Languages Table to search in
+ * @param lang_id The Language ID
+ * @return The WBXML Public ID (can be WBXML_PUBLIC_ID_UNKNOWN if Language doesn't have one, or if Language not found)
+*/
+WBXML_DECLARE(WB_ULONG) wbxml_tables_get_wbxml_publicid(const WBXMLLangEntry *main_table,
+                                                        WBXMLLanguage lang_id);
+
+/**
+ * @brief Search for a Tag Entry in Language Table, given the XML Name of the Tag
+ * @param lang_table The Language Table to search in
+ * @param cur_code_page The current code page so that it can be searched first, or -1 to start from the first one.
+ * @param xml_name The XML Name of the Tag to search
+ * @return The Tag Entry of this XML Name in Language Table, or NULL if not found
+ */
+WBXML_DECLARE(const WBXMLTagEntry *) wbxml_tables_get_tag_from_xml(const WBXMLLangEntry *lang_table,
+                                                                   const int cur_code_page,
+                                                                   const WB_UTINY *xml_name);
+
+/**
+ * @brief Search for an Attribute Entry in Language Table, given the XML Name and Value of the Attribute
+ * @param lang_table The Language Table to search in
+ * @param xml_name The XML Name of the Attribute to search
+ * @param xml_value The XML Value of the Attribute to search
+ * @param value_left Is the WBXMLAttrEntry returned EXACTLY the Attribute we are searching ? (ie: is the Attribute Value
+ *                   found matching the one we were looking for ?). If Yes, then this is NULL. If not, then this is the
+ *                   attribute value part that we still have to encode.
+ * @return The Attribute Entry of this XML Attribute Name in Language Table, or NULL if not found
+ * @note Has the Attribut Value can be expressed in many ways in WBXML, this function is focused on
+ *       searching for the ATTRIBUTE NAME !
+ *       Thus, when Attribute Name is found in Table, we search for an Entry with the same Attribute Name / Attribute Value
+ *       pair. If found the 'value_left' parameter is set to NULL. If not, we still return an Entry matching the Attribute Name,
+ *       but the 'value_left' parameter is the Attribute Value part that is not included in the Attrbute Token.
+ */
+WBXML_DECLARE(const WBXMLAttrEntry *) wbxml_tables_get_attr_from_xml(const WBXMLLangEntry *lang_table,
+                                                                     WB_UTINY *xml_name,
+                                                                     WB_UTINY *xml_value,
+                                                                     WB_UTINY **value_left);
+
+/**
+ * @brief Search for an Extension Token Entry in Language Table, given the XML Value of the Extension
+ * @param lang_table The Language Table to search in
+ * @param xml_value The XML Value of the Extension to search
+ * @return The Extension Token Entry of this XML Value in Language Table, or NULL if not found
+ */
+WBXML_DECLARE(const WBXMLExtValueEntry *) wbxml_tables_get_ext_from_xml(const WBXMLLangEntry *lang_table,
+                                                                        WB_UTINY *xml_value);
+
+/**
+ * @brief Check if an XML Attribute Value contains at least one Attribute Value defined in Language Attribute Values Table
+ * @param lang_table The Language Table to search in
+ * @param xml_value The XML Attribute Value to check
+ * @return TRUE if this value contains an Attribute Value, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_tables_contains_attr_value_from_xml(const WBXMLLangEntry *lang_table,
+                                                                 WB_UTINY *xml_value);
+
+/**
+ * @brief Get an XML NameSpace, given a WBXML Code Page
+ * @param ns_table  The NameSpace Table
+ * @param code_page The WBXML Code Page
+ * @return The XML NameSpace, or NULL if not found
+ */
+WBXML_DECLARE(const WB_TINY *) wbxml_tables_get_xmlns(const WBXMLNameSpaceEntry *ns_table,
+                                                      WB_UTINY code_page);
+
+WBXML_DECLARE(WB_UTINY) wbxml_tables_get_code_page(const WBXMLNameSpaceEntry *ns_table,
+                                                   const WB_TINY* xmlns);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_TABLES_H */

--- a/src/libwbxml/wbxml_tree.c
+++ b/src/libwbxml/wbxml_tree.c
@@ -1,0 +1,1365 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2008-2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tree.c
+ * @ingroup wbxml_tree
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/18
+ *
+ * @brief WBXML Tree
+ */
+
+#include "wbxml_config_internals.h"
+#include "wbxml_tree.h"
+#include "wbxml_log.h"
+#include "wbxml_parser.h"
+#include "wbxml_encoder.h"
+#include "wbxml_tree_clb_xml.h"
+#include "wbxml_tree_clb_wbxml.h"
+#include "wbxml_internals.h"
+
+/***************************************************
+ *    Public Functions
+ */
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_from_wbxml(WB_UTINY *wbxml,
+                                                WB_ULONG wbxml_len,
+                                                WBXMLLanguage lang,
+                                                WBXMLCharsetMIBEnum charset,
+                                                WBXMLTree **tree)
+{
+    WBXMLParser *wbxml_parser = NULL;
+    WB_LONG error_index = 0;
+    WBXMLTreeClbCtx wbxml_tree_clb_ctx;
+    WBXMLError ret = WBXML_OK;
+    WBXMLContentHandler wbxml_tree_content_handler = 
+        {
+            wbxml_tree_clb_wbxml_start_document,
+            wbxml_tree_clb_wbxml_end_document,
+            wbxml_tree_clb_wbxml_start_element,
+            wbxml_tree_clb_wbxml_end_element,
+            wbxml_tree_clb_wbxml_characters,
+            wbxml_tree_clb_wbxml_pi
+        };
+
+    if (tree != NULL)
+        *tree = NULL;
+
+    /* Create WBXML Parser */
+    if((wbxml_parser = wbxml_parser_create()) == NULL) {
+        WBXML_ERROR((WBXML_PARSER, "Can't create WBXML Parser"));
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Init context */
+    wbxml_tree_clb_ctx.error = WBXML_OK;
+    wbxml_tree_clb_ctx.current = NULL;
+    if ((wbxml_tree_clb_ctx.tree = wbxml_tree_create(WBXML_LANG_UNKNOWN, WBXML_CHARSET_UNKNOWN)) == NULL) {
+        wbxml_parser_destroy(wbxml_parser);
+        WBXML_ERROR((WBXML_PARSER, "Can't create WBXML Tree"));
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+    
+    /* Set Handlers Callbacks */
+    wbxml_parser_set_user_data(wbxml_parser, &wbxml_tree_clb_ctx);
+    wbxml_parser_set_content_handler(wbxml_parser, &wbxml_tree_content_handler);
+
+    /* Give the user the possibility to force Document Language */
+    if (lang != WBXML_LANG_UNKNOWN)
+        wbxml_parser_set_language(wbxml_parser, lang);
+
+    /* Give the user the possibility to force the document character set */
+    if (charset != WBXML_CHARSET_UNKNOWN)
+        wbxml_parser_set_meta_charset(wbxml_parser, charset);
+
+    /* Parse the WBXML document to WBXML Tree */
+    ret = wbxml_parser_parse(wbxml_parser, wbxml, wbxml_len);
+    if ((ret != WBXML_OK) || (wbxml_tree_clb_ctx.error != WBXML_OK)) 
+    {
+        error_index = wbxml_parser_get_current_byte_index(wbxml_parser);
+        WBXML_ERROR((WBXML_PARSER, "WBXML Parser failed at %ld - token: %x (%s)", 
+                                   error_index,
+                                   wbxml[error_index],
+                                   ret != WBXML_OK ? wbxml_errors_string(ret) : wbxml_errors_string(wbxml_tree_clb_ctx.error)));
+        
+        wbxml_tree_destroy(wbxml_tree_clb_ctx.tree);
+    }
+    else {
+        *tree = wbxml_tree_clb_ctx.tree;
+    }
+
+    /* Clean-up */
+    wbxml_parser_destroy(wbxml_parser);
+
+    if (ret != WBXML_OK)
+        return ret;
+    else
+        return wbxml_tree_clb_ctx.error;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_to_wbxml(WBXMLTree *tree,
+                                              WB_UTINY **wbxml,
+                                              WB_ULONG  *wbxml_len,
+                                              WBXMLGenWBXMLParams *params)
+{
+    WBXMLEncoder *wbxml_encoder = NULL;
+    WBXMLError ret = WBXML_OK;
+
+    /* Encode WBXML Tree to WBXML Document */
+    if ((wbxml_encoder = wbxml_encoder_create()) == NULL) {
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Set the WBXML Tree to encode */
+    wbxml_encoder_set_tree(wbxml_encoder, tree);
+
+    /* Set encoder parameters */
+    if (params == NULL) {
+        /* Default Parameters */
+
+        /* Ignores "Empty Text" Nodes */
+        wbxml_encoder_set_ignore_empty_text(wbxml_encoder, TRUE);
+
+        /* Remove leading and trailing whitespaces in "Text Nodes" */
+        wbxml_encoder_set_remove_text_blanks(wbxml_encoder, TRUE);
+
+        /* Use String Table */
+        wbxml_encoder_set_use_strtbl(wbxml_encoder, TRUE);
+
+        /* Don't produce an anonymous document by default */
+        wbxml_encoder_set_produce_anonymous(wbxml_encoder, FALSE);
+    }
+    else {
+        /* WBXML Version */
+        wbxml_encoder_set_wbxml_version(wbxml_encoder, params->wbxml_version);
+
+        /* Keep Ignorable Whitespaces ? */
+        if (!params->keep_ignorable_ws) {
+            /* Ignores "Empty Text" Nodes */
+            wbxml_encoder_set_ignore_empty_text(wbxml_encoder, TRUE);
+
+            /* Remove leading and trailing whitespaces in "Text Nodes" */
+            wbxml_encoder_set_remove_text_blanks(wbxml_encoder, TRUE);
+        }
+
+        /* String Table */
+        wbxml_encoder_set_use_strtbl(wbxml_encoder, params->use_strtbl);
+
+        /* Produce an anonymous document? */
+        wbxml_encoder_set_produce_anonymous(wbxml_encoder,
+            params->produce_anonymous);
+
+        /** @todo Add parameter to call : wbxml_encoder_set_output_charset() */
+    }
+
+    /* Encode WBXML */
+    ret = wbxml_encoder_encode_to_wbxml(wbxml_encoder, wbxml, wbxml_len);
+
+    /* Clean-up */
+    wbxml_encoder_destroy(wbxml_encoder);
+
+    return ret;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_from_xml(WB_UTINY *xml, WB_ULONG xml_len, WBXMLTree **tree)
+{
+#if defined( HAVE_EXPAT )
+
+    const XML_Feature *feature_list = NULL;
+    XML_Parser         xml_parser   = NULL;
+    WBXMLError         ret          = WBXML_OK;
+    WB_BOOL            expat_utf16  = FALSE;
+    WBXMLTreeClbCtx    wbxml_tree_clb_ctx;
+
+    if ((xml == NULL) || (xml_len == 0) || (tree == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    /* Clean up pointer */
+    *tree = NULL;
+    
+    /* First Check if Expat is outputing UTF-16 strings */
+    feature_list = (const XML_Feature *)XML_GetFeatureList();
+
+    if ((feature_list != NULL) && (feature_list[0].value != sizeof(WB_TINY))) {
+#if !defined( HAVE_ICONV )
+        /* Ouch, can't convert from UTF-16 to UTF-8 */
+        return WBXML_ERROR_XMLPARSER_OUTPUT_UTF16;
+#else
+        /* Expat returns UTF-16 encoded strings in its callbacks */
+        expat_utf16 = TRUE;
+#endif /* !HAVE_ICONV */
+    }
+
+    /* Create Expat XML Parser */
+    if ((xml_parser = XML_ParserCreateNS(NULL, WBXML_NAMESPACE_SEPARATOR)) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Init context */
+    wbxml_tree_clb_ctx.current = NULL;
+    wbxml_tree_clb_ctx.error = WBXML_OK;
+    wbxml_tree_clb_ctx.skip_lvl = 0;
+    wbxml_tree_clb_ctx.skip_start = 0;
+    wbxml_tree_clb_ctx.xml_parser = xml_parser;
+    wbxml_tree_clb_ctx.input_buff = xml;
+    wbxml_tree_clb_ctx.expat_utf16 = expat_utf16;
+
+    /* Create WBXML Tree */
+    if ((wbxml_tree_clb_ctx.tree = wbxml_tree_create(WBXML_LANG_UNKNOWN, WBXML_CHARSET_UNKNOWN)) == NULL) {
+        XML_ParserFree(xml_parser);
+        WBXML_ERROR((WBXML_PARSER, "Can't create WBXML Tree"));
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+    
+    /* Set Handlers Callbacks */
+    XML_SetXmlDeclHandler(xml_parser, wbxml_tree_clb_xml_decl);
+    XML_SetStartDoctypeDeclHandler(xml_parser, wbxml_tree_clb_xml_doctype_decl);
+    XML_SetElementHandler(xml_parser, wbxml_tree_clb_xml_start_element, wbxml_tree_clb_xml_end_element);
+    XML_SetCdataSectionHandler(xml_parser, wbxml_tree_clb_xml_start_cdata, wbxml_tree_clb_xml_end_cdata);
+    XML_SetProcessingInstructionHandler(xml_parser , wbxml_tree_clb_xml_pi);
+    XML_SetCharacterDataHandler(xml_parser, wbxml_tree_clb_xml_characters);
+    XML_SetUserData(xml_parser, (void*)&wbxml_tree_clb_ctx);
+
+    /* Parse the XML Document to WBXML Tree */
+    if (XML_Parse(xml_parser, (WB_TINY*) xml, xml_len, TRUE) == 0)
+    {
+        WBXML_ERROR((WBXML_CONV, "xml2wbxml conversion failed - expat error %i\n"
+            "\tdescription: %s\n"
+            "\tline: %i\n"
+            "\tcolumn: %i\n"
+            "\tbyte index: %i\n"
+            "\ttotal bytes: %i\n%s",
+            XML_GetErrorCode(xml_parser), 
+            XML_ErrorString(XML_GetErrorCode(xml_parser)), 
+            XML_GetCurrentLineNumber(xml_parser), 
+            XML_GetCurrentColumnNumber(xml_parser), 
+            XML_GetCurrentByteIndex(xml_parser), 
+            XML_GetCurrentByteCount(xml_parser), xml));
+
+        wbxml_tree_destroy(wbxml_tree_clb_ctx.tree);
+
+        ret = WBXML_ERROR_XML_PARSING_FAILED;
+    }
+    else {
+        if ((ret = wbxml_tree_clb_ctx.error) != WBXML_OK)
+        {
+            WBXML_ERROR((WBXML_CONV, "xml2wbxml conversion failed - context error %i", ret));
+            wbxml_tree_destroy(wbxml_tree_clb_ctx.tree);
+        }
+        else
+            *tree = wbxml_tree_clb_ctx.tree;
+    }
+
+    /* Clean-up */
+    XML_ParserFree(xml_parser);
+
+    return ret;
+
+#else /* HAVE_EXPAT */
+
+#if defined( HAVE_LIBXML )
+
+    /** @todo Use LibXML2 SAX interface ! */
+    return WBXML_ERROR_NO_XMLPARSER;
+
+#else /* HAVE_LIBXML */
+    
+    /** @note You can add here another XML Parser support */
+    return WBXML_ERROR_NO_XMLPARSER;
+
+#endif /* HAVE_LIBXML */
+
+#endif /* HAVE_EXPAT */
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_to_xml(WBXMLTree *tree,
+                                            WB_UTINY **xml,
+                                            WB_ULONG  *xml_len,
+                                            WBXMLGenXMLParams *params)
+{
+    WBXMLEncoder *wbxml_encoder = NULL;
+    WBXMLError ret = WBXML_OK;
+
+    /* Create WBXML Encoder */
+    if ((wbxml_encoder = wbxml_encoder_create()) == NULL) {
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Set the WBXML Tree to encode */
+    wbxml_encoder_set_tree(wbxml_encoder, tree);
+
+    /* Set encoder parameters */
+    if (params == NULL) {
+        /* Default Values */
+
+        /* Set XML Generation Type */
+        wbxml_encoder_set_xml_gen_type(wbxml_encoder, WBXML_GEN_XML_INDENT);
+
+        /* Set Indent */
+        wbxml_encoder_set_indent(wbxml_encoder, 0);
+
+        /* Skip Ignorable Whitespaces */
+        wbxml_encoder_set_ignore_empty_text(wbxml_encoder, TRUE);
+        wbxml_encoder_set_remove_text_blanks(wbxml_encoder, TRUE);
+    }
+    else {
+        /* Set XML Generation Type */
+        wbxml_encoder_set_xml_gen_type(wbxml_encoder, params->gen_type);
+
+        /* Set Indent */
+        if (params->gen_type == WBXML_GEN_XML_INDENT)
+            wbxml_encoder_set_indent(wbxml_encoder, params->indent);
+
+        /* Ignorable Whitespaces */
+        if (params->keep_ignorable_ws) {
+            wbxml_encoder_set_ignore_empty_text(wbxml_encoder, FALSE);
+            wbxml_encoder_set_remove_text_blanks(wbxml_encoder, FALSE);
+        }
+        else {
+            wbxml_encoder_set_ignore_empty_text(wbxml_encoder, TRUE);
+            wbxml_encoder_set_remove_text_blanks(wbxml_encoder, TRUE);
+        }
+
+        /** @todo Add parameter to call : wbxml_encoder_set_output_charset() */
+    }
+
+    /* Encode WBXML Tree to XML */
+    ret = wbxml_encoder_encode_tree_to_xml(wbxml_encoder, xml, xml_len);
+
+    /* Clean-up */
+    wbxml_encoder_destroy(wbxml_encoder);
+
+    return ret;
+}
+
+
+#if defined( HAVE_LIBXML )
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_from_libxml_doc(xmlDocPtr libxml_doc,
+                                                     WBXMLTree **tree)
+{
+    /** @todo wbxml_tree_from_libxml_doc() */
+    return WBXML_ERROR_NOT_IMPLEMENTED;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_to_libxml_doc(WBXMLTree *tree,
+                                                   xmlDocPtr *libxml_doc)
+{
+    /** @todo wbxml_tree_to_libxml_doc() */
+    return WBXML_ERROR_NOT_IMPLEMENTED;
+}
+
+#endif /* HAVE_LIBXML */
+
+
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create(WBXMLTreeNodeType type)
+{
+    WBXMLTreeNode *result = NULL;
+    
+    if ((result = wbxml_malloc(sizeof(WBXMLTreeNode))) == NULL)
+        return NULL;
+
+    result->type = type;
+    result->name = NULL;
+    result->attrs = NULL;
+    result->content = NULL;
+    result->tree = NULL;
+
+    result->parent = NULL;
+    result->children = NULL;
+    result->next = NULL;
+    result->prev = NULL;
+
+    return result;
+}
+
+
+WBXML_DECLARE(void) wbxml_tree_node_destroy(WBXMLTreeNode *node)
+{
+    if (node == NULL)
+        return;
+
+    wbxml_tag_destroy(node->name);
+    wbxml_list_destroy(node->attrs, wbxml_attribute_destroy_item);
+    wbxml_buffer_destroy(node->content);
+    wbxml_tree_destroy(node->tree);
+
+    wbxml_free(node);
+}
+
+
+WBXML_DECLARE(void) wbxml_tree_node_destroy_item(void *node)
+{
+    wbxml_tree_node_destroy((WBXMLTreeNode *)node);
+}
+
+
+WBXML_DECLARE(void) wbxml_tree_node_destroy_all(WBXMLTreeNode *node)
+{
+    WBXMLTreeNode *parent_node   = NULL;
+    WBXMLTreeNode *current_node  = NULL;
+    WBXMLTreeNode *previous_node = NULL;
+    WBXMLTreeNode *tmp_node      = NULL;
+    WB_BOOL        end_of_walk   = FALSE;
+
+    if (node == NULL)
+        return;
+
+    /* Let's go through the sub-tree (iteratively) to free all the nodes */
+    current_node = node;
+    parent_node  = node->parent;
+
+    while (!end_of_walk)
+    {
+        if (current_node == NULL) {
+            /* Leaf reached */
+            if (previous_node == NULL) {
+                end_of_walk = TRUE;
+                break;
+            }
+            else {
+                if (previous_node->parent == parent_node) {
+                    /* End of parsing, we have parsed the last child of node */
+                    end_of_walk = TRUE;
+                    break;
+                }
+                else {
+                    /* Let's parse next child of parent node */                    
+                    current_node = previous_node->next;
+                    tmp_node = previous_node->parent;
+
+                    /* Destroy this node (leaf) */
+                    wbxml_tree_node_destroy(previous_node);
+
+                    previous_node = tmp_node;
+                }
+            }
+        }
+        else {
+            /* Go deeper in sub-tree */
+            previous_node = current_node;
+            current_node = current_node->children;        
+        }
+    }
+
+    wbxml_tree_node_destroy(node);
+}
+
+
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_xml_elt(const WBXMLLangEntry *lang_table,
+                                                              const WB_UTINY *name)
+{
+    const WBXMLTagEntry *tag_entry = NULL;
+    WBXMLTreeNode *node = NULL;
+    WBXMLTag *tag = NULL;
+    
+    /* Search for XML Tag Name in Table */
+    if ((tag_entry = wbxml_tables_get_tag_from_xml(lang_table, -1, name)) != NULL) {
+        /* Found : token tag */
+        tag = wbxml_tag_create_token(tag_entry);
+    }
+    else {
+        /* Not found : literal tag */
+        tag = wbxml_tag_create_literal((WB_UTINY *)name);
+    }
+
+    if (tag == NULL)
+        return NULL;
+
+    /* Create a new Node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_ELEMENT_NODE)) == NULL) {
+        wbxml_tag_destroy(tag);
+        return NULL;
+    }
+    
+    /* Set Node Tag */
+    node->name = tag;
+    
+    return node;
+}
+
+
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_xml_elt_with_text(const WBXMLLangEntry *lang_table,
+                                                                        const WB_UTINY *name,
+                                                                        const WB_UTINY *text,
+                                                                        WB_ULONG len)
+{
+    WBXMLTreeNode *node = NULL;
+    WBXMLTreeNode *text_node = NULL;
+    
+    /* Create element node */
+    if ((node = wbxml_tree_node_create_xml_elt(lang_table, name)) == NULL)
+        return NULL;
+    
+    /* Create text node */
+    if ((text_node = wbxml_tree_node_create_text(text, len)) == NULL) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+    
+    /* Add text node to element node */
+    if (!wbxml_tree_node_add_child(node, text_node)) {
+        wbxml_tree_node_destroy(node);
+        wbxml_tree_node_destroy(text_node);
+        return NULL;
+    }
+    
+    return node;
+}
+
+
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_text(const WB_UTINY *text,
+                                                           WB_ULONG len)
+{
+    WBXMLTreeNode *node = NULL;
+
+    /* Create a new Node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_TEXT_NODE)) == NULL) {
+        return NULL;
+    }
+
+    /* Set Content */
+    if ((node->content = wbxml_buffer_create(text, len, len)) == NULL) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+
+    return node;
+}
+
+
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_cdata(const WB_UTINY *text,
+                                                            WB_ULONG len)
+{
+    WBXMLTreeNode *node = NULL;
+    WBXMLTreeNode *text_node = NULL;
+
+    /* Create a new node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_CDATA_NODE)) == NULL) {
+        return NULL;
+    }
+
+    /* Create a text node */
+    if ((text_node = wbxml_tree_node_create_text(text, len)) == NULL) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+    
+    /* Add text node to cdata */
+    if (!wbxml_tree_node_add_child(node, text_node)) {
+        wbxml_tree_node_destroy_all(node);
+        node = NULL;
+    }
+
+    return node;
+}
+
+
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_tree(WBXMLTreeNode *root,
+                                                           WBXMLLanguage lang,
+                                                           WBXMLCharsetMIBEnum orig_charset)
+{
+    WBXMLTreeNode* result = NULL;
+    WBXMLTree*     tree   = NULL;
+    
+    if ((root == NULL) || (lang == WBXML_LANG_UNKNOWN))
+        return NULL;
+    
+    /* Create Tree */
+    if ((tree = wbxml_tree_create(lang, orig_charset)) == NULL)
+        return NULL;
+    
+    /* Fill Tree */
+    tree->root = root;
+    
+    /* Create Tree Node */
+    if ((result = wbxml_tree_node_create(WBXML_TREE_TREE_NODE)) == NULL) {
+        wbxml_tree_destroy(tree);
+        return NULL;
+    }
+    
+    /* Fill Tree Node */
+    result->tree = tree;
+    
+    return result;
+}
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_tree_node_add_child(WBXMLTreeNode *parent,
+                                                 WBXMLTreeNode *node)
+{
+    WBXMLTreeNode *tmp = NULL;
+
+    if ((parent == NULL) || (node == NULL))
+        return FALSE;
+
+    /* Set parent to new node */
+    node->parent = parent;    
+
+    /* Search for previous sibbling element */
+    if (parent->children != NULL) {
+        /* Add this Node to end of Sibbling Node list of Parent */
+        tmp = parent->children;
+
+        while (tmp->next != NULL)
+            tmp = tmp->next;
+        
+        node->prev = tmp;
+        tmp->next = node;
+    }
+    else {
+        /* No previous sibbling element */
+        parent->children = node;
+    }
+
+    return TRUE;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_attr(WBXMLTreeNode *node,
+                                                   WBXMLAttribute *attr)
+{
+    WBXMLAttribute *new_attr = NULL;
+
+    if ((node == NULL) || (attr == NULL)) {
+        return WBXML_ERROR_BAD_PARAMETER;
+    }
+
+    /* Create list if needed */
+    if (node->attrs == NULL) {
+        if ((node->attrs = wbxml_list_create()) == NULL) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    }
+
+    /* Duplicate Attribute */
+    if ((new_attr = wbxml_attribute_duplicate(attr)) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    
+    /* Add attribute to list */
+    if (!wbxml_list_append(node->attrs, new_attr)) {
+        wbxml_attribute_destroy(attr);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    return WBXML_OK;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_attrs(WBXMLTreeNode *node,
+                                                    WBXMLAttribute **attrs)
+{
+    WB_ULONG i = 0;
+
+    if ((node == NULL) || (attrs == NULL)) {
+        return WBXML_ERROR_BAD_PARAMETER;
+    }
+
+    while (attrs[i] != NULL) {
+        /* Add attribute */
+        if (wbxml_tree_node_add_attr(node, attrs[i]) != WBXML_OK)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+        i++;
+    }
+
+    return WBXML_OK;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_xml_attr(const WBXMLLangEntry *lang_table,
+                                                       WBXMLTreeNode *node,
+                                                       const WB_UTINY *name,
+                                                       const WB_UTINY *value)
+{
+    WBXMLAttribute *attr = NULL;
+    const WBXMLAttrEntry *attr_entry = NULL;
+
+    /* Create list if needed */
+    if (node->attrs == NULL) {
+        if ((node->attrs = wbxml_list_create()) == NULL) {
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+    }
+
+    /* Create Attribute */
+    if ((attr = wbxml_attribute_create()) == NULL)
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+    /* Set Attribute Name */
+    if ((attr_entry = wbxml_tables_get_attr_from_xml(lang_table, (WB_UTINY *)name, (WB_UTINY *)value, NULL)) != NULL)
+        attr->name = wbxml_attribute_name_create_token(attr_entry);
+    else
+        attr->name = wbxml_attribute_name_create_literal((WB_UTINY *)name);
+
+    if (attr->name == NULL) {
+        wbxml_attribute_destroy(attr);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Set Attribute Value */
+    attr->value = wbxml_buffer_create_real(value, WBXML_STRLEN(value), WBXML_STRLEN(value));
+    if (attr->value == NULL) {
+        wbxml_attribute_destroy(attr);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    /* Add attribute to list */
+    if (!wbxml_list_append(node->attrs, attr)) {
+        wbxml_attribute_destroy(attr);
+        return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    return WBXML_OK;
+}
+
+
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_xml_attrs(const WBXMLLangEntry *lang_table,
+                                                        WBXMLTreeNode *node,
+                                                        const WB_UTINY **attrs)
+{
+    const WB_UTINY **p = attrs;
+
+    if ((lang_table == NULL) || (node == NULL) || (attrs == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    while (p && *p) {
+        /* Add attribute */
+        if (wbxml_tree_node_add_xml_attr(lang_table, node, *p, *(p+1)) != WBXML_OK)
+            return WBXML_ERROR_NOT_ENOUGH_MEMORY;
+
+        p += 2;
+    }
+
+    return WBXML_OK;
+}
+
+
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_elt_get_from_name(WBXMLTreeNode *node, const char *name, WB_BOOL recurs)
+{
+    WBXMLTreeNode *current_node = NULL;
+    WBXMLTreeNode *recurs_node = NULL;
+
+    if ((node == NULL) || (name == NULL))
+        return NULL;
+
+    /* Let's go through the tree */
+    current_node = node;
+
+    while (current_node != NULL)
+    {
+        /* Is this a normal node? */
+        if (current_node->type == WBXML_TREE_ELEMENT_NODE)
+        {
+            /* Is this the Node we searched ? */
+            if (WBXML_STRCMP(wbxml_tag_get_xml_name(current_node->name), name) == 0)
+            {
+                return current_node;
+            }
+
+            /* Sould we start a recursive search? */
+            if (recurs && current_node->children)
+            {
+                recurs_node = wbxml_tree_node_elt_get_from_name(current_node->children, name, TRUE);
+                /* Is this the Node we searched ? */
+                if (recurs_node)
+                {
+                    return recurs_node;
+                }
+            }
+        }
+
+        /* Go to next Sibbling Node */
+        current_node = current_node->next;
+    }
+
+    /* A node with the specified name could not be found. */
+    return NULL;
+}
+
+
+#if defined ( WBXML_SUPPORT_SYNCML )
+
+WBXML_DECLARE(WBXMLSyncMLDataType) wbxml_tree_node_get_syncml_data_type(WBXMLTreeNode *node)
+{
+    WBXMLTreeNode *tmp_node = NULL;
+
+    if (node == NULL)
+        return WBXML_SYNCML_DATA_TYPE_NORMAL;
+
+    /* If we are in a CDATA node then we must look into the parent node. */
+    if (node->type == WBXML_TREE_CDATA_NODE)
+        node = node->parent;
+
+    /* Are we in a <Data> ? */
+    if ((node->type == WBXML_TREE_ELEMENT_NODE) &&
+        (node->name != NULL) &&
+        (WBXML_STRCMP(wbxml_tag_get_xml_name(node->name), "Data") == 0))
+    {
+        /* Go to Parent element (or Parent of Parent) and search for <Meta> then <Type> */
+        if (((node->parent != NULL) && 
+             (node->parent->children != NULL) && 
+             ((tmp_node = wbxml_tree_node_elt_get_from_name(node->parent->children, "Meta", FALSE)) != NULL) &&
+             ((tmp_node = wbxml_tree_node_elt_get_from_name(tmp_node->children, "Type", FALSE)) != NULL)) ||
+            (((node->parent != NULL) && 
+              (node->parent->parent != NULL) && 
+              (node->parent->parent->children != NULL) && 
+              ((tmp_node = wbxml_tree_node_elt_get_from_name(node->parent->parent->children, "Meta", FALSE)) != NULL)) &&
+              ((tmp_node = wbxml_tree_node_elt_get_from_name(tmp_node->children, "Type", FALSE)) != NULL)))
+        {
+            /* Check <Type> value */
+            if ((tmp_node->children != NULL) && (tmp_node->children->type == WBXML_TREE_TEXT_NODE)) {
+                /* This function is used by wbxml and xml callbacks.
+                 * So content types must be handled for both situations.
+                 */
+
+                /* application/vnd.syncml-devinf+wbxml */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "application/vnd.syncml-devinf+wbxml") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_WBXML;
+                }
+                
+                /* application/vnd.syncml-devinf+xml */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "application/vnd.syncml-devinf+xml") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_NORMAL;
+                }
+
+                /* application/vnd.syncml.dmtnds+wbxml */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "application/vnd.syncml.dmtnds+wbxml") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_WBXML;
+                }
+                
+                /* application/vnd.syncml.dmtnds+xml */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "application/vnd.syncml.dmtnds+xml") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_NORMAL;
+                }
+
+                /* text/clear */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "text/clear") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_CLEAR;
+                }
+                
+                /* text/directory;profile=vCard */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "text/directory;profile=vCard") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_DIRECTORY_VCARD;
+                }
+                
+                /* text/x-vcard */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "text/x-vcard") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_VCARD;
+                }
+                
+                /* text/x-vcalendar */
+                if (wbxml_buffer_compare_cstr(tmp_node->children->content, "text/x-vcalendar") == 0) {
+                    return WBXML_SYNCML_DATA_TYPE_VCALENDAR;
+                }
+            }
+        }
+        
+        /**
+         * Hack: we assume that any <Data> inside a <Replace> or <Add> Item is a vObject (vCard / vCal / ...).
+         *
+         * This is because when parsing a <Data> content we really need to put a CDATA, event if we don't really
+         * know the content-type. For example when receiving the end of a splitted vObject with Samsung D600, we receive this:
+         *
+         * 	      <Replace>
+         * 	        <CmdID>162</CmdID>
+         * 	        <Item>
+         * 	          <Source>
+         * 	            <LocURI>./690</LocURI>
+         * 	          </Source>
+         * 	          <Data>EF;CELL:0661809055
+         * 	TEL;HOME:0299783886
+         * 	X-IRMC-LUID:690
+         * 	END:VCARD</Data>
+         * 	        </Item>
+         * 	      </Replace>
+         *
+         * There is no <Meta> info to find the content-type of the <Data>.
+         */
+        if ( (node->parent != NULL) &&
+             (node->parent->parent != NULL) &&
+             (node->parent->parent->name != NULL) &&
+             ((WBXML_STRCMP(wbxml_tag_get_xml_name(node->parent->parent->name), "Add") == 0) ||
+              (WBXML_STRCMP(wbxml_tag_get_xml_name(node->parent->parent->name), "Replace") == 0)) )
+        {
+            return WBXML_SYNCML_DATA_TYPE_VOBJECT;
+        }
+    }
+
+    return WBXML_SYNCML_DATA_TYPE_NORMAL;
+}
+
+#endif /* WBXML_SUPPORT_SYNCML */
+
+
+WBXML_DECLARE(WB_BOOL) wbxml_tree_node_have_child_elt(WBXMLTreeNode *node)
+{
+    WBXMLTreeNode *current = NULL;
+
+    if (node != NULL) {
+        /* Get first child */
+        current = node->children;
+
+        while (current != NULL) {
+            if (current->type == WBXML_TREE_ELEMENT_NODE) {
+                /* Element Node found ! */
+                return TRUE;
+            }
+
+            /* Check next child */
+            current = current->next;
+        }
+    }
+
+    return FALSE;
+}
+
+
+WBXML_DECLARE(WBXMLList*) wbxml_tree_node_get_all_children(WBXMLTreeNode *node)
+{
+    WBXMLList* result = NULL;
+    
+    if ( node == NULL )
+        return NULL;
+    
+    node = node->children;
+    
+    while ( node != NULL ) {
+        /* Create result list if not already done */
+        if ( result == NULL )
+            result = wbxml_list_create();
+        
+        /* Append node to result */
+        wbxml_list_append(result, node);
+        
+        /* Go to next node */
+        node = node->next;
+    } 
+    
+    return result;
+}
+
+
+WBXML_DECLARE(WBXMLTree *) wbxml_tree_create(WBXMLLanguage lang,
+                                             WBXMLCharsetMIBEnum orig_charset)
+{
+    WBXMLTree *result = NULL;
+    
+    if ((result = wbxml_malloc(sizeof(WBXMLTree))) == NULL)
+        return NULL;
+
+    result->lang = wbxml_tables_get_table(lang);
+    result->root = NULL;
+    result->orig_charset = orig_charset;
+    result->cur_code_page = 0;
+
+    return result;
+}
+
+
+WBXML_DECLARE(void) wbxml_tree_destroy(WBXMLTree *tree)
+{
+    if (tree != NULL) {
+        /* Destroy root node and all its children */
+        wbxml_tree_node_destroy_all(tree->root);
+
+        /* Free tree */
+        wbxml_free(tree);
+    }
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WB_BOOL) wbxml_tree_add_node(WBXMLTree *tree, WBXMLTreeNode *parent, WBXMLTreeNode *node)
+{
+    WBXMLTreeNode *tmp = NULL;
+
+    if ((tree == NULL) || (node == NULL))
+        return FALSE;
+
+    /* Set parent to new node */
+    node->parent = parent;    
+
+    /* Check if this is the Root Element */
+    if (parent != NULL) {
+        /* This is not the Root Element... search for previous sibbling element */
+        if (parent->children != NULL) {
+            /* Add this Node to end of Sibbling Node list of Parent */
+            tmp = parent->children;
+
+            /* !!! WARNING !!!
+             * EXPAT splits &lt;html&gt; into three separate text nodes.
+             * Therefore it is necessary to scan for splitted text nodes and
+             * join them to get consistent text nodes.
+             */
+
+            /* If the handled node is a text node and the last node is a text node
+             * then the last node must be replace.
+             * Otherwise the node will be appended.
+             */
+            while (tmp->next != NULL)
+                tmp = tmp->next;
+
+	    if (node->type == WBXML_TREE_TEXT_NODE &&
+                tmp->type == WBXML_TREE_TEXT_NODE) {
+
+                /* join the two text nodes and replace the present text node */
+                if (!wbxml_buffer_append(tmp->content, node->content))
+                    return FALSE;
+
+		if (tmp->prev == NULL) {
+                    /* tmp is first child */
+                    parent->children = node;
+                } else {
+                    /* tmp is not first child */
+                    tmp->prev->next = node;
+                    node->prev = tmp->prev;
+                }
+
+                wbxml_buffer_destroy(node->content);
+                node->content = tmp->content;
+                tmp->content = NULL;
+                wbxml_tree_node_destroy(tmp);
+            } else {
+                /* normal situation => append node */
+                node->prev = tmp;
+                tmp->next = node;
+            }
+        }
+        else {
+            /* No previous sibbling element */
+            parent->children = node;
+        }
+    }
+    else {
+        /* We do NOT allow replacement of an existing Tree Node */
+        if (tree->root != NULL)
+            return FALSE;
+
+        /* This is the Root Element */
+        tree->root = node;
+    }
+
+    return TRUE;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLError) wbxml_tree_extract_node(WBXMLTree *tree,
+                                                  WBXMLTreeNode *node)
+{
+    if ((tree == NULL) || (node == NULL))
+        return WBXML_ERROR_BAD_PARAMETER;
+
+    /* Parent link */
+    if (node->parent != NULL) {
+        if (node->parent->children == node) {
+            /* Update parent children */
+		    node->parent->children = node->next;
+        }
+
+        /* No more parent */
+        node->parent = NULL;
+    }
+    else {
+        /* Root removed ! */
+        tree->root = node->next;
+    }
+
+    /* Link next node to previous node */
+    if (node->next != NULL)
+        node->next->prev = node->prev;
+
+    /* Link previous node to next node */
+    if (node->prev != NULL)
+        node->prev->next = node->next;
+
+    /* Cleanup pointers */
+    node->next = node->prev = NULL;
+
+    return WBXML_OK;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_elt(WBXMLTree *tree,
+                                                  WBXMLTreeNode *parent,
+                                                  WBXMLTag *tag)
+{
+    WBXMLTreeNode *node = NULL;
+
+    /* Create a new Node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_ELEMENT_NODE)) == NULL) {
+        return NULL;
+    }
+
+    /* Set Element */
+    if ((node->name = wbxml_tag_duplicate(tag)) == NULL) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+
+    /* Add this Node to Tree  */
+    if (!wbxml_tree_add_node(tree, parent, node)) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+
+    return node;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_elt_with_attrs(WBXMLTree *tree,
+                                                             WBXMLTreeNode *parent,
+                                                             WBXMLTag *tag,
+                                                             WBXMLAttribute **attrs)
+{
+    WBXMLTreeNode *node = NULL;
+
+    /* Add element */
+    if ((node = wbxml_tree_add_elt(tree, parent, tag)) == NULL) {
+        return NULL;
+    }
+
+    /* Add attributes to element */
+    if ((attrs != NULL) && (*attrs != NULL)) {
+        if (wbxml_tree_node_add_attrs(node, attrs) != WBXML_OK) {
+            /* Remove node from Tree */
+            wbxml_tree_extract_node(tree, node);
+            wbxml_tree_node_destroy(node);
+            return NULL;
+        }
+    }
+
+    return node;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_xml_elt(WBXMLTree *tree,
+                                                      WBXMLTreeNode *parent,
+                                                      WB_UTINY *name)
+{
+    const WBXMLTagEntry *tag_entry = NULL;
+    WBXMLTreeNode *node = NULL;
+    WBXMLTag *tag = NULL;
+    WB_UTINY *sep = NULL;
+    const WB_UTINY *namespace_name = NULL;
+    WB_UTINY *element_name = NULL;
+
+    /* Separate the namespace from the element name */
+    sep = (WB_UTINY *)strrchr((const WB_TINY *) name, WBXML_NAMESPACE_SEPARATOR);
+    if (sep != NULL) {
+        /* Temporarily split the string by changing the separater to a null-terminator */
+        *sep = '\0';
+        
+        namespace_name = name;
+        element_name = sep+1;
+    }
+    else {
+        /* No namespace, so just set it to an empty string (specifically, the null-terminator at the end of the elemet name */
+        namespace_name = name + strlen((const WB_TINY *) name);
+        element_name = name;
+    }
+
+    WBXML_DEBUG((WBXML_CONV, "Parsed element name: Namespace='%s', Element='%s'", namespace_name, element_name));
+
+    /* Update the current code page to match the one specified by the namespace */
+    tree->cur_code_page = wbxml_tables_get_code_page(tree->lang->nsTable, (const WB_TINY *) namespace_name);
+
+    /* Search for XML Tag Name in Table */
+    if ((tag_entry = wbxml_tables_get_tag_from_xml(tree->lang, tree->cur_code_page, element_name)) != NULL) {
+        tree->cur_code_page = tag_entry->wbxmlCodePage;
+
+        /* Found : token tag */
+        tag = wbxml_tag_create_token(tag_entry);
+    }
+    else {
+        /* Not found : literal tag */
+        tag = wbxml_tag_create_literal(element_name);
+    }
+
+    if (sep != NULL) {
+        /* We are done with the element and namespace names, so put the separator character back */
+        *sep = WBXML_NAMESPACE_SEPARATOR;
+    }
+    
+    if (tag == NULL)
+        return NULL;
+
+    /* Create a new Node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_ELEMENT_NODE)) == NULL) {
+        wbxml_tag_destroy(tag);
+        return NULL;
+    }
+    
+    /* Set Node Tag */
+    node->name = tag;
+
+    /* Add this Node to Tree  */
+    if (!wbxml_tree_add_node(tree, parent, node)) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+    
+    return node;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_xml_elt_with_attrs(WBXMLTree *tree,
+                                                                 WBXMLTreeNode *parent,
+                                                                 WB_UTINY *name,
+                                                                 const WB_UTINY **attrs)
+{
+    WBXMLTreeNode *node = NULL;
+
+    /* Add element */
+    if ((node = wbxml_tree_add_xml_elt(tree, parent, name)) == NULL) {
+        return NULL;
+    }
+
+    /* Add attributes to element */
+    if ((attrs != NULL) && (*attrs != NULL)) {
+        if (wbxml_tree_node_add_xml_attrs(tree->lang, node, attrs) != WBXML_OK) {
+            /* Remove node from Tree */
+            wbxml_tree_extract_node(tree, node);
+            wbxml_tree_node_destroy(node);
+            return NULL;
+        }
+    }
+
+    return node;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_text(WBXMLTree *tree,
+                                                   WBXMLTreeNode *parent,
+                                                   const WB_UTINY *text,
+                                                   WB_ULONG len)
+{
+    WBXMLTreeNode *node = NULL;
+
+    /* Create a new Node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_TEXT_NODE)) == NULL) {
+        return NULL;
+    }
+
+    /* Set Content */
+    if ((node->content = wbxml_buffer_create(text, len, len)) == NULL) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+
+    /* Add this Node to Tree  */
+    if (!wbxml_tree_add_node(tree, parent, node)) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+
+    return node;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_cdata(WBXMLTree *tree,
+                                                    WBXMLTreeNode *parent)
+{
+    WBXMLTreeNode *node = NULL;
+
+    /* Create a new Node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_CDATA_NODE)) == NULL) {
+        return NULL;
+    }
+
+    /* Add this Node to Tree  */
+    if (!wbxml_tree_add_node(tree, parent, node)) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+
+    return node;
+}
+
+
+/** @todo wbxml_tree_add_cdata_with_text() */
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_tree(WBXMLTree *tree,
+                                                   WBXMLTreeNode *parent,
+                                                   WBXMLTree *new_tree)
+{
+    WBXMLTreeNode *node = NULL;
+
+    /* Create a new Node */
+    if ((node = wbxml_tree_node_create(WBXML_TREE_TREE_NODE)) == NULL) {        
+        return NULL;
+    }
+
+    /* Add this Node to Tree  */
+    if (!wbxml_tree_add_node(tree, parent, node)) {
+        wbxml_tree_node_destroy(node);
+        return NULL;
+    }
+
+    /* Set Tree */
+    node->tree = new_tree;
+
+    return node;
+}
+
+
+/** @todo Rewrite this function (use wbxml_tree_node_* functions) */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_xml_elt_with_attrs_and_text(WBXMLTree *tree,
+                                                                          WBXMLTreeNode *parent,
+                                                                          WB_UTINY *name,
+                                                                          const WB_UTINY **attrs,
+                                                                          const WB_UTINY *text,
+                                                                          WB_ULONG len)
+{
+    WBXMLTreeNode *new_node = NULL;
+    
+    /* Add XML node */
+    if ((new_node = wbxml_tree_add_xml_elt_with_attrs(tree, parent, name, attrs)) == NULL)
+        return NULL;
+    
+    /* Add text node */
+    if ((text != NULL) && (len > 0)) {
+        if (wbxml_tree_add_text(tree, new_node, text, len) == NULL) {
+            wbxml_tree_node_destroy(new_node);
+            return NULL;
+        }
+    }
+    
+    return new_node;
+}

--- a/src/libwbxml/wbxml_tree.h
+++ b/src/libwbxml/wbxml_tree.h
@@ -2,27 +2,27 @@
  * libwbxml, the WBXML Library.
  * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
  * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- * 
+ *
  * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
- * 
+ *
  * Contact: aymerick@jehanne.org
  * Home: http://libwbxml.aymerick.com
  */
- 
+
 /**
  * @file wbxml_tree.h
  * @ingroup wbxml_tree
@@ -43,17 +43,17 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include <wbxml_config.h>
+#include "wbxml_config.h"
 
 /** @addtogroup wbxml_tree
- *  @{ 
+ *  @{
  */
 
 
 /****************************************************
  *	WBXML Tree Structures
  */
-  
+
 
 /**
  * @brief WBXML Tree Node Type
@@ -77,7 +77,7 @@ typedef struct WBXMLTreeNode_s
     WBXMLList           *attrs;     /**< Node Attributes (if type is 'WBXML_TREE_ELEMENT_NODE') */
     WBXMLBuffer         *content;   /**< Node Content (if  type is 'WBXML_TREE_TEXT_NODE')  */
     struct WBXMLTree_s  *tree;      /**< Node Tree (if  type is 'WBXML_TREE_TREE_NODE') */
-    
+
     struct WBXMLTreeNode_s  *parent;    /**< Parent Node */
     struct WBXMLTreeNode_s  *children;  /**< Children Node */
     struct WBXMLTreeNode_s  *next;      /**< Next sibling Node */
@@ -87,7 +87,7 @@ typedef struct WBXMLTreeNode_s
 
 /**
  * @brief WBXML Tree structure
- * 
+ *
  * This structure is created when parsing a WBXML or XML document, thanks to
  * the functions wbxml_tree_from_wbxml() and wbxml_tree_from_xml().
  *
@@ -99,7 +99,7 @@ typedef struct WBXMLTreeNode_s
  * @note All the strings inside the WBXML Tree are encoded into UTF-8
  */
 typedef struct WBXMLTree_s
-{    
+{
     const WBXMLLangEntry *lang;         /**< Language Table */
     WBXMLTreeNode        *root;         /**< Root Element */
     WBXMLCharsetMIBEnum   orig_charset; /**< Charset encoding of original document */
@@ -107,7 +107,7 @@ typedef struct WBXMLTree_s
 } WBXMLTree;
 
 
-/** 
+/**
  * WBXML Tree Clb Context Structure
  * @note Used by WBXML Tree Callbacks ('wbxml_tree_clb_wbxml.h' and 'wbxml_tree_clb_xml.h')
  */
@@ -123,7 +123,7 @@ typedef struct WBXMLTreeClbCtx_s {
 #if defined( HAVE_EXPAT )
     XML_Parser     xml_parser;    /**< Pointer to Expat XML Parser */
     WB_BOOL        expat_utf16;   /**< Is Expat compiled to output UTF-16 ? */
-#endif /* HAVE_EXPAT */ 
+#endif /* HAVE_EXPAT */
 } WBXMLTreeClbCtx;
 
 
@@ -152,7 +152,7 @@ typedef enum WBXMLSyncMLDataType_e {
  * @param wbxml     [in]  The WBXML document to parse
  * @param wbxml_len [in]  The WBXML document length
  * @param lang      [in]  Can be used to force parsing of a given Language (set it to WBXML_LANG_UNKNOWN if you don't want to force anything)
- * @param tree      [out] The resulting WBXML Tree 
+ * @param tree      [out] The resulting WBXML Tree
  * @result Return WBXML_OK if no error, an error code otherwise
  */
 WBXML_DECLARE(WBXMLError) wbxml_tree_from_wbxml(WB_UTINY *wbxml,
@@ -178,7 +178,7 @@ WBXML_DECLARE(WBXMLError) wbxml_tree_to_wbxml(WBXMLTree *tree,
  * @brief Parse an XML document, using internal callbacks (in wbxml_tree_clb_xml.c), and construct a WBXML Tree
  * @param xml     [in]  The XML document to parse
  * @param xml_len [in]  Length of the XML document
- * @param tree    [out] The resulting WBXML Tree 
+ * @param tree    [out] The resulting WBXML Tree
  * @result Return WBXML_OK if no error, an error code otherwise
  * @note Needs 'HAVE_EXPAT' compile flag
  */
@@ -205,7 +205,7 @@ WBXML_DECLARE(WBXMLError) wbxml_tree_to_xml(WBXMLTree *tree,
 /**
  * @brief Parse a LibXML document, and construct the corresponding WBXML Tree
  * @param libxml_doc [in]  The LibXML document to parse
- * @param tree       [out] The resulting WBXML Tree 
+ * @param tree       [out] The resulting WBXML Tree
  * @result Return WBXML_OK if no error, an error code otherwise
  * @note Needs 'HAVE_LIBXML' compile flag
  */

--- a/src/libwbxml/wbxml_tree.h
+++ b/src/libwbxml/wbxml_tree.h
@@ -1,0 +1,563 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tree.h
+ * @ingroup wbxml_tree
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/16
+ *
+ * @brief WBXML Tree
+ */
+
+#ifndef WBXML_TREE_H
+#define WBXML_TREE_H
+
+#include "wbxml.h"
+#include "wbxml_elt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <wbxml_config.h>
+
+/** @addtogroup wbxml_tree
+ *  @{ 
+ */
+
+
+/****************************************************
+ *	WBXML Tree Structures
+ */
+  
+
+/**
+ * @brief WBXML Tree Node Type
+ */
+typedef enum WBXMLTreeNodeType_e
+{
+    WBXML_TREE_ELEMENT_NODE = 0, /**< Element Node */
+    WBXML_TREE_TEXT_NODE,        /**< Text Node */
+    WBXML_TREE_CDATA_NODE,       /**< CDATA Node */
+    WBXML_TREE_PI_NODE,          /**< PI Node */
+    WBXML_TREE_TREE_NODE         /**< WBXML Tree Node */
+} WBXMLTreeNodeType;
+
+/**
+ * @brief WBXML Tree Node structure
+ */
+typedef struct WBXMLTreeNode_s
+{
+    WBXMLTreeNodeType   type;       /**< Node Type */
+    WBXMLTag            *name;      /**< Node Name (if type is 'WBXML_TREE_ELEMENT_NODE') */
+    WBXMLList           *attrs;     /**< Node Attributes (if type is 'WBXML_TREE_ELEMENT_NODE') */
+    WBXMLBuffer         *content;   /**< Node Content (if  type is 'WBXML_TREE_TEXT_NODE')  */
+    struct WBXMLTree_s  *tree;      /**< Node Tree (if  type is 'WBXML_TREE_TREE_NODE') */
+    
+    struct WBXMLTreeNode_s  *parent;    /**< Parent Node */
+    struct WBXMLTreeNode_s  *children;  /**< Children Node */
+    struct WBXMLTreeNode_s  *next;      /**< Next sibling Node */
+    struct WBXMLTreeNode_s  *prev;      /**< Previous sibling Node */
+} WBXMLTreeNode;
+
+
+/**
+ * @brief WBXML Tree structure
+ * 
+ * This structure is created when parsing a WBXML or XML document, thanks to
+ * the functions wbxml_tree_from_wbxml() and wbxml_tree_from_xml().
+ *
+ * It represents the parsed document, and have this fields:
+ *   - lang: the language table of the parsed document (in wbxml_tables.c)
+ *   - root: the root element of the Tree representing the parsed document
+ *   - orig_charset: the original charset encoding of the parsed document
+ *
+ * @note All the strings inside the WBXML Tree are encoded into UTF-8
+ */
+typedef struct WBXMLTree_s
+{    
+    const WBXMLLangEntry *lang;         /**< Language Table */
+    WBXMLTreeNode        *root;         /**< Root Element */
+    WBXMLCharsetMIBEnum   orig_charset; /**< Charset encoding of original document */
+    WB_UTINY              cur_code_page;/**< Last seen code page */
+} WBXMLTree;
+
+
+/** 
+ * WBXML Tree Clb Context Structure
+ * @note Used by WBXML Tree Callbacks ('wbxml_tree_clb_wbxml.h' and 'wbxml_tree_clb_xml.h')
+ */
+typedef struct WBXMLTreeClbCtx_s {
+    /* For XML and WBXML Clb */
+    WBXMLTree     *tree;          /**< The WBXML Tree we are constructing */
+    WBXMLTreeNode *current;       /**< Current Tree Node */
+    WBXMLError     error;         /**< Error while parsing Document */
+    /* For XML Clb */
+    WB_ULONG       skip_lvl;      /**< Used to skip a whole XML node (used for SyncML) */
+    WB_LONG        skip_start;    /**< Starting Skipping position in XML Document (used for SyncML) */
+    WB_UTINY      *input_buff;    /**< Pointer to Input Buffer */
+#if defined( HAVE_EXPAT )
+    XML_Parser     xml_parser;    /**< Pointer to Expat XML Parser */
+    WB_BOOL        expat_utf16;   /**< Is Expat compiled to output UTF-16 ? */
+#endif /* HAVE_EXPAT */ 
+} WBXMLTreeClbCtx;
+
+
+#if defined ( WBXML_SUPPORT_SYNCML )
+/**
+ * SyncML Data Type (the type of data inside <Data> element)
+ */
+typedef enum WBXMLSyncMLDataType_e {
+    WBXML_SYNCML_DATA_TYPE_NORMAL = 0,      /**< Not specific Data Type */
+    WBXML_SYNCML_DATA_TYPE_WBXML,           /**< application/vnd.syncml-devinf+wbxml (WBXML Document) */
+    WBXML_SYNCML_DATA_TYPE_CLEAR,			/**< text/clear */
+    WBXML_SYNCML_DATA_TYPE_DIRECTORY_VCARD, /**< text/directory;profile=vCard */
+    WBXML_SYNCML_DATA_TYPE_VCARD,           /**< text/x-vcard */
+    WBXML_SYNCML_DATA_TYPE_VCALENDAR,       /**< text/x-vcalendar */
+    WBXML_SYNCML_DATA_TYPE_VOBJECT          /**< Hack: we assume that any <Data> inside a <Replace> or <Add> Item is a vObjec (vCard / vCal / ...) */
+} WBXMLSyncMLDataType;
+#endif /* WBXML_SUPPORT_SYNCML */
+
+
+/****************************************************
+ *  WBXML Tree Building Functions
+ */
+
+/**
+ * @brief Parse a WBXML document, using internal callbacks (in wbxml_tree_clb_wbxml.c), and construct a WBXML Tree
+ * @param wbxml     [in]  The WBXML document to parse
+ * @param wbxml_len [in]  The WBXML document length
+ * @param lang      [in]  Can be used to force parsing of a given Language (set it to WBXML_LANG_UNKNOWN if you don't want to force anything)
+ * @param tree      [out] The resulting WBXML Tree 
+ * @result Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_from_wbxml(WB_UTINY *wbxml,
+                                                WB_ULONG wbxml_len,
+                                                WBXMLLanguage lang,
+                                                WBXMLCharsetMIBEnum charset,
+                                                WBXMLTree **tree);
+
+/**
+ * @brief Convert a WBXML Tree to a WBXML document
+ * @param tree      [in]  The WBXML Tree to convert
+ * @param wbxml     [out] The resulting WBXML document
+ * @param wbxml_len [out] The resulting WBXML document length
+ * @param params    [in]  Parameters (if NULL, default values are used)
+ * @result Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_to_wbxml(WBXMLTree *tree,
+                                              WB_UTINY **wbxml,
+                                              WB_ULONG  *wbxml_len,
+                                              WBXMLGenWBXMLParams *params);
+
+/**
+ * @brief Parse an XML document, using internal callbacks (in wbxml_tree_clb_xml.c), and construct a WBXML Tree
+ * @param xml     [in]  The XML document to parse
+ * @param xml_len [in]  Length of the XML document
+ * @param tree    [out] The resulting WBXML Tree 
+ * @result Return WBXML_OK if no error, an error code otherwise
+ * @note Needs 'HAVE_EXPAT' compile flag
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_from_xml(WB_UTINY *xml,
+                                              WB_ULONG xml_len,
+                                              WBXMLTree **tree);
+
+/**
+ * @brief Convert a WBXML Tree to an XML document
+ * @param tree    [in]  The WBXML Tree to convert
+ * @param xml     [out] The resulting XML document
+ * @param xml_len [out] The resulting XML document length
+ * @param params  [in]  Parameters (if NULL, default values are used)
+ * @result Return WBXML_OK if no error, an error code otherwise
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_to_xml(WBXMLTree *tree,
+                                            WB_UTINY **xml,
+                                            WB_ULONG  *xml_len,
+                                            WBXMLGenXMLParams *params);
+
+/** @todo Libxml support ! */
+#if defined( HAVE_LIBXML )
+
+/**
+ * @brief Parse a LibXML document, and construct the corresponding WBXML Tree
+ * @param libxml_doc [in]  The LibXML document to parse
+ * @param tree       [out] The resulting WBXML Tree 
+ * @result Return WBXML_OK if no error, an error code otherwise
+ * @note Needs 'HAVE_LIBXML' compile flag
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_from_libxml_doc(xmlDocPtr libxml_doc,
+                                                     WBXMLTree **tree);
+
+/**
+ * @brief Parse a WBXML Tree, and construct the corresponding LibXML document
+ * @param tree       [in]  The WBXML Tree to parse
+ * @param libxml_doc [out] The resulting LibXML document
+ * @result Return WBXML_OK if no error, an error code otherwise
+ * @note Needs 'HAVE_LIBXML' compile flag
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_to_libxml_doc(WBXMLTree *tree,
+                                                   xmlDocPtr *libxml_doc);
+
+#endif /* HAVE_LIBXML */
+
+
+/****************************************************
+ *	WBXML Tree Functions
+ */
+
+/**
+ * @brief Create a Tree Node structure
+ * @param type Node type
+ * @return The newly created Tree Node, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create(WBXMLTreeNodeType type);
+
+/**
+ * @brief Destroy a Tree Node structure
+ * @param node The Tree Node structure to destroy
+ * @note The Node is freed, but not extracted from its WBXML Tree (use wbxml_tree_extract_node() before)
+ */
+WBXML_DECLARE(void) wbxml_tree_node_destroy(WBXMLTreeNode *node);
+
+/**
+ * @brief Destroy a Tree Node structure (used for wbxml_list_destroy())
+ * @param node The Tree Node structure to destroy
+ */
+WBXML_DECLARE(void) wbxml_tree_node_destroy_item(void *node);
+
+/**
+ * @brief Destroy a Tree Node structure, and all its children
+ * @param node The Tree Node structure to destroy
+ * @note The Node (and its sub-tree) is freed, but not extracted from its WBXML Tree (use wbxml_tree_extract_node() before)
+ */
+WBXML_DECLARE(void) wbxml_tree_node_destroy_all(WBXMLTreeNode *node);
+
+/**
+ * @brief Create a Tree Node structure, given the XML node name
+ * @param lang_table Language table
+ * @param name       XML node name
+ * @return The newly created Tree Node, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_xml_elt(const WBXMLLangEntry *lang_table,
+                                                              const WB_UTINY *name);
+
+/**
+ * @brief Create a Tree Node structure, given the XML node name and text content
+ * @param lang_table Language table
+ * @param name       XML node name
+ * @param text       Text content
+ * @param len        Text content length
+ * @return The newly created Tree Node, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_xml_elt_with_text(const WBXMLLangEntry *lang_table,
+                                                                        const WB_UTINY *name,
+                                                                        const WB_UTINY *text,
+                                                                        WB_ULONG len);
+
+/**
+ * @brief Create a Text Node structure
+ * @param text       Text content
+ * @param len        Text content length
+ * @return The newly created Tree Node, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_text(const WB_UTINY *text,
+                                                           WB_ULONG len);
+
+/**
+ * @brief Create a CDATA Node structure
+ * @param text       Text content
+ * @param len        Text content length
+ * @return The newly created Tree Node, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_cdata(const WB_UTINY *text,
+                                                            WB_ULONG len);
+
+/**
+ * @brief Create a Tree Node structure
+ * @param root Root node for this Tree
+ * @param lang Language table to use
+ * @param orig_charset Original charset
+ * @return The newly created Tree Node, or NULL if not enough memory
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_create_tree(WBXMLTreeNode *root,
+                                                           WBXMLLanguage lang,
+                                                           WBXMLCharsetMIBEnum orig_charset);
+
+/**
+ * @brief Add a Child node
+ * @param parent Parent node
+ * @param node   Child node to add
+ * @return TRUE if added or FALSE if error
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_tree_node_add_child(WBXMLTreeNode *parent,
+                                                 WBXMLTreeNode *node);
+
+/**
+ * @brief Extract a node
+ * @param node Node to extract
+ * @return TRUE if extracted or FALSE if error
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_extract(WBXMLTreeNode *node);
+
+/**
+ * @brief Add a WBXML Attribute to a Tree Node structure
+ * @param node The Tree Node to modify
+ * @param attr The WBXML Attribute to add
+ * @return WBXML_OK if no error, an error code otherwise
+ * @note This is only meanfull for an element node
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_attr(WBXMLTreeNode *node,
+                                                   WBXMLAttribute *attr);
+
+/**
+ * @brief Add a WBXML Attributes list to a Tree Node structure
+ * @param node  The Tree Node to modify
+ * @param attrs The WBXML Attributes to add
+ * @return WBXML_OK if no error, an error code otherwise
+ * @note This is only meanfull for an element node
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_attrs(WBXMLTreeNode *node,
+                                                    WBXMLAttribute **attrs);
+
+/**
+ * @brief Add an XML Attribute to a Tree Node structure
+ * @param lang_table Language table
+ * @param node The Tree Node to modify
+ * @param name The XML Attribute name
+ * @param value The XML Attribute value
+ * @return WBXML_OK if no error, an error code otherwise
+ * @note This is only meanfull for an element node
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_xml_attr(const WBXMLLangEntry *lang_table,
+                                                       WBXMLTreeNode *node,
+                                                       const WB_UTINY *name,
+                                                       const WB_UTINY *value);
+
+/**
+ * @brief Add an XML Attributes list to a Tree Node structure
+ * @param lang_table Language table
+ * @param node  The Tree Node to modify
+ * @param attrs The XML Attributes to add
+ * @return WBXML_OK if no error, an error code otherwise
+ * @note This is only meanfull for an element node
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_node_add_xml_attrs(const WBXMLLangEntry *lang_table,
+                                                        WBXMLTreeNode *node,
+                                                        const WB_UTINY **attrs);
+
+/**
+ * @brief Get an Element Node, given the Element Name
+ * @param node   The Tree Node where to start searching
+ * @param name   The Element Name we are searching
+ * @param recurs If FALSE, only search into direct childs of 'node'
+ * @return The found Tree Node, or NULL if not found
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_node_elt_get_from_name(WBXMLTreeNode *node,
+                                                                 const char *name,
+                                                                 WB_BOOL recurs);
+
+#if defined ( WBXML_SUPPORT_SYNCML )
+
+/**
+ * @brief Get the SyncML Data Type of this Tree Node
+ * @param node The Tree Node
+ * @return The SyncML Data Type of this Tree Node (cf: WBXMLSyncMLDataType enum)
+ * @note If no specific Data Type is found, this function returns 'WBXML_SYNCML_DATA_TYPE_NORMAL'
+ */
+WBXML_DECLARE(WBXMLSyncMLDataType) wbxml_tree_node_get_syncml_data_type(WBXMLTreeNode *node);
+
+#endif /* WBXML_SUPPORT_SYNCML */
+
+/**
+ * @brief Check if a node have an Element Node in its children list
+ * @param node The Tree Node
+ * @return YES if one of the node children is an Element, FALSE otherwise
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_tree_node_have_child_elt(WBXMLTreeNode *node);
+
+/**
+ * @brief Get all children from node
+ * @param node The Tree Node
+ * @return A list of all children belonging to this node, or NULL if no children found
+ */
+WBXML_DECLARE(WBXMLList*) wbxml_tree_node_get_all_children(WBXMLTreeNode *node);
+
+
+/**
+ * @brief Create a Tree structure
+ * @param lang Tree Language
+ * @param orig_charset Original tree charset
+ * @return The newly created Tree, or NULL if not enough memory
+ * @note The 'orig_charset' is used for further Tree encoding, it does NOT set
+ *       the internal Tree representation charset (UTF8 is always used).
+ */
+WBXML_DECLARE(WBXMLTree *) wbxml_tree_create(WBXMLLanguage lang,
+                                             WBXMLCharsetMIBEnum orig_charset);
+
+/**
+ * @brief Destroy a Tree structure, and all its nodes
+ * @param tree The Tree structure to destroy
+ */
+WBXML_DECLARE(void) wbxml_tree_destroy(WBXMLTree *tree);
+
+/**
+ * @brief Add a Node to a Tree
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param node   The new Tree Node to add
+ * @return TRUE is added, or FALSE if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns FALSE, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WB_BOOL) wbxml_tree_add_node(WBXMLTree *tree,
+                                           WBXMLTreeNode *parent,
+                                           WBXMLTreeNode *node);
+
+/**
+ * @brief Extract a Tree Node from its WBXML Tree
+ * @param tree  The Tree to modify
+ * @param node  The Tree Node to extract
+ * @return WBXML_OK if no error, an error code otherwise
+ * @note The node is extracted but not freed
+ */
+WBXML_DECLARE(WBXMLError) wbxml_tree_extract_node(WBXMLTree *tree,
+                                                  WBXMLTreeNode *node);
+
+/**
+ * @brief Add an Element Node to Tree, given its WBXML Tag
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param tag    Element to add
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_elt(WBXMLTree *tree,
+                                                  WBXMLTreeNode *parent,
+                                                  WBXMLTag *tag);
+
+/**
+ * @brief Add a Tag Element Node to Tree, with its WBXML Attributes
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param tag    Element to add
+ * @param attrs  Element attributes
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_elt_with_attrs(WBXMLTree *tree,
+                                                             WBXMLTreeNode *parent,
+                                                             WBXMLTag *tag,
+                                                             WBXMLAttribute **attrs);
+
+/**
+ * @brief Add an Element Node to a Tree, given its XML Name
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param name   XML element name to add
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_xml_elt(WBXMLTree *tree,
+                                                      WBXMLTreeNode *parent,
+                                                      WB_UTINY *name);
+
+/**
+ * @brief Add an Element Node to Tree, with its WBXML Attributes, given there XML values
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param name   XML element name to add
+ * @param attrs  XML element attributes
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_xml_elt_with_attrs(WBXMLTree *tree,
+                                                                 WBXMLTreeNode *parent,
+                                                                 WB_UTINY *name,
+                                                                 const WB_UTINY **attrs);
+
+/**
+ * @brief Add a Text Node to Tree
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param text   Text to add
+ * @param len    Text length
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_text(WBXMLTree *tree,
+                                                   WBXMLTreeNode *parent,
+                                                   const WB_UTINY *text,
+                                                   WB_ULONG len);
+
+/**
+ * @brief Add CDATA Node to Tree
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_cdata(WBXMLTree *tree,
+                                                    WBXMLTreeNode *parent);
+
+/** @todo wbxml_tree_add_cdata_with_text() */
+
+/**
+ * @brief Add a Tree Node to Tree
+ * @param tree     The Tree to modify
+ * @param parent   Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param new_tree The new Tree to add (will be freed when destroying the main Tree, so caller must not free it)
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_tree(WBXMLTree *tree,
+                                                   WBXMLTreeNode *parent,
+                                                   WBXMLTree *new_tree);
+
+/**
+ * @brief Add an Element Node to a Tree, given its XML Name, its attributes and a text content
+ * @param tree   The Tree to modify
+ * @param parent Parent of the new Node (ie: Position where to add the new Node in Tree)
+ * @param name   XML element name to add
+ * @param attrs  XML element attributes
+ * @param text   Text content for this new element
+ * @param len    Text content length
+ * @return The newly created node, or NULL if error.
+ * @note If 'parent' is NULL: if 'tree' already have a Root Element this function returns NULL, else 'node' becomes the Root Element of 'tree'
+ */
+WBXML_DECLARE(WBXMLTreeNode *) wbxml_tree_add_xml_elt_with_attrs_and_text(WBXMLTree *tree,
+                                                                          WBXMLTreeNode *parent,
+                                                                          WB_UTINY *name,
+                                                                          const WB_UTINY **attrs,
+                                                                          const WB_UTINY *text,
+                                                                          WB_ULONG len);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_TREE_H */

--- a/src/libwbxml/wbxml_tree_clb_wbxml.c
+++ b/src/libwbxml/wbxml_tree_clb_wbxml.c
@@ -1,0 +1,222 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tree_clb_wbxml.c
+ * @ingroup wbxml_tree
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/22
+ *
+ * @brief WBXML Tree Callbacks for WBXML Parser
+ */
+
+#include "wbxml_tree_clb_wbxml.h"
+#include "wbxml_tree.h"
+
+
+/***************************************************
+ *  Public Functions
+ */
+
+void wbxml_tree_clb_wbxml_start_document(void *ctx, WBXMLCharsetMIBEnum charset, const WBXMLLangEntry *lang)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    tree_ctx->tree->lang = lang;
+    tree_ctx->tree->orig_charset = charset;
+}
+
+
+void wbxml_tree_clb_wbxml_end_document(void *ctx)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    if (tree_ctx->error != WBXML_OK)
+        return;
+}
+
+
+void wbxml_tree_clb_wbxml_start_element(void *ctx, WBXMLTag *element, WBXMLAttribute **attrs)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    /* Add a new Node to tree */
+    tree_ctx->current = wbxml_tree_add_elt_with_attrs(tree_ctx->tree,
+                                                      tree_ctx->current,
+                                                      element,
+                                                      attrs);
+    if (tree_ctx->current == NULL) {
+        tree_ctx->error = WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+void wbxml_tree_clb_wbxml_end_element(void *ctx, WBXMLTag *element)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    if (tree_ctx->current == NULL) {
+        tree_ctx->error = WBXML_ERROR_INTERNAL;
+        return;
+    }
+
+    if (tree_ctx->current->parent == NULL) {
+        /* This must be the Root Element */
+        if (tree_ctx->current != tree_ctx->tree->root) {
+            tree_ctx->error = WBXML_ERROR_INTERNAL;
+        }
+    }
+    else {
+#if defined ( WBXML_SUPPORT_SYNCML )
+        /* Have we added a CDATA section ? 
+         * If so, we assume that now that we have reached an end of Element, 
+         * the CDATA section ended, and so we go back to parent.
+         */
+        if ((tree_ctx->current != NULL) && (tree_ctx->current->type == WBXML_TREE_CDATA_NODE))
+            tree_ctx->current = tree_ctx->current->parent;
+#endif /* WBXML_SUPPORT_SYNCML */
+
+        /* Go back one step upper in the tree */
+        tree_ctx->current = tree_ctx->current->parent;
+    }
+}
+
+
+void wbxml_tree_clb_wbxml_characters(void *ctx, WB_UTINY *ch, WB_ULONG start, WB_ULONG length)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+#if defined ( WBXML_SUPPORT_SYNCML )
+    WBXMLTree *tmp_tree = NULL;
+#endif /* WBXML_SUPPORT_SYNCML */
+
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+#if defined ( WBXML_SUPPORT_SYNCML )
+    /* Specific treatment for SyncML */
+    switch (wbxml_tree_node_get_syncml_data_type(tree_ctx->current)) {
+    case WBXML_SYNCML_DATA_TYPE_WBXML:
+        /* Deal with Embedded SyncML Documents - Parse WBXML */
+        if (wbxml_tree_from_wbxml(ch + start, length, WBXML_LANG_UNKNOWN, tree_ctx->tree->orig_charset, &tmp_tree) != WBXML_OK) {
+            /* Not parsable ? Just add it as a Text Node... */
+            goto text_node;
+        }
+
+        /* Add Tree Node */
+        if (wbxml_tree_add_tree(tree_ctx->tree,
+                                tree_ctx->current,
+                                tmp_tree) == NULL)
+        {
+            tree_ctx->error = WBXML_ERROR_INTERNAL;
+            wbxml_tree_destroy(tmp_tree);
+        }
+
+        /* Return !! */
+        return;
+        break;
+
+    case WBXML_SYNCML_DATA_TYPE_CLEAR:
+    case WBXML_SYNCML_DATA_TYPE_DIRECTORY_VCARD:
+    case WBXML_SYNCML_DATA_TYPE_VCALENDAR:
+    case WBXML_SYNCML_DATA_TYPE_VCARD:
+    case WBXML_SYNCML_DATA_TYPE_VOBJECT:
+        /*
+         * Add a CDATA section node
+         *
+         * Example:
+         * <Add>
+         *   <CmdID>6</CmdID>
+         *   <Meta><Type xmlns='syncml:metinf'>text/x-vcard</Type></Meta>
+         *   <Item>
+         *     <Source>
+         *         <LocURI>pas-id-3F4B790300000000</LocURI>
+         *     </Source>         
+         *     <Data><![CDATA[BEGIN:VCARD
+         *  VERSION:2.1
+         *  X-EVOLUTION-FILE-AS:Ximian, Inc.
+         *  N:
+         *  LABEL;WORK;ENCODING=QUOTED-PRINTABLE:401 Park Drive  3 West=0ABoston, MA
+         *  02215=0AUSA
+         *  TEL;WORK;VOICE:(617) 236-0442
+         *  TEL;WORK;FAX:(617) 236-8630
+         *  EMAIL;INTERNET:[EMAIL PROTECTED]
+         *  URL:www.ximian.com/
+         *  ORG:Ximian, Inc.
+         *  NOTE:Welcome to the Ximian Addressbook.
+         *  UID:pas-id-3F4B790300000000
+         *  END:VCARD
+         *  ]]>
+         *     </Data>
+         *   </Item>
+         * </Add>
+         *
+         * The end of CDATA section is assumed to be reached when parsing the end 
+         * of </Data> element.
+         */
+
+        /* Add new CDATA Node */
+        tree_ctx->current = wbxml_tree_add_cdata(tree_ctx->tree, tree_ctx->current);
+        if (tree_ctx->current == NULL) {
+            tree_ctx->error = WBXML_ERROR_INTERNAL;
+            return;
+        }
+
+        /* Now we can add the Text Node */
+        break;
+
+    default:
+        /* NOP */
+        break;
+    } /* switch */
+
+text_node:
+
+#endif /* WBXML_SUPPORT_SYNCML */
+
+    /* Add Text Node */
+    if (wbxml_tree_add_text(tree_ctx->tree,
+                            tree_ctx->current,
+                            (const WB_UTINY*) ch + start,
+                            length) == NULL)
+    {
+        tree_ctx->error = WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+void wbxml_tree_clb_wbxml_pi(void *ctx, const WB_UTINY *target, WB_UTINY *data)
+{
+    /** @todo wbxml_tree_clb_pi() */
+}

--- a/src/libwbxml/wbxml_tree_clb_wbxml.h
+++ b/src/libwbxml/wbxml_tree_clb_wbxml.h
@@ -1,0 +1,103 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tree_clb_wbxml.h
+ * @ingroup wbxml_tree
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/02/22
+ *
+ * @brief WBXML Tree Callbacks for WBXML Parser
+ */
+
+#ifndef WBXML_TREE_CLB_WBXML_H
+#define WBXML_TREE_CLB_WBXML_H
+
+#include "wbxml.h"
+#include "wbxml_elt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_tree
+ *  @{ 
+ */
+
+/**
+ * @brief Start Document Callback
+ * @param ctx User data
+ * @param charset Charset (IANA code)
+ * @param lang Language Table for this Document (cf: wbxml_table.[h|c])
+ */
+void wbxml_tree_clb_wbxml_start_document(void *ctx, WBXMLCharsetMIBEnum charset, const WBXMLLangEntry *lang);
+
+/**
+ * @brief End Document Callback
+ * @param ctx User data
+ */
+void wbxml_tree_clb_wbxml_end_document(void *ctx);
+
+/**
+ * @brief Start Element Callback
+ * @param ctx User data
+ * @param element The Tag Element
+ * @param atts The attributes attached to the element
+ */
+void wbxml_tree_clb_wbxml_start_element(void *ctx, WBXMLTag *element, WBXMLAttribute **atts);
+
+/**
+ * @brief End Element Callback
+ * @param ctx User data
+ * @param element The Tag Element
+ */
+void wbxml_tree_clb_wbxml_end_element(void *ctx, WBXMLTag *element);
+
+/**
+ * @brief Characters Callback
+ * @param ctx User data
+ * @param ch The characters
+ * @param start The start position in the array
+ * @param length The number of characters to read from the array
+ */
+void wbxml_tree_clb_wbxml_characters(void *ctx, WB_UTINY *ch, WB_ULONG start, WB_ULONG length);
+
+/**
+ * @brief Processing Instruction Callback
+ * @param ctx User data
+ * @param target The processing instruction target.
+ * @param data The processing instruction data, or null if  none was supplied. The data does
+ *            not include any whitespace separating it from the target
+ */
+void wbxml_tree_clb_wbxml_pi(void *ctx, const WB_UTINY *target, WB_UTINY *data);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* WBXML_TREE_CLB_WBXML_H */

--- a/src/libwbxml/wbxml_tree_clb_xml.c
+++ b/src/libwbxml/wbxml_tree_clb_xml.c
@@ -1,0 +1,644 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2008-2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tree_clb_xml.c
+ * @ingroup wbxml_tree
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/03/11
+ *
+ * @brief WBXML Tree Callbacks for XML Parser (Expat)
+ */
+
+#include "wbxml_config_internals.h"
+
+#if defined( HAVE_EXPAT )
+
+#include "wbxml_tree_clb_xml.h"
+#include "wbxml_tree.h"
+#include "wbxml_log.h"
+#include "wbxml_charset.h"
+#include "wbxml_base64.h"
+#include <assert.h>
+
+/************************************
+ *  Public Functions
+ */
+
+void wbxml_tree_clb_xml_decl(void           *ctx,
+                             const XML_Char *version,
+                             const XML_Char *encoding,
+                             int             standalone)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    (void) standalone; /* avoid warning about unused parameter */
+
+    if (tree_ctx->expat_utf16) {
+        /** @todo Convert from UTF-16 to UTF-8 */
+    }
+
+    /* This handler is called for XML declarations and also for text declarations discovered 
+     * in external entities. The way to distinguish is that the version parameter will
+     * be NULL for text declarations.
+     */
+    if (version != NULL) {
+        if (encoding != NULL) {
+            /* Get encoding */
+            if (!wbxml_charset_get_mib((const WB_TINY*)encoding, &(tree_ctx->tree->orig_charset))) {
+                WBXML_WARNING((WBXML_CONV, "Charset Encoding not supported: %s", encoding));
+            }
+        }
+    }
+}
+
+
+void wbxml_tree_clb_xml_doctype_decl(void           *ctx, 
+                                     const XML_Char *doctypeName, 
+                                     const XML_Char *sysid,
+                                     const XML_Char *pubid, 
+                                     int             has_internal_subset)
+{    
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+    const WBXMLLangEntry *lang_table = NULL;
+
+    (void) doctypeName;         /* avoid warning about unused parameter */
+    (void) has_internal_subset; /* avoid warning about unused parameter */
+
+    if (tree_ctx->expat_utf16) {
+        /** @todo Convert from UTF-16 to UTF-8 */
+    }
+
+    /* Search for Language Table, given the XML Public ID and System ID */
+    lang_table = wbxml_tables_search_table(wbxml_tables_get_main(), 
+                                           (const WB_UTINY *) pubid, 
+                                           (const WB_UTINY *) sysid, 
+                                           NULL);
+
+    if (lang_table != NULL) {
+        /* Ho Yeah ! We got it ! */
+        tree_ctx->tree->lang = lang_table;
+    }
+    else {
+        /* We will try to find the Language Table, given the Root Element */
+        WBXML_WARNING((WBXML_CONV, "Language Table NOT found, given the XML Public ID and System ID"));
+    }
+}
+
+
+void wbxml_tree_clb_xml_start_element(void           *ctx,
+                                      const XML_Char *localName,
+                                      const XML_Char **attrs)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+    const WBXMLLangEntry *lang_table = NULL;
+
+    WBXML_DEBUG((WBXML_PARSER, "Expat element start callback ('%s')", localName));
+
+    if (tree_ctx->expat_utf16) {
+        /** @todo Convert from UTF-16 to UTF-8 */
+    }
+
+    /* Check for Error */
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    /* Are we skipping a whole node ? */
+    if (tree_ctx->skip_lvl > 0) {
+        tree_ctx->skip_lvl++;
+        return;
+    }
+
+    if (tree_ctx->current == NULL) {
+        /* This is the Root Element */
+        if (tree_ctx->tree->lang == NULL) {
+            /* Language Table not already found: Search again */
+            lang_table = wbxml_tables_search_table(wbxml_tables_get_main(), 
+                                                   NULL, 
+                                                   NULL, 
+                                                   (const WB_UTINY *) localName);
+        
+            if (lang_table == NULL) {
+                /* Damn, this is an unknown language for us... */
+                tree_ctx->error = WBXML_ERROR_UNKNOWN_XML_LANGUAGE;
+                return;
+            }
+            else {
+                /* Well, we hope this was the Language we are searching for.. let's try with it :| */
+                tree_ctx->tree->lang = lang_table;
+            }
+        }
+    }
+
+#if defined( WBXML_SUPPORT_SYNCML )
+
+    /* If this is an embedded (not root) document, skip it
+     * Actually SyncML DevInf and DM DDF are known as such
+     * potentially embedded documents.
+     */
+    if ((
+         (WBXML_STRCMP(localName, "syncml:devinf:DevInf") == 0) ||
+         (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0)
+        )&&
+        (tree_ctx->current != NULL))
+    {
+        tree_ctx->skip_start = XML_GetCurrentByteIndex(tree_ctx->xml_parser);
+
+        /* Skip this node */
+        tree_ctx->skip_lvl++;
+
+        return;
+    }
+
+#endif /* WBXML_SUPPORT_SYNCML */
+
+    /* Add Element Node */
+    tree_ctx->current = wbxml_tree_add_xml_elt_with_attrs(tree_ctx->tree,
+                                                          tree_ctx->current,
+                                                          (WB_UTINY *) localName,
+                                                          (const WB_UTINY**) attrs);
+
+    if (tree_ctx->current == NULL) {
+        tree_ctx->error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+    }
+}
+
+
+void wbxml_tree_clb_xml_end_element(void           *ctx,
+                                    const XML_Char *localName)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+    WBXMLBuffer *content = NULL;
+    WBXMLTreeNode *node = NULL;
+    WBXMLError ret = WBXML_OK;
+
+    WBXML_DEBUG((WBXML_PARSER, "Expat element end callback ('%s')", localName));
+
+    /* If the node is flagged as binary node
+     * then the data is base64 encoded in the XML document
+     * and the data must be decoded in one step.
+     * Examples: Microsoft ActiveSync tags ConversationId or MIME
+     */
+
+    node = tree_ctx->current;
+    if (node && node->type == WBXML_TREE_ELEMENT_NODE &&
+        node->name->type == WBXML_VALUE_TOKEN &&
+        node->name->u.token->options & WBXML_TAG_OPTION_BINARY)
+    {
+        if (node->content == NULL)
+        {
+            WBXML_DEBUG((WBXML_PARSER, "    Binary tag: No content => no conversion!"));
+        } else {
+            WBXML_DEBUG((WBXML_PARSER, "    Binary tag: Convert base64 data"));
+            ret = wbxml_buffer_decode_base64(node->content);
+            if (ret != WBXML_OK)
+            {
+                WBXML_DEBUG((WBXML_PARSER, "    Binary tag: Base64 decoder failed!"));
+                tree_ctx->error = ret;
+            } else {
+                /* Add the buffer as a regular string node (since libwbxml doesn't
+                 * offer a way to specify an opaque data node). The WBXML
+                 * encoder is responsible for generating correct opaque data for
+                 * nodes like this.
+                 */
+                if (wbxml_tree_add_text(tree_ctx->tree,
+                                        tree_ctx->current,
+                                        (const WB_UTINY*)wbxml_buffer_get_cstr(node->content),
+                                        wbxml_buffer_len(node->content)) == NULL)
+                {
+                    WBXML_DEBUG((WBXML_PARSER, "    Binary tag: Cannot add base64 decoded node!"));
+                    tree_ctx->error = WBXML_ERROR_INTERNAL;
+                }
+            }
+            /* safe cleanup */
+            content = node->content;
+            node->content = NULL;
+            wbxml_buffer_destroy(content);
+        }
+    }
+
+    if (tree_ctx->expat_utf16) {
+        /** @todo Convert from UTF-16 to UTF-8 */
+    }
+
+    /* Check for Error */
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    /* Are we skipping a whole node ? */
+    if (tree_ctx->skip_lvl > 0) {
+        if (tree_ctx->skip_lvl == 1)
+        {
+            /* End of skipped node */
+
+#if defined( WBXML_SUPPORT_SYNCML )
+            if (WBXML_STRCMP(localName, "syncml:devinf:DevInf") == 0 ||
+	        WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0) {
+		/* definitions first ... or some compilers don't like it */
+                WBXMLBuffer *embed_doc = NULL;
+                WBXMLTree *tree = NULL;
+		const WBXMLLangEntry *lang;
+
+                /* Get embedded DevInf or DM DDF Document */
+                embed_doc = wbxml_buffer_create(tree_ctx->input_buff + tree_ctx->skip_start, 
+                                                 XML_GetCurrentByteIndex(tree_ctx->xml_parser) - tree_ctx->skip_start,
+                                                 XML_GetCurrentByteIndex(tree_ctx->xml_parser) - tree_ctx->skip_start + 10);
+                if (embed_doc == NULL) {
+                    tree_ctx->error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                    wbxml_buffer_destroy(embed_doc);
+                    return;
+                }
+
+                if (tree_ctx->expat_utf16) {
+                    /** @todo Convert from UTF-16 to UTF-8 */
+                }
+
+                /* Check Buffer Creation and add the closing tag */
+		if ((WBXML_STRCMP(localName, "syncml:devinf:DevInf") == 0 &&
+		     (!wbxml_buffer_append_cstr(embed_doc, "</DevInf>")))
+                    ||
+		    (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0 &&
+		     (!wbxml_buffer_append_cstr(embed_doc, "</MgmtTree>"))))
+                {
+                    tree_ctx->error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+                    wbxml_buffer_destroy(embed_doc);
+                    return;
+                }
+
+                /* Add doctype to give the XML parser a chance */
+		if (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0 &&
+		    tree_ctx->tree->lang->langID != WBXML_LANG_SYNCML_SYNCML12)
+		{
+                    tree_ctx->error = WBXML_ERROR_UNKNOWN_XML_LANGUAGE;
+                    wbxml_buffer_destroy(embed_doc);
+                    return;
+		}
+		switch(tree_ctx->tree->lang->langID)
+		{
+			case WBXML_LANG_SYNCML_SYNCML10:
+				lang = wbxml_tables_get_table(WBXML_LANG_SYNCML_DEVINF10);
+				break;
+			case WBXML_LANG_SYNCML_SYNCML11:
+				lang = wbxml_tables_get_table(WBXML_LANG_SYNCML_DEVINF11);
+				break;
+			case WBXML_LANG_SYNCML_SYNCML12:
+				if (WBXML_STRCMP(localName, "syncml:dmddf1.2:MgmtTree") == 0) {
+					lang = wbxml_tables_get_table(WBXML_LANG_SYNCML_DMDDF12);
+				} else {
+					lang = wbxml_tables_get_table(WBXML_LANG_SYNCML_DEVINF12);
+				}
+				break;
+			default:
+				tree_ctx->error = WBXML_ERROR_UNKNOWN_XML_LANGUAGE;
+				wbxml_buffer_destroy(embed_doc);
+				return;
+		}
+
+		assert (lang!= NULL);
+		if (lang == NULL) {
+			tree_ctx->error = WBXML_ERROR_UNKNOWN_XML_LANGUAGE;
+			wbxml_buffer_destroy(embed_doc);
+			return;
+		}
+
+		/* DOCTYPE in reverse order */
+		if (!wbxml_buffer_insert_cstr(embed_doc,(WB_UTINY *) "\">\n", 0) ||                     /* > */
+		    !wbxml_buffer_insert_cstr(embed_doc, (WB_UTINY *) lang->publicID->xmlDTD, 0) ||      /* DTD */
+		    !wbxml_buffer_insert_cstr(embed_doc, (WB_UTINY *) "\" \"", 0) ||                     /* DTD */
+		    !wbxml_buffer_insert_cstr(embed_doc, (WB_UTINY *) lang->publicID->xmlPublicID, 0) || /* Public ID */
+		    !wbxml_buffer_insert_cstr(embed_doc, (WB_UTINY *) " PUBLIC \"", 0) ||                /*  PUBLIC " */
+		    !wbxml_buffer_insert_cstr(embed_doc, (WB_UTINY *) lang->publicID->xmlRootElt, 0) ||  /* Root Element */
+		    !wbxml_buffer_insert_cstr(embed_doc, (WB_UTINY *) "<!DOCTYPE ", 0))                  /* <!DOCTYPE */
+		{
+			tree_ctx->error = WBXML_ERROR_ENCODER_APPEND_DATA;
+                	wbxml_buffer_destroy(embed_doc);
+			return;
+		}
+
+                WBXML_DEBUG((WBXML_PARSER, "\t Embedded Doc : '%s'", wbxml_buffer_get_cstr(embed_doc)));
+
+                /* Parse 'DevInf' Document */
+                if ((ret = wbxml_tree_from_xml(wbxml_buffer_get_cstr(embed_doc),
+                                               wbxml_buffer_len(embed_doc),
+                                               &tree)) != WBXML_OK)
+                {
+                    tree_ctx->error = ret;
+                    wbxml_buffer_destroy(embed_doc);
+                    return;
+                }
+
+                /* Add Tree Node */
+                tree_ctx->current = wbxml_tree_add_tree(tree_ctx->tree,
+                                                        tree_ctx->current,
+                                                        tree);
+                if (tree_ctx->current == NULL)
+                {
+                    tree_ctx->error = WBXML_ERROR_INTERNAL;
+                    wbxml_tree_destroy(tree);
+                    wbxml_buffer_destroy(embed_doc);
+                    return;
+                }
+
+                /* Clean-up */
+                wbxml_buffer_destroy(embed_doc);
+                tree_ctx->skip_lvl = 0;
+            }
+#endif /* WBXML_SUPPORT_SYNCML */
+        }
+        else {
+            tree_ctx->skip_lvl--;
+            return;
+        }
+    }
+
+    if (tree_ctx->current == NULL) {
+        tree_ctx->error = WBXML_ERROR_INTERNAL;
+        return;
+    }
+
+    if (tree_ctx->current->parent == NULL) {
+        /* This must be the Root Element */
+        if (tree_ctx->current != tree_ctx->tree->root) {
+            tree_ctx->error = WBXML_ERROR_INTERNAL;
+        }
+    }
+    else {
+#if defined ( WBXML_SUPPORT_SYNCML )
+        /* Have we added a missing CDATA section ? 
+         * If so, we assume that now that we have reached an end of Element, 
+         * the CDATA section ended, and so we go back to parent.
+         */
+        if ((tree_ctx->current != NULL) && (tree_ctx->current->type == WBXML_TREE_CDATA_NODE))
+            tree_ctx->current = tree_ctx->current->parent;
+#endif /* WBXML_SUPPORT_SYNCML */
+
+        /* Go back one step upper in the tree */
+        tree_ctx->current = tree_ctx->current->parent;
+    }
+}
+
+
+void wbxml_tree_clb_xml_start_cdata(void *ctx)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    /* Check for Error */
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    /* Are we skipping a whole node ? */
+    if (tree_ctx->skip_lvl > 0)
+        return;
+
+    /* Add CDATA Node */
+    tree_ctx->current = wbxml_tree_add_cdata(tree_ctx->tree, tree_ctx->current);
+    if (tree_ctx->current == NULL) {
+        tree_ctx->error = WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+void wbxml_tree_clb_xml_end_cdata(void *ctx)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    /* Check for Error */
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    /* Are we skipping a whole node ? */
+    if (tree_ctx->skip_lvl > 0)
+        return;
+        
+    if (tree_ctx->current == NULL) {
+        tree_ctx->error = WBXML_ERROR_INTERNAL;
+        return;
+    }
+
+    if (tree_ctx->current->parent == NULL) {
+        /* This must be the Root Element */
+        if (tree_ctx->current != tree_ctx->tree->root) {
+            tree_ctx->error = WBXML_ERROR_INTERNAL;
+        }
+    }
+    else {
+        /* Go back one step upper in the tree */
+        tree_ctx->current = tree_ctx->current->parent;
+    }
+}
+
+
+void wbxml_tree_clb_xml_characters(void           *ctx,
+                                   const XML_Char *ch,
+                                   int             len)
+{
+    WBXMLTreeNode *node;
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    WBXML_DEBUG((WBXML_PARSER, "Expat text callback"));
+
+    if (tree_ctx->expat_utf16) {
+        /** @todo Convert from UTF-16 to UTF-8 */
+    }
+
+    /* Check for Error */
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    /* Are we skipping a whole node ? */
+    if (tree_ctx->skip_lvl > 0)
+        return;
+
+#if defined ( WBXML_SUPPORT_SYNCML )
+    /* Specific treatment for SyncML */
+    switch (wbxml_tree_node_get_syncml_data_type(tree_ctx->current)) {
+    case WBXML_SYNCML_DATA_TYPE_DIRECTORY_VCARD:
+    case WBXML_SYNCML_DATA_TYPE_VCALENDAR:
+    case WBXML_SYNCML_DATA_TYPE_VCARD:
+    case WBXML_SYNCML_DATA_TYPE_VOBJECT:
+        /* SyncML has some real design bugs
+         * because the authors of the specification did not understand XML.
+         *
+         * There must be a hack to preserve the CRLFs of vFormat objects.
+         * The only chance to do this is the detection of the vFormat itself
+         * and the conversion of every LF to a CRLF.
+         *
+         * The line breaks are always in a single text node.
+         * So a CR is appended to get a CRLF at the end.
+         */
+
+        if (len == 1 && ch[0] == '\n') /* line break - LF */
+        {
+            ch = "\r\n";
+            len = 2;
+        }
+
+        /* Do not break here.
+         * The CDATA handling is required for vFormat objects too.
+         */
+    case WBXML_SYNCML_DATA_TYPE_CLEAR:
+        /*
+         * Add a missing CDATA section node
+         *
+         * Example:
+         * <Add>
+         *   <CmdID>6</CmdID>
+         *   <Meta><Type xmlns='syncml:metinf'>text/x-vcard</Type></Meta>
+         *   <Item>
+         *     <Source>
+         *         <LocURI>pas-id-3F4B790300000000</LocURI>
+         *     </Source>         
+         *     <Data>BEGIN:VCARD
+         *  VERSION:2.1
+         *  X-EVOLUTION-FILE-AS:Ximian, Inc.
+         *  N:
+         *  LABEL;WORK;ENCODING=QUOTED-PRINTABLE:401 Park Drive  3 West=0ABoston, MA
+         *  02215=0AUSA
+         *  TEL;WORK;VOICE:(617) 236-0442
+         *  TEL;WORK;FAX:(617) 236-8630
+         *  EMAIL;INTERNET:[EMAIL PROTECTED]
+         *  URL:www.ximian.com/
+         *  ORG:Ximian, Inc.
+         *  NOTE:Welcome to the Ximian Addressbook.
+         *  UID:pas-id-3F4B790300000000
+         *  END:VCARD</Data>
+         *   </Item>
+         * </Add>
+         *
+         * The end of CDATA section is assumed to be reached when parsing the end 
+         * of </Data> element.
+         *
+         * This kind of document is erroneous, but we must handle it.
+         * Normally, this should be:
+         *
+         *  ...
+         *     <Data><!CDATA[[BEGIN:VCARD
+         *  VERSION:2.1
+         *  X-EVOLUTION-FILE-AS:Ximian, Inc.
+         *  ...
+         *  UID:pas-id-3F4B790300000000
+         *  END:VCARD
+         *  ]]></Data>
+         *  ...
+         */
+
+        /* 
+         * We add a missing CDATA section if we are not already in a CDATA section.
+         *
+         * We don't add a CDATA section if we have already added a CDATA section. This
+         * permits to correctly handle good XML documents like this:
+         *
+         *  ...
+         *     <Data><!CDATA[[BEGIN:VCARD
+         *  VERSION:2.1
+         *  X-EVOLUTION-FILE-AS:Ximian, Inc.
+         *  ...
+         *  UID:pas-id-3F4B790300000000
+         *  END:VCARD
+         *  ]]>
+         *     </Data>
+         *  ...
+         *
+         * In this example, the spaces beetwen "]]>" and "</Data>" must not be added
+         * to a CDATA section. 
+         */
+        if ((tree_ctx->current != NULL) && 
+            (tree_ctx->current->type != WBXML_TREE_CDATA_NODE) &&
+            !((tree_ctx->current->children != NULL) && 
+              (tree_ctx->current->children->type == WBXML_TREE_CDATA_NODE)))
+        {
+            /* Add CDATA Node */
+            tree_ctx->current = wbxml_tree_add_cdata(tree_ctx->tree, tree_ctx->current);
+            if (tree_ctx->current == NULL) {
+                tree_ctx->error = WBXML_ERROR_INTERNAL;
+                return;
+            }
+        }
+
+        /* Now we can add the Text Node */
+        break;
+
+    default:
+        /* NOP */
+        break;
+    } /* switch */
+#endif /* WBXML_SUPPORT_SYNCML */
+
+    /* We expect that "byte array" or BLOB types are 
+     * encoded in Base 64 in the XML code, since they may contain binary data.
+     */
+
+    node = tree_ctx->current;
+    if (node && node->type == WBXML_TREE_ELEMENT_NODE &&
+        node->name->type == WBXML_VALUE_TOKEN &&
+        node->name->u.token->options & WBXML_TAG_OPTION_BINARY)
+    {
+        WBXML_DEBUG((WBXML_PARSER, "    Binary tag: Caching base64 encoded data for later conversion."));
+        if (node->content == NULL)
+        {
+            node->content = wbxml_buffer_create(ch, len, 1);
+            if (node->content == NULL)
+                tree_ctx->error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        } else {
+            if (!wbxml_buffer_append_data(node->content, ch, len))
+                tree_ctx->error = WBXML_ERROR_NOT_ENOUGH_MEMORY;
+        }
+        return;
+    }
+
+    /* Add Text Node */
+    if (wbxml_tree_add_text(tree_ctx->tree,
+                            tree_ctx->current,
+                            (const WB_UTINY*) ch,
+                            len) == NULL)
+    {
+        tree_ctx->error = WBXML_ERROR_INTERNAL;
+    }
+}
+
+
+void wbxml_tree_clb_xml_pi(void           *ctx,
+                           const XML_Char *target,
+                           const XML_Char *data)
+{
+    WBXMLTreeClbCtx *tree_ctx = (WBXMLTreeClbCtx *) ctx;
+
+    if (tree_ctx->expat_utf16) {
+        /** @todo Convert from UTF-16 to UTF-8 */
+    }
+
+    /* Check for Error */
+    if (tree_ctx->error != WBXML_OK)
+        return;
+
+    /* Are we skipping a whole node ? */
+    if (tree_ctx->skip_lvl > 0)
+        return;
+
+    /** @todo wbxml2xml_clb_pi() */
+}
+
+#endif /* HAVE_EXPAT */

--- a/src/libwbxml/wbxml_tree_clb_xml.h
+++ b/src/libwbxml/wbxml_tree_clb_xml.h
@@ -1,0 +1,126 @@
+/*
+ * libwbxml, the WBXML Library.
+ * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
+ * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
+ * 
+ * Contact: aymerick@jehanne.org
+ * Home: http://libwbxml.aymerick.com
+ */
+ 
+/**
+ * @file wbxml_tree_clb_xml.h
+ * @ingroup wbxml_tree
+ *
+ * @author Aymerick Jehanne <aymerick@jehanne.org>
+ * @date 03/03/11
+ *
+ * @brief WBXML Tree Callbacks for XML Parser (Expat)
+ */
+
+#ifndef WBXML_TREE_CLB_XML_H
+#define WBXML_TREE_CLB_XML_H
+
+#include "wbxml.h"
+#include <wbxml_config.h>
+
+#if defined( HAVE_EXPAT )
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup wbxml_tree 
+ *  @{ 
+ */
+
+/**
+ * @brief XML Declarations Callback
+ * @param ctx User data
+ * @param version XML version
+ * @param encoding XML encoding
+ * @param standalone Value -1, 0, or 1 indicating respectively that there was no standalone parameter in the declaration, that it was given as no, or that it was given as yes.
+ */
+void wbxml_tree_clb_xml_decl(void *ctx, const XML_Char *version,
+                             const XML_Char *encoding, int standalone);
+
+/**
+ * @brief Doctype Declaration Callback
+ * @param ctx User data
+ * @param doctypeName Doctype Name
+ * @param sysid System ID
+ * @param pubid Public ID
+ * @param has_internal_subset Non-zero if the DOCTYPE declaration has an internal subset
+ */
+void wbxml_tree_clb_xml_doctype_decl(void *ctx, const XML_Char *doctypeName, 
+                                     const XML_Char *sysid, const XML_Char *pubid, 
+                                     int has_internal_subset);
+
+/**
+ * @brief Start Element Callback
+ * @param ctx User data
+ * @param localName The local tag name
+ * @param attrs The attributes attached to the element
+ */
+void wbxml_tree_clb_xml_start_element(void *ctx, const XML_Char *localName, const XML_Char **attrs);
+
+/**
+ * @brief End Element Callback
+ * @param ctx User data
+ * @param localName The local tag name
+ */
+void wbxml_tree_clb_xml_end_element(void *ctx, const XML_Char *localName);
+
+/**
+ * @brief Start of CDATA Section Callback
+ * @param ctx User data
+ */
+void wbxml_tree_clb_xml_start_cdata(void *ctx);
+
+/**
+ * @brief End of CDATA Section Callback
+ * @param ctx User data
+ */
+void wbxml_tree_clb_xml_end_cdata(void *ctx);
+
+/**
+ * @brief Characters Callback
+ * @param ctx User data
+ * @param ch The characters array
+ * @param len The number of characters to read from the array
+ */
+void wbxml_tree_clb_xml_characters(void *ctx, const XML_Char *ch, int len);
+
+/**
+ * @brief Processing Instruction Callback
+ * @param ctx User data
+ * @param target The processing instruction target.
+ * @param data The processing instruction data, or null if  none was supplied. The data does
+ *             not include any whitespace separating it from the target
+ */
+void wbxml_tree_clb_xml_pi(void *ctx, const XML_Char *target, const XML_Char *data);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* HAVE_EXPAT */
+
+#endif /* WBXML_TREE_CLB_XML_H */

--- a/src/libwbxml/wbxml_tree_clb_xml.h
+++ b/src/libwbxml/wbxml_tree_clb_xml.h
@@ -2,27 +2,27 @@
  * libwbxml, the WBXML Library.
  * Copyright (C) 2002-2008 Aymerick Jehanne <aymerick@jehanne.org>
  * Copyright (C) 2011 Michael Bell <michael.bell@opensync.org>
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- * 
+ *
  * LGPL v2.1: http://www.gnu.org/copyleft/lesser.txt
- * 
+ *
  * Contact: aymerick@jehanne.org
  * Home: http://libwbxml.aymerick.com
  */
- 
+
 /**
  * @file wbxml_tree_clb_xml.h
  * @ingroup wbxml_tree
@@ -37,7 +37,7 @@
 #define WBXML_TREE_CLB_XML_H
 
 #include "wbxml.h"
-#include <wbxml_config.h>
+#include "wbxml_config.h"
 
 #if defined( HAVE_EXPAT )
 
@@ -45,8 +45,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
-/** @addtogroup wbxml_tree 
- *  @{ 
+/** @addtogroup wbxml_tree
+ *  @{
  */
 
 /**
@@ -67,8 +67,8 @@ void wbxml_tree_clb_xml_decl(void *ctx, const XML_Char *version,
  * @param pubid Public ID
  * @param has_internal_subset Non-zero if the DOCTYPE declaration has an internal subset
  */
-void wbxml_tree_clb_xml_doctype_decl(void *ctx, const XML_Char *doctypeName, 
-                                     const XML_Char *sysid, const XML_Char *pubid, 
+void wbxml_tree_clb_xml_doctype_decl(void *ctx, const XML_Char *doctypeName,
+                                     const XML_Char *sysid, const XML_Char *pubid,
                                      int has_internal_subset);
 
 /**

--- a/src/wbxml.c
+++ b/src/wbxml.c
@@ -1,92 +1,226 @@
 #include <python2.7/Python.h>
-#include <wbxml.h>
+
+#include "libwbxml/wbxml.h"
+#include "wbxml_helpers.h"
+
 
 static PyObject* WBXMLParseError;
 
-static PyObject* xml_to_wbxml(PyObject* self, PyObject* args) {
-  WBXMLError ret;
-  WB_UTINY *xml;
-  WB_UTINY *wbxml;
-  WB_ULONG xml_len = 0;
-  WB_ULONG wbxml_len = 0;
-  WBXMLGenWBXMLParams params;
+static PyObject* xml_to_wbxml(PyObject* self, PyObject* args, PyObject* kwargs) {
 
-  if(!PyArg_ParseTuple(args, "s#", &xml, &xml_len)) {
-    return NULL;
-  }
+    // initialize return code & error strings
+    WBXMLError ret = WBXML_OK;
+    char error_context[1024] = {0};
+    char error_string[1024] = {0};
 
-  params.wbxml_version = WBXML_VERSION_13;
-  params.use_strtbl = TRUE;
-  params.keep_ignorable_ws = FALSE;
-  params.produce_anonymous = TRUE;
+    // interpret arguments
+    char* keywords[] = {"xml", "version", "preserve_whitespaces", "string_table", "publicid", NULL};
+    WB_UTINY *xml;
+    WB_ULONG xml_len;
+    char* language = NULL;
+    int language_len = 0;
+    char* version = "1.3";
+    int version_len = 3;
+    int preserve_whitespaces = 0;
+    unsigned int string_table = 0;
+    unsigned int publicid = 1;
+    if (!PyArg_ParseTupleAndKeywords(
+        args, kwargs,
+        "s#|s#iII", keywords,
+        &xml, &xml_len,
+        &version, &version_len,
+        &preserve_whitespaces, &string_table, &publicid
+    )) {
+        return NULL;
+    }
 
-  ret = wbxml_conv_xml2wbxml_withlen(xml, xml_len, &wbxml, &wbxml_len, &params);
-  if(ret != WBXML_OK) {
-    PyErr_SetString(WBXMLParseError, (const char*)wbxml_errors_string(ret));
-    return NULL;
-  }
+    // initialize converter
+    WBXMLConvXML2WBXML *conv = NULL;
+    ret = wbxml_conv_xml2wbxml_create(&conv);
+    if (ret != WBXML_OK) {
+        snprintf(error_context, sizeof(error_context), "execution of `wbxml_conv_xml2wbxml_create` failed");
+        goto clean_up;
+    }
+    // configure converter
+    wbxml_conv_xml2wbxml_set_version(conv, get_version(version));
+    if (preserve_whitespaces) {
+        wbxml_conv_xml2wbxml_enable_preserve_whitespaces(conv);
+    }
+    if (!string_table) {
+        wbxml_conv_xml2wbxml_disable_string_table(conv);
+    }
+    if (!publicid) {
+        wbxml_conv_xml2wbxml_disable_public_id(conv);
+    }
 
-  PyObject *value = PyString_FromStringAndSize((const char*)wbxml, wbxml_len);
+    // convert
+    WB_UTINY *wbxml;
+    WB_ULONG wbxml_len = 0;
+    ret = wbxml_conv_xml2wbxml_run(conv, xml, xml_len, &wbxml, &wbxml_len);
+    if (ret != WBXML_OK) {
+        snprintf(error_context, sizeof(error_context), "execution of `wbxml_conv_wbxml2xml_run` failed with wbxml_len=%d", xml_len);
+        goto clean_up;
+    }
 
-  if(wbxml != NULL) {
-    wbxml_free(wbxml);
-  }
+    // the end!
+    clean_up:
 
-  return value;
+    if (conv != NULL) {
+        wbxml_conv_xml2wbxml_destroy(conv);
+    }
+
+    // raise exception
+    if (ret != WBXML_OK) {
+        if (error_context[0] == '\0') {
+            snprintf(error_string, sizeof(error_string), "%s", (const char*)wbxml_errors_string(ret));
+        } else {
+            snprintf(error_string, sizeof(error_string), "%s (%s)", (const char*)wbxml_errors_string(ret), error_context);
+        }
+        PyErr_SetString(WBXMLParseError, error_string);
+        return NULL;
+    }
+
+    // success
+    PyObject *value = PyString_FromStringAndSize((const char*)wbxml, wbxml_len);//
+    if (wbxml != NULL) {
+        wbxml_free(wbxml);
+    }
+    return value;
 }
 
-static char xml_to_wbxml_docs[] = 
-  "xml_to_wbxml(): converts xml to wbxml.\n";
 
-static PyObject* wbxml_to_xml(PyObject* self, PyObject* args) {
-  WBXMLError ret;
-  WB_UTINY *wbxml;
-  WB_UTINY *xml;
-  WB_ULONG xml_len = 0;
-  WB_ULONG wbxml_len = 0;
-  WBXMLGenXMLParams params;
+char* keywords[] = {"wbxml", "version", "preserve_whitespaces", "string_table", "publicid", NULL};
 
-  if(!PyArg_ParseTuple(args, "s#", &wbxml, &wbxml_len)) {
-    return NULL;
-  }
+static char xml_to_wbxml_docs[] =
+  "Converts XML to WBXML.\n\n"
+  "Args:\n"
+  "    xml (str): The XML string to be converted\n"
+  "    version (str, optional): Which version of the WBXML standard to consider (can be any of: '1.0', '1.1', '1.2', '1.3')\n"
+  "    preserve_whitespaces (bool, optional): Whether whitespaces should be preserved or not\n"
+  "    string_table (bool, optional): Whether a string tables should be used in the resulting WBXML document\n"
+  "    publicid (bool, optional): Whether the WBXML Public ID should be included in the resulting WBXML document or not\n\n"
+  "Returns:\n"
+  "    str: WBXML-formatted result\n";
 
-  params.gen_type = WBXML_GEN_XML_INDENT;
-  params.lang = WBXML_LANG_UNKNOWN;
-  params.indent = 2;
-  params.keep_ignorable_ws = FALSE;
+static PyObject* wbxml_to_xml(PyObject* self, PyObject* args, PyObject* kwargs) {
 
-  ret = wbxml_conv_wbxml2xml_withlen(wbxml, wbxml_len, &xml, &xml_len, &params);
-  if(ret != WBXML_OK) {
-    PyErr_SetString(WBXMLParseError, (const char*)wbxml_errors_string(ret));
-    return NULL;
-  }
+    // initialize return code & error strings
+    WBXMLError ret = WBXML_OK;
+    char error_context[1024] = {0};
+    char error_string[1024] = {0};
 
-  PyObject *value = PyString_FromStringAndSize((const char*)xml, xml_len);
+    // interpret arguments
+    char* keywords[] = {"wbxml", "charset", "language", "generation_type", "preserve_whitespaces", "indent", NULL};
+    WB_UTINY *wbxml;
+    WB_ULONG wbxml_len;
+    char* charset = NULL;
+    int charset_len = 0;
+    char* language = NULL;
+    int language_len = 0;
+    char* generation_type = "indent";
+    int generation_type_len = 0;
+    int preserve_whitespaces = 0;
+    unsigned int indent = 4;
+    if (!PyArg_ParseTupleAndKeywords(
+        args, kwargs,
+        "s#|s#s#s#iI", keywords,
+        &wbxml, &wbxml_len,
+        &charset, &charset_len,
+        &language, &language_len,
+        &generation_type, &generation_type_len,
+        &preserve_whitespaces, &indent
+    )) {
+        return NULL;
+    }
 
-  if(xml != NULL) {
-    wbxml_free(xml);
-  }
+    // initialize converter
+    WBXMLConvWBXML2XML *conv = NULL;
+    ret = wbxml_conv_wbxml2xml_create(&conv);
+    if (ret != WBXML_OK) {
+        snprintf(error_context, sizeof(error_context), "execution of `wbxml_conv_wbxml2xml_create` failed");
+        goto clean_up;
+    }
+    // configure converter
+    if (charset && charset_len) {
+        wbxml_conv_wbxml2xml_set_charset(conv, get_charset(charset));
+    }
+    if (language && language_len) {
+        wbxml_conv_wbxml2xml_set_language(conv, get_lang(language));
+    }
+    if (generation_type && generation_type_len) {
+        wbxml_conv_wbxml2xml_set_gen_type(conv, get_gen_type(generation_type));
+    }
+    if (preserve_whitespaces) {
+        wbxml_conv_wbxml2xml_enable_preserve_whitespaces(conv);
+    }
+    wbxml_conv_wbxml2xml_set_indent(conv, (WB_TINY) indent);
 
-  return value;
+    // convert
+    WB_UTINY *xml;
+    WB_ULONG xml_len = 0;
+    ret = wbxml_conv_wbxml2xml_run(conv, wbxml, wbxml_len, &xml, &xml_len);
+    if (ret != WBXML_OK) {
+        snprintf(error_context, sizeof(error_context), "execution of `wbxml_conv_wbxml2xml_run` failed with wbxml_len=%d", wbxml_len);
+        goto clean_up;
+    }
+
+    // the end!
+    clean_up:
+
+    if (conv != NULL) {
+        wbxml_conv_wbxml2xml_destroy(conv);
+    }
+
+    // exception
+    if (ret != WBXML_OK) {
+        if (error_context[0] == '\0') {
+            snprintf(error_string, sizeof(error_string), "%s", (const char*)wbxml_errors_string(ret));
+        } else {
+            snprintf(error_string, sizeof(error_string), "%s (%s)", (const char*)wbxml_errors_string(ret), error_context);
+        }
+        PyErr_SetString(WBXMLParseError, error_string);
+        return NULL;
+    }
+
+    // success
+    PyObject *value = PyString_FromStringAndSize((const char*)xml, xml_len);
+    return value;
 }
 
 static char wbxml_to_xml_docs[] =
-  "wbxml_to_xml(): converts wbxml to xml.\n";
+  "Converts WBXML to XML.\n\n"
+  "Args:\n"
+  "    wbxml (str): The WBXML string to be converted\n"
+  "    charset (str, optional): Which charset to use (can be any of: 'ASCII', 'ISO-8859-1', 'ISO-8859-2', 'ISO-8859-3', 'ISO-8859-4', 'ISO-8859-5', 'ISO-8859-6', 'ISO-8859-7', 'ISO-8859-8', 'ISO-8859-9', 'ISO-10646-UCS-2')\n"
+  "    language (str, optional): Which WBXML language to use for conversion (can be any of: 'WML10', 'WML11', 'WML12', 'WML13', 'WTA10', 'WTAWML12', 'CHANNEL11', 'CHANNEL12', 'SI10', 'SL10', 'CO10', 'PROV10', 'EMN10', 'DRMREL10', 'OTA', 'SYNCML10', 'DEVINF10', 'SYNCML11', 'DEVINF11', 'METINF11', 'SYNCML12', 'DEVINF12', 'METINF12', 'DMDDF12', 'CSP11', 'CSP12', 'AIRSYNC', 'ACTIVESYNC', 'CONML')\n"
+  "    generation_type (str, optional): How compact the generated XML should be  (can be any of: 'compact', 'canonical', 'indent')\n"
+  "    preserve_whitespaces (bool, optional): Whether whitespaces should be preserved or not\n"
+  "    int (int, optional): Number of spaces to use to indent the output XML\n\n"
+  "Returns:\n"
+  "    str: XML-formatted result\n";
 
 
 static PyMethodDef wbxml_funcs[] = {
-  {"xml_to_wbxml", (PyCFunction)xml_to_wbxml,
-    METH_VARARGS, xml_to_wbxml_docs},
-  {"wbxml_to_xml", (PyCFunction)wbxml_to_xml,
-    METH_VARARGS, wbxml_to_xml_docs},
-  {NULL}
+    {
+        "xml_to_wbxml",
+        (PyCFunction)xml_to_wbxml,
+        METH_VARARGS | METH_KEYWORDS,
+        xml_to_wbxml_docs
+    },
+    {
+        "wbxml_to_xml",
+        (PyCFunction)wbxml_to_xml,
+        METH_VARARGS | METH_KEYWORDS,
+        wbxml_to_xml_docs
+    },
+    {NULL}
 };
 
 PyMODINIT_FUNC initwbxml(void) {
   PyObject* module;
 
-  module = Py_InitModule3("wbxml", 
-      wbxml_funcs, 
+  module = Py_InitModule3("wbxml",
+      wbxml_funcs,
       "Python wrapper for libwbxml");
 
   if(module == NULL) {

--- a/src/wbxml.c
+++ b/src/wbxml.c
@@ -71,6 +71,9 @@ static PyObject* xml_to_wbxml(PyObject* self, PyObject* args, PyObject* kwargs) 
 
     // raise exception
     if (ret != WBXML_OK) {
+        if (wbxml != NULL) {
+            wbxml_free(wbxml);
+        }
         if (error_context[0] == '\0') {
             snprintf(error_string, sizeof(error_string), "%s", (const char*)wbxml_errors_string(ret));
         } else {
@@ -81,7 +84,7 @@ static PyObject* xml_to_wbxml(PyObject* self, PyObject* args, PyObject* kwargs) 
     }
 
     // success
-    PyObject *value = PyString_FromStringAndSize((const char*)wbxml, wbxml_len);//
+    PyObject *value = PyString_FromStringAndSize((const char*)wbxml, wbxml_len);
     if (wbxml != NULL) {
         wbxml_free(wbxml);
     }

--- a/src/wbxml.c
+++ b/src/wbxml.c
@@ -173,6 +173,9 @@ static PyObject* wbxml_to_xml(PyObject* self, PyObject* args, PyObject* kwargs) 
 
     // exception
     if (ret != WBXML_OK) {
+        if (xml != NULL) {
+            wbxml_free(xml);
+        }
         if (error_context[0] == '\0') {
             snprintf(error_string, sizeof(error_string), "%s", (const char*)wbxml_errors_string(ret));
         } else {
@@ -184,6 +187,9 @@ static PyObject* wbxml_to_xml(PyObject* self, PyObject* args, PyObject* kwargs) 
 
     // success
     PyObject *value = PyString_FromStringAndSize((const char*)xml, xml_len);
+    if (xml != NULL) {
+        wbxml_free(xml);
+    }
     return value;
 }
 

--- a/src/wbxml_helpers.h
+++ b/src/wbxml_helpers.h
@@ -1,0 +1,189 @@
+#ifndef PYTHON_WBXML__SRC__WBXML_HELPERS__H
+#define PYTHON_WBXML__SRC__WBXML_HELPERS__H
+
+
+#include "libwbxml/wbxml.h"
+#include "libwbxml/wbxml_mem.h"
+
+
+static WBXMLVersion get_version(const WB_TINY *lang)
+{
+    if (WBXML_STRCMP(lang, "1.0") == 0)
+        return WBXML_VERSION_10;
+    if (WBXML_STRCMP(lang, "1.1") == 0)
+        return WBXML_VERSION_11;
+    if (WBXML_STRCMP(lang, "1.2") == 0)
+        return WBXML_VERSION_12;
+    if (WBXML_STRCMP(lang, "1.3") == 0)
+        return WBXML_VERSION_13;
+
+    return WBXML_VERSION_UNKNOWN;
+}
+
+
+static WBXMLLanguage get_lang(const WB_TINY *lang)
+{
+#if defined( WBXML_SUPPORT_WML )
+    if (WBXML_STRCMP(lang, "WML10") == 0)
+        return WBXML_LANG_WML10;
+    if (WBXML_STRCMP(lang, "WML11") == 0)
+        return WBXML_LANG_WML11;
+    if (WBXML_STRCMP(lang, "WML12") == 0)
+        return WBXML_LANG_WML12;
+    if (WBXML_STRCMP(lang, "WML13") == 0)
+        return WBXML_LANG_WML13;
+#endif /* WBXML_SUPPORT_WML */
+
+#if defined( WBXML_SUPPORT_WTA )
+    if (WBXML_STRCMP(lang, "WTA10") == 0)
+        return WBXML_LANG_WTA10;
+    if (WBXML_STRCMP(lang, "WTAWML12") == 0)
+        return WBXML_LANG_WTAWML12;
+    if (WBXML_STRCMP(lang, "CHANNEL11") == 0)
+        return WBXML_LANG_CHANNEL11;
+    if (WBXML_STRCMP(lang, "CHANNEL12") == 0)
+        return WBXML_LANG_CHANNEL12;
+#endif /* WBXML_SUPPORT_WTA */
+
+#if defined( WBXML_SUPPORT_SI )
+    if (WBXML_STRCMP(lang, "SI10") == 0)
+        return WBXML_LANG_SI10;
+#endif /* WBXML_SUPPORT_SI */
+
+#if defined( WBXML_SUPPORT_SL )
+    if (WBXML_STRCMP(lang, "SL10") == 0)
+        return WBXML_LANG_SL10;
+#endif /* WBXML_SUPPORT_SL */
+
+#if defined( WBXML_SUPPORT_CO )
+    if (WBXML_STRCMP(lang, "CO10") == 0)
+        return WBXML_LANG_CO10;
+#endif /* WBXML_SUPPORT_CO */
+
+#if defined( WBXML_SUPPORT_PROV )
+    if (WBXML_STRCMP(lang, "PROV10") == 0)
+        return WBXML_LANG_PROV10;
+#endif /* WBXML_SUPPORT_PROV */
+
+#if defined( WBXML_SUPPORT_EMN )
+    if (WBXML_STRCMP(lang, "EMN10") == 0)
+        return WBXML_LANG_EMN10;
+#endif /* WBXML_SUPPORT_EMN */
+
+#if defined( WBXML_SUPPORT_DRMREL )
+    if (WBXML_STRCMP(lang, "DRMREL10") == 0)
+        return WBXML_LANG_DRMREL10;
+#endif /* WBXML_SUPPORT_DRMREL */
+
+#if defined( WBXML_SUPPORT_OTA_SETTINGS )
+    if (WBXML_STRCMP(lang, "OTA") == 0)
+        return WBXML_LANG_OTA_SETTINGS;
+#endif /* WBXML_SUPPORT_OTA_SETTINGS */
+
+#if defined( WBXML_SUPPORT_SYNCML )
+    if (WBXML_STRCMP(lang, "SYNCML10") == 0)
+        return WBXML_LANG_SYNCML_SYNCML10;
+    if (WBXML_STRCMP(lang, "DEVINF10") == 0)
+        return WBXML_LANG_SYNCML_DEVINF10;
+    if (WBXML_STRCMP(lang, "SYNCML11") == 0)
+        return WBXML_LANG_SYNCML_SYNCML11;
+    if (WBXML_STRCMP(lang, "DEVINF11") == 0)
+        return WBXML_LANG_SYNCML_DEVINF11;
+    if (WBXML_STRCMP(lang, "METINF11") == 0)
+        return WBXML_LANG_SYNCML_METINF11;
+    if (WBXML_STRCMP(lang, "SYNCML12") == 0)
+        return WBXML_LANG_SYNCML_SYNCML12;
+    if (WBXML_STRCMP(lang, "DEVINF12") == 0)
+        return WBXML_LANG_SYNCML_DEVINF12;
+    if (WBXML_STRCMP(lang, "METINF12") == 0)
+        return WBXML_LANG_SYNCML_METINF12;
+    if (WBXML_STRCMP(lang, "DMDDF12") == 0)
+        return WBXML_LANG_SYNCML_DMDDF12;
+#endif /* WBXML_SUPPORT_SYNCML */
+
+#if defined( WBXML_SUPPORT_WV )
+    if (WBXML_STRCMP(lang, "CSP11") == 0)
+        return WBXML_LANG_WV_CSP11;
+    if (WBXML_STRCMP(lang, "CSP12") == 0)
+        return WBXML_LANG_WV_CSP12;
+#endif /* WBXML_SUPPORT_WV */
+
+#if defined( WBXML_SUPPORT_AIRSYNC )
+    if (WBXML_STRCMP(lang, "AIRSYNC") == 0)
+        return WBXML_LANG_AIRSYNC;
+    if (WBXML_STRCMP(lang, "ACTIVESYNC") == 0)
+        return WBXML_LANG_ACTIVESYNC;
+#endif /* WBXML_SUPPORT_AIRSYNC */
+
+#if defined( WBXML_SUPPORT_CONML )
+    if (WBXML_STRCMP(lang, "CONML") == 0)
+        return WBXML_LANG_CONML;
+#endif /* WBXML_SUPPORT_CONML */
+
+    return WBXML_LANG_UNKNOWN;
+}
+
+
+static WBXMLCharsetMIBEnum get_charset(const WB_TINY *charset)
+{
+    /* The good old ASCII */
+
+    if (WBXML_STRCMP(charset, "ASCII") == 0)
+        return WBXML_CHARSET_US_ASCII;
+
+    /* ISO-8859 character sets */
+
+    if (WBXML_STRCMP(charset, "ISO-8859-1") == 0)
+        return WBXML_CHARSET_ISO_8859_1;
+    if (WBXML_STRCMP(charset, "ISO-8859-2") == 0)
+        return WBXML_CHARSET_ISO_8859_2;
+    if (WBXML_STRCMP(charset, "ISO-8859-3") == 0)
+        return WBXML_CHARSET_ISO_8859_3;
+    if (WBXML_STRCMP(charset, "ISO-8859-4") == 0)
+        return WBXML_CHARSET_ISO_8859_4;
+    if (WBXML_STRCMP(charset, "ISO-8859-5") == 0)
+        return WBXML_CHARSET_ISO_8859_5;
+    if (WBXML_STRCMP(charset, "ISO-8859-6") == 0)
+        return WBXML_CHARSET_ISO_8859_6;
+    if (WBXML_STRCMP(charset, "ISO-8859-7") == 0)
+        return WBXML_CHARSET_ISO_8859_7;
+    if (WBXML_STRCMP(charset, "ISO-8859-8") == 0)
+        return WBXML_CHARSET_ISO_8859_8;
+    if (WBXML_STRCMP(charset, "ISO-8859-9") == 0)
+        return WBXML_CHARSET_ISO_8859_9;
+    if (WBXML_STRCMP(charset, "ISO-10646-UCS-2") == 0)
+        return WBXML_CHARSET_ISO_10646_UCS_2;
+
+    /* Chinese character set */
+
+    if (WBXML_STRCMP(charset, "SHIFT_JIS") == 0)
+        return WBXML_CHARSET_SHIFT_JIS;
+
+    /* Japanese character set */
+
+    if (WBXML_STRCMP(charset, "BIG5") == 0)
+        return WBXML_CHARSET_BIG5;
+
+    /* Unicode character sets */
+
+    if (WBXML_STRCMP(charset, "UTF-8") == 0)
+        return WBXML_CHARSET_UTF_8;
+    if (WBXML_STRCMP(charset, "UTF-16") == 0)
+        return WBXML_CHARSET_UTF_16;
+
+    return WBXML_CHARSET_UNKNOWN;
+}
+
+static WBXMLGenXMLType get_gen_type(const WB_TINY *charset)
+{
+    if (WBXML_STRCMP(charset, "compact") == 0)
+        return WBXML_GEN_XML_COMPACT;
+    if (WBXML_STRCMP(charset, "canonical") == 0)
+        return WBXML_GEN_XML_CANONICAL;
+    if (WBXML_STRCMP(charset, "indent") == 0)
+        return WBXML_GEN_XML_INDENT;
+    return WBXML_GEN_XML_INDENT;
+}
+
+
+#endif // PYTHON_WBXML__SRC__WBXML_HELPERS__H


### PR DESCRIPTION
The original  **python-wbxml** library didn't allow me to communicate with an Exchange server with ActiveSync.

Conversions are now configurable via keyword arguments (see Python docstrings).

I had to integrate the source files of **libwbxml** within the repo, because some methods that were not available from the publicly available library (**libwbxml-dev**) were needed.